### PR TITLE
some codex fixes.

### DIFF
--- a/Ruleset/ufopedia40k.rul
+++ b/Ruleset/ufopedia40k.rul
@@ -2314,8 +2314,7 @@ ufopaedia:
     section: STR_NOT_AVAILABLE
   - id: STR_LASCAN_MALTHUS
     requires:
-      - STR_LASCAN
-      - STR_ADEPTAS
+      - STR_LASCAN_MALTHUS
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: LASCANNON.SPK
@@ -2376,17 +2375,15 @@ ufopaedia:
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: 1MG.SPK
     requires:
-      - STR_CHAOSHARMONIC_MELTAGUN
-      - STR_ADEPTAS
+      - STR_HARMONIC_MELTAGUN
     text: STR_HARMONIC_MELTAGUN_UFOPEDIA
     listOrder: 11101
   - id: STR_CHAOSHARMONIC_MELTAGUN                   #106
     type_id: 14
-    section: STR_WEAPONS_AND_EQUIPMENT
+    section: STR_ALIEN_ARTIFACTS
     image_id: 1MG.SPK
     requires:
       - STR_CHAOSHARMONIC_MELTAGUN
-      - STR_ADEPTAS
     text: STR_CHAOSHARMONIC_MELTAGUN_UFOPEDIA
     listOrder: 11101
 


### PR DESCRIPTION
the malthus lascannon and the harmonic melta gun were missing their codex pages for space marines (and other factions aside from adeptas). also the harmonic melta had a chaos requisite for unlock (chaos variant has its own codex page). the light lascannon page had a regular lascannon research as a requisite. the chaos harmonic melta gun page was restricted to adeptas, and it was located in the wrong section (I think).