### PR TITLE
Landspeeder in the TTV, Drop Pod Codex page

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -1402,6 +1402,7 @@ en-US:
   STR_RHINO_NO_TT_UFOPAEDIA: "The Rhino is the Space Marine's ground transport" # needs more text
   STR_SOLDIER_TERMINATOR: "Terminator"
   STR_DREADNOUGHT_MARINE: "Dreadnought Requisition"
+  STR_SPEEDR: "Landspeeder Requsition"
 
 ## Stats for Nerds
 

--- a/Ruleset/SM/research_SM.rul
+++ b/Ruleset/SM/research_SM.rul
@@ -43,3 +43,17 @@ research:
     dependencies:
       - STR_UFO_CONSTRUCTION
       - STR_MARINES_STRATEGY
+
+  - name: STR_SPEEDR
+    cost: 150
+    points: 10
+    dependencies:
+      - STR_GENERALLOCK
+    unlocks:
+      - STR_SPEEDC
+
+  - name: STR_SPEEDC
+    cost: 0
+    points: 0
+    dependencies:
+      - STR_GENERALLOCK

--- a/Ruleset/SM/ufopaedia_SM.rul
+++ b/Ruleset/SM/ufopaedia_SM.rul
@@ -20,3 +20,13 @@
     requires:
       - STR_MARINES_STRATEGY
 
+  - id: STR_DROP                  #121
+    type_id: 11
+    section: STR_XCOM_CRAFT_ARMAMENT
+    image_id: DROPPOD.SPK
+    requires:
+      - STR_MARINES_STRATEGY
+      - STR_NOT_PRIMARIS
+    text: STR_DROPPOD_UFOPEDIA
+    listOrder: 121
+


### PR DESCRIPTION
just a small qol change.
now you can actually see what will you get for researching the "Light Craft" (now named the "Landspeeder Requisition") topic.