### PR TITLE
tenacious script update

### DIFF
--- a/Ruleset/scripts/scripts_tenacious_enemies.rul
+++ b/Ruleset/scripts/scripts_tenacious_enemies.rul
@@ -6,6 +6,9 @@ armors:
         var int temp;
         var ptr RuleArmor targetArmor;
 
+        if eq damaging_type 11;
+          return;
+        end;
         unit.getRuleArmor targetArmor;
         targetArmor.getSize temp;
 
@@ -53,6 +56,9 @@ armors:
         var int temp;
         var ptr RuleArmor targetArmor;
 
+        if eq damaging_type 11;
+          return;
+        end;
         unit.getRuleArmor targetArmor;
         targetArmor.getSize temp;
 
@@ -100,6 +106,9 @@ armors:
         var int temp;
         var ptr RuleArmor targetArmor;
 
+        if eq damaging_type 11;
+          return;
+        end;
         unit.getRuleArmor targetArmor;
         targetArmor.getSize temp;
 
@@ -147,6 +156,9 @@ armors:
         var int temp;
         var ptr RuleArmor targetArmor;
 
+        if eq damaging_type 11;
+          return;
+        end;
         unit.getRuleArmor targetArmor;
         targetArmor.getSize temp;
 


### PR DESCRIPTION
disables the tenacious scripts for melta damage, meaning melta damage wont be converted to stun damage when hitting necrons, unlike other weapons