### PR TITLE
Mostly Grey Knight Update

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -43,11 +43,11 @@ en-US:
 
   STR_ALIEN_SUPPLY: "Chaos Resupply"
   STR_ALIEN_SUPPLY_UFOPEDIA: "For every enemy stronghold built, the enemy must also provide supplies and reinforcements, building up their positions to expand their foothold on the planet and fuel more raids into our territory. {NEWLINE} {NEWLINE} As our own options are limited, by identifying and boarding these vessels we can resupply ourselves."
-  
-  STR_ALIEN_HARVEST_UFOPEDIA: "The Chaos Forces ever seek to befoul the perfect human Imperial form, as tainted flesh soon gives way to warped minds, with mutation comes heresy of the foulest kind. A single rotten apple spoils the whole bunch, root out this filth by putting every mutant, extended family and loose acquaintances to the flamer and chainsword! {NEWLINE} {NEWLINE}...And any Chaos forces you may find as well, of course. " 
+
+  STR_ALIEN_HARVEST_UFOPEDIA: "The Chaos Forces ever seek to befoul the perfect human Imperial form, as tainted flesh soon gives way to warped minds, with mutation comes heresy of the foulest kind. A single rotten apple spoils the whole bunch, root out this filth by putting every mutant, extended family and loose acquaintances to the flamer and chainsword! {NEWLINE} {NEWLINE}...And any Chaos forces you may find as well, of course. "
   STR_ALIEN_INFILTRATION_UFOPEDIA: "The Forces of Chaos are ever eager to tempt the loyal citizens of the Imperium with seduction and sedition, in depraved mockery of all that is holy, infiltrating the governing bodies of entire sectors with their heretic words. Cut out their tongues and sew their foul mouths shut once and for all!"
   STR_ALIEN_RESEARCH_UFOPEDIA: "The Forces of Chaos seek to amplify the warp disturbance wherever they can, using foul techno-sorcery to disrupt the stability of realspace. This not only cuts our communications, but allow the spread of unchecked mutation and ever larger daemonic incursions."
-  
+
   STR_CHIMEDON_SPAWNER: "Chimedon"
   STR_CHIMEDON_TURRET: "Chimedon"
   STR_CHIMEDON_ARMOR: "Chimedon"
@@ -1089,6 +1089,7 @@ en-US:
   STR_BURST_SNAP_SHOT: "Double Tap Shot"
   STR_LAUNCH_GRENADE: "Launch Grenade"
   STR_LAUNCH_GRENADE_SHORT: "Grenade (x{0})"
+  STR_HALLEBARD_SNAPSHOT_LUNGE: "Lunge"
 
   STR_INCENDIARY_GRENADE40: "40mm Incendiary Grenade"
   STR_PENITENCE_GRENADE40: "40mm Penitence Grenade"
@@ -1369,7 +1370,7 @@ en-US:
   NURGLE_CULTIST_GREENROBE_ARMOR_RITUALIST: "Nurgle Cultist"
   STR_NURGLE_CULTIST_LEADER_RITUALIST: "Nurgle Cult Leader"
   STR_NURGLE_CULTIST_LEADER_ARMOR_RITUALIST: "Nurgle Cult Leader"
-  
+
   STR_GREEN_MONK: "Sickly Civilian"
   GREEN_ROBE_ARMOR: "Sickly Civilian"
   STR_GREEN_ROBE_CORPSE: "Diseased Corpse"
@@ -1540,16 +1541,16 @@ en-US:
   SLAANESH_DEMIMONDE_ARMOR_BLESSED_RITUALIST: "Slaanesh Demimonde"
   SLAANESH_DEMIMONDE_ARMOR_SACRIFICE: "Slaanesh Demimonde"
   SLAANESH_DEMIMONDE_ARMOR_BLESSED_SACRIFICE: "Slaanesh Demimonde"
-  STR_SLAANESH_DEMIMONDE_UFOPEDIA: "{NEWLINE} Wearing Slaanesh adorned cultist attire, these well sewn ritual dresses are heretical in the extreme." 
+  STR_SLAANESH_DEMIMONDE_UFOPEDIA: "{NEWLINE} Wearing Slaanesh adorned cultist attire, these well sewn ritual dresses are heretical in the extreme."
   STR_SLAANESH_DEMIMONDE_ORIGINS: "Demimonde Origins"
   STR_SLAANESH_DEMIMONDE_ORIGINS_UFOPEDIA: "{NEWLINE} Slaanesh Demimonde are hedonistic followers of Slaanesh who live hidden within Imperial society, doing their masters bidding until called upon to serve as offerings in heretical rituals, becoming willing hosts for Daemonettes."
-  
+
   STR_SLAANESH_SACRIFICE_F: "Slaanesh Sacrifice"
   STR_SLAANESH_SACRIFICE_M: "Slaanesh Sacrifice"
   SLAANESH_SACRIFICE_F_ARMOR: "Slaanesh Sacrifice"
   SLAANESH_SACRIFICE_M_ARMOR: "Slaanesh Sacrifice"
   STR_SLAANESH_SACRIFICE_CORPSE: "Slaanesh Pillar" #not actually a corpse, just the pillar
-  
+
   STR_CIVILIAN_HEDONITE_SACRIFICE: "Slaanesh Offering"
   STR_CIVILIAN_HEDONITE_BLESSED_SACRIFICE: "Slaanesh Offering"
   STR_CIVILIAN_HEDONITE_BLESSED_ALPHA_SACRIFICE: "Slaanesh Offering"
@@ -1557,7 +1558,7 @@ en-US:
   CIVILIAN_HEDONITE_ARMOR_BLESSED_SACRIFICE: "Slaanesh Offering"
   CIVILIAN_HEDONITE_ARMOR_BLESSED_ALPHA_SACRIFICE: "Slaanesh Offering"
   STR_CIVILIAN_HEDONITE_CORPSE: "Slaanesh Hedonite Corpse"
-  
+
 #SLAANGOR
   STR_SLAANGOR_LATE: "Chosen Slaangor Warband"
   STR_SLAANGOR_MIXED: "Slaangor Warband"
@@ -1766,7 +1767,7 @@ en-US:
   STR_Demidaemonette_ARMOR_UFOPEDIA: "{NEWLINE}{NEWLINE} CODEX ARMOR DETAIL" #ROSE
   STR_CHRYSSALID_TERRORISTSELENE: "Lesser Daemonette"
   STR_DIRE_DAEMONETTE: "Dire Daemonette"
-  STR_CHRYSSALID_ARMOR_DIRE: "Dire Daemonette" 
+  STR_CHRYSSALID_ARMOR_DIRE: "Dire Daemonette"
   STR_DIRE_DAEMONETTE_CORPSE: "Dire Daemonette Corpse"
   STR_DIRE_DAEMONETTE_CLAWS: "Daemonette Claws"
   STR_DIRE_DAEMONETTE_ORIGINS: "Dire Daemonette Origins"
@@ -3627,7 +3628,7 @@ en-US:
   STR_SECTOID_DARK_DISCIPLE_DAEMONETTE: "Dark Disciple"
   STR_SECTOID_DARK_DISCIPLE_NEVERBORN: "Dark Disciple"
   STR_SECTOID_DARK_DISCIPLE_NEVERBORN_RITUALIST: "Dark Disciple"
-  
+
   STR_DARK_DISCIPLE_ARMOR_NEVERBORN_RITUALIST: "Dark Disciple"
   STR_DARK_DISCIPLE_ARMOR: "Dark Disciple"
   STR_DARK_DISCIPLE_ARMOR_DAEMONETTE: "Dark Disciple"
@@ -3726,7 +3727,7 @@ en-US:
   STR_CAT_NURGLE: "Nurgle"
 
 #GSC
-  STR_GSC_RETALIATION: "Spiral Revenge" 
+  STR_GSC_RETALIATION: "Spiral Revenge"
   STR_GENE_CULT: "Genestealer Cult"
   STR_TYRANID_OUTPOST: "Tyranid Outpost"
 
@@ -4111,9 +4112,22 @@ en-US:
 
 ## Grey Knights Armor
 
-  STR_GK_CHP_LVL2_UC: "Aegis T. Chaplain Armor"
-  STR_GK_CHP_LVL3_UC: "Aegis T. Chaplain Armor"
+  STR_GK_CHP_LV1_UC: "Aegis T. Chaplain Armor"
+  STR_GK_CHP_LV2_UC: "Aegis T. Chaplain Armor"
+  STR_GK_CHP_LV3_UC: "Aegis T. Chaplain Armor"
 
+  STR_GK_TEC_LV4_UC: "Aegis T. Techmarine Armor"
+
+  STR_GK_APO_LV1_UC: "Aegis T. Apothecary Armor"
+  STR_GK_APO_LV2_UC: "Aegis T. Apothecary Armor"
+  STR_GK_APO_LV3_UC: "Aegis T. Apothecary Armor"
+  STR_GK_APO_LV4_UC: "Aegis T. Apothecary Armor"
+
+## Grey Knights Spells
+
+  STR_SMITE_TOME: "Tome of the Mind (Holocaust)"
+  STR_HOLOCAUST_SPELL: "Holocaust"
+  STR_HOLOCAUST_SPELL_UFOPEDIA: "{NEWLINE} A powerful evocation of spiritual flame exclusive to the Grey Knights that scours flesh and soul alike, echoing the God Emperor's final banishment of Horus. Deals incendiary and morale damage that scales with the user's psychic ability and Devotion."
 
 ## Grey Knights Research
 
@@ -4157,29 +4171,46 @@ en-US:
     {NEWLINE}Shield: 150
     {NEWLINE}Built-In MC Storm Bolter"
 
+  STR_GK_APO_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
+    {ALT}{NEWLINE}LVL1:\tNot Available
+    {ALT}{NEWLINE}LVL2:\tTU-10, STA-10, HP+10, BRV+10
+    {NEWLINE}Narthecium
+    {ALT}{NEWLINE}LVL3:\tTU-10, STA-10, HP+10, BRV+10, MEL+5, Shield: 100
+    {NEWLINE}Narthecium
+    {ALT}{NEWLINE}LVL4:\tTU-10, STA-10, HP+20, BRV+20, MEL+10, Shield: 150
+    {NEWLINE}Advanced Narthecium
+    {ALT}{NEWLINE}LVL5:\tTU-10, STA-10, HP+30, BRV+30, MEL+20, Shield: 200
+    {NEWLINE}Mastercrafted Narthecium"
+
   STR_GK_LIB_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL1:\tNot Available
     {ALT}{NEWLINE}LVL2:\tNot Available
-    {ALT}{NEWLINE}LVL3:\tNone, Spell: Shield
-    {ALT}{NEWLINE}LVL4:\tSTA+30, FA-10, MEL+10, Spell: Lockdown
-    {ALT}{NEWLINE}LVL5:\tSTA+30, FA-20, MEL+20, Spell: Speed + Shield"
+    {ALT}{NEWLINE}LVL3:\tSTA+10, FA-10, THR-10, DEV+10
+    {NEWLINE} Spell: Shield
+    {ALT}{NEWLINE}LVL4:\tSTA+20, FA-10, THR-10, PSY+20, DEV+20, Psi Vision: 3
+    {NEWLINE} Spell: Lockdown
+    {ALT}{NEWLINE}LVL5:\tSTA+30, BRV+10, FA-10, THR-10, PSY+30, DEV+30, Psi Vision: 4
+    {NEWLINE} Spell: Speed + Lockdown"
 
   STR_GK_TEC_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL1:\tNot Available
-    {ALT}{NEWLINE}LVL2:\tNone, Analyse + Repair
-    {ALT}{NEWLINE}LVL3:\tNone, Analyse + Repair + Tarantula Turret
-    {ALT}{NEWLINE}LVL4:\tNone, Analyse + Repair + Thunderfire Turret
-    {ALT}{NEWLINE}LVL5:\tNot Available"
-
+    {ALT}{NEWLINE}LVL2:\tSTA+50, HP+10, REA-10, THR+10, STR+25, MEL+10
+    {NEWLINE} Analyse + Repair
+    {ALT}{NEWLINE}LVL3:\tSTA+50, HP+10, REA-10, THR+10, STR+25, MEL+10
+    {NEWLINE} Analyse + Repair + Tarantula Turret
+    {ALT}{NEWLINE}LVL4:\tSTA+50, HP+10, REA-10, THR+10, STR+25, MEL+10
+    {NEWLINE} Analyse + Repair + Thunderfire Turret
+    {ALT}{NEWLINE}LVL5:\tSTA+80, HP+20, REA-10, THR+20, STR+40, MEL+20, Shield: 100
+    {NEWLINE} Analyse + Repair + Thunderfire Turret"
 
   STR_GK_CHP_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL1:\tNot Available
     {ALT}{NEWLINE}LVL2:\tNot Available
-    {ALT}{NEWLINE}LVL3:\tNone,
+    {ALT}{NEWLINE}LVL3:\tTU+10, STA+10, HP+20, REA-10,
     {NEWLINE}MC Storm Bolter, Crozius Arcanum
-    {ALT}{NEWLINE}LVL4:\tBRV+10, Shield: 80,
+    {ALT}{NEWLINE}LVL4:\tTU+10, STA+10, HP+20, BRV+10, REA-10, Shield: 80,
     {NEWLINE}MC Storm Bolter, Crozius Arcanum
-    {ALT}{NEWLINE}LVL5:\tBRV+20, Shield: 150,
+    {ALT}{NEWLINE}LVL5:\tTU+10, STA+10, HP+20, BRV+20, REA-10, Shield: 150,
     {NEWLINE}MC Storm Bolter, Crozius Arcanum"
 
 ## Primaris Armor Bonuses
@@ -4253,8 +4284,8 @@ en-US:
     {ALT}{NEWLINE}LVL1:\tNot Available
     {ALT}{NEWLINE}LVL2:\tNot Available
     {ALT}{NEWLINE}LVL3:\tNone, Spell: Shield
-    {ALT}{NEWLINE}LVL4:\tSTA+30, FA-10, MEL+10, Spell: Lockdown
-    {ALT}{NEWLINE}LVL5:\tSTA+30, FA-20, MEL+20, Spell: Speed + Shield"
+    {ALT}{NEWLINE}LVL4:\tSTA+30, FA-10, MEL+10, Psi Vision: 3, Spell: Lockdown
+    {ALT}{NEWLINE}LVL5:\tSTA+30, FA-20, MEL+20, Psi Vision: 5, Spell: Speed + Shield"
 
   STR_MKX_LIB_LEVELS_ARMOR_UFOPEDIA: "Promotion Armor Total Bonuses:
     {NEWLINE}F: Front, S: Side, R: Rear, U: Under
@@ -4386,8 +4417,8 @@ en-US:
   GMGEO17: "Ruins"
   GMGEO18: "Decisive Battles"
   GMGEO19: "Craven"
-  GMGEO20: "Durandal"  
-  
+  GMGEO20: "Durandal"
+
   GMTACTIC4: "Final Liberation Battle Track #1"
   GMTACTIC5: "Final Liberation Battle Track #2"
   GMTACTIC6: "Final Liberation Battle Track #3"
@@ -4411,8 +4442,8 @@ en-US:
   GMTACTIC24: "Final Liberation Battle Track #13 - Go Hard"
   GMTACTIC25: "Soil Control"
   GMTACTIC26: "Knight of Fire"
-  GMTACTIC27: "Omega"  
-  
+  GMTACTIC27: "Omega"
+
   #*** MISC 2 *********************************************************************
   STR_PLASMA_CANNON_DEP1: "Craft Plasma Cannon"
   STR_PLASMA_CANNON_DEP2: "Craft Plasma Cannon"

--- a/Language/ru.yml
+++ b/Language/ru.yml
@@ -4084,9 +4084,16 @@ ru:
 
 ## Grey Knights Armor
 
-  STR_GK_CHP_LVL2_UC: "Броня Капеллана Эгида"
-  STR_GK_CHP_LVL3_UC: "Броня Капеллана Эгида"
+  STR_GK_CHP_LV1_UC: "Броня Капеллана Эгида"
+  STR_GK_CHP_LV2_UC: "Броня Капеллана Эгида"
+  STR_GK_CHP_LV3_UC: "Броня Капеллана Эгида"
 
+  STR_GK_TEC_LV4_UC: "Aegis T. Techmarine Armor"
+
+  STR_GK_APO_LV1_UC: "Aegis T. Apothecary Armor"
+  STR_GK_APO_LV2_UC: "Aegis T. Apothecary Armor"
+  STR_GK_APO_LV3_UC: "Aegis T. Apothecary Armor"
+  STR_GK_APO_LV4_UC: "Aegis T. Apothecary Armor"
 
 ## Grey Knights Research
 

--- a/Ruleset/ALLFACTIONS/personal_light.rul
+++ b/Ruleset/ALLFACTIONS/personal_light.rul
@@ -15,7 +15,7 @@ armors:
   - type: CENT_ARMOR           #CENT UNIT
     personalLight: 6
   - type: CENT_ARMOR_UC            #CENT
-    personalLight: 
+    personalLight: 6
   - type: CLOAKED_WOMAN2_ARMOR
     personalLight: 6
   - type: CLOAKED_WOMAN_ARMOR
@@ -52,19 +52,19 @@ armors:
     personalLight: 6
   - type: GSC_ARMORED_CAR_ARMOR
     personalLight: 6
-  - type: GSC_AUTOCANNON_ARMOR 
+  - type: GSC_AUTOCANNON_ARMOR
     personalLight: 6
   - type: GSC_CIVILIAN_F0_ARMOR
     personalLight: 6
   - type: GSC_CIVILIAN_F1_ARMOR
     personalLight: 6
-  - type: GSC_CIVILIAN_FSPACER_ARMOR #Female Space Crew 
+  - type: GSC_CIVILIAN_FSPACER_ARMOR #Female Space Crew
     personalLight: 6
   - type: GSC_CIVILIAN_M0_ARMOR
     personalLight: 6
   - type: GSC_CIVILIAN_M1_ARMOR
     personalLight: 6
-  - type: GSC_CIVILIAN_MSPACER_ARMOR #Male Space Crew 
+  - type: GSC_CIVILIAN_MSPACER_ARMOR #Male Space Crew
     personalLight: 6
   - type: GSC_CLOAKED_WOMAN2_ARMOR
     personalLight: 6
@@ -72,7 +72,7 @@ armors:
     personalLight: 6
   - type: GSC_CLOAKED_WOMAN_ORANGE_ARMOR
     personalLight: 6
-  - type: GSC_HB_ARMOR 
+  - type: GSC_HB_ARMOR
     personalLight: 6
   - type: GUARD_ARMORF
     personalLight: 6
@@ -85,17 +85,17 @@ armors:
   - type: STR_GUARD_POWER_ARMOR
     personalLight: 6
   - type: STR_GUARD_POWER_ARMOR_MULTILAS
-    personalLight: 6    
+    personalLight: 6
   - type: STR_KRIEG_POWER_ARMOR
     personalLight: 6
   - type: STR_KRIEG_POWER_ARMOR_MULTILAS
-    personalLight: 6    
+    personalLight: 6
   - type: STR_GUARD_POWER_ARMOR_MEDIC
     personalLight: 6
   - type: STR_GUARD_POWER_ARMOR_OFFICER
     personalLight: 6
   - type: STR_GUARD_POWER_ARMOR_COMMISSAR
-    personalLight: 6    
+    personalLight: 6
   - type: LEMONRUSS_ARMOR
     personalLight: 6
   - type: LEMONRUSS_ARMORB
@@ -210,7 +210,7 @@ armors:
     personalLight: 6
   - type: STR_ALPHA_CORVUS_ARMOR #Beakie
     personalLight: 6
-  - type: STR_ALPHA_DEV_ARMOR_ULTRA 
+  - type: STR_ALPHA_DEV_ARMOR_ULTRA
     personalLight: 6
   - type: STR_ALPHA_GREYKNIGHT_ARMOR #Grey Knight disguise
     personalLight: 6
@@ -220,7 +220,7 @@ armors:
     personalLight: 6
   - type: STR_APOT_ARMOR_UC
     personalLight: 6
-  - type: STR_ARBITOR_ARMOR_UC 
+  - type: STR_ARBITOR_ARMOR_UC
     personalLight: 6
   - type: STR_ASS_ARMOR_HONOR_UC #ASSAULT HONOR
     personalLight: 6
@@ -231,7 +231,7 @@ armors:
   - type: STR_BEASTGUARD_HEAVY_ARMOR
     personalLight: 6
   - type: STR_BEASTGUARD_HEAVY_ARMOR_SLAB
-    personalLight: 6    
+    personalLight: 6
   - type: STR_BEASTGUARD_FLAK_ARMOR
     personalLight: 6
   - type: STR_BEASTGUARD_FLAK_ARMOR_MEDIC
@@ -243,9 +243,9 @@ armors:
   - type: STR_FELINID_JUMP_ARMOR
     personalLight: 6
   - type: STR_FELINIDGUARD_CARAPACE_ARMOR
-    personalLight: 6  
+    personalLight: 6
   - type: STR_FELINIDGUARD_MEDIC_CARAPACE_ARMOR
-    personalLight: 6  
+    personalLight: 6
   - type: STR_BIOMANCER
     personalLight: 6
   - type: STR_BLACK_LEGION_CSM_ARMOR #ELITE TIER 5 CSM
@@ -340,26 +340,26 @@ armors:
     personalLight: 6
   - type: STR_DEMI_DAEMONETTE_ARMOR     #DEMI ARMOR
     personalLight: 6
-  - type: STR_CHRYSSALID_ARMOR_DIRE 
+  - type: STR_CHRYSSALID_ARMOR_DIRE
     personalLight: 6
-  - type: SLAANESH_DEMIMONDE_ARMOR    
-    personalLight: 6  
-  - type: SLAANESH_DEMIMONDE_ARMOR_RITUALIST    
-    personalLight: 6  
-  - type: SLAANESH_DEMIMONDE_ARMOR_BLESSED 
-    personalLight: 6      
+  - type: SLAANESH_DEMIMONDE_ARMOR
+    personalLight: 6
+  - type: SLAANESH_DEMIMONDE_ARMOR_RITUALIST
+    personalLight: 6
+  - type: SLAANESH_DEMIMONDE_ARMOR_BLESSED
+    personalLight: 6
   - type: SLAANESH_DEMIMONDE_ARMOR_BLESSED_RITUALIST
-    personalLight: 6      
+    personalLight: 6
   - type: SLAANESH_DEMIMONDE_ARMOR_SACRIFICE
-    personalLight: 6      
+    personalLight: 6
   - type: SLAANESH_DEMIMONDE_ARMOR_BLESSED_SACRIFICE
-    personalLight: 6 
+    personalLight: 6
   - type: CIVILIAN_HEDONITE_ARMOR_SACRIFICE
-    personalLight: 6 
+    personalLight: 6
   - type: CIVILIAN_HEDONITE_ARMOR_BLESSED_SACRIFICE
-    personalLight: 6 
+    personalLight: 6
   - type: CIVILIAN_HEDONITE_ARMOR_BLESSED_ALPHA_SACRIFICE
-    personalLight: 6 
+    personalLight: 6
   - type: STR_DESERTER_GUARD_BASIC_FLAKARMOR
     personalLight: 6
   - type: STR_DESERTER_GUARD_BASIC_GREENSHIRT
@@ -382,8 +382,8 @@ armors:
     personalLight: 6
   - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_MULTILAS
     personalLight: 6
-  - type: STR_ASSASSINNEUTRAL_FEMSUIT 
-    personalLight: 6  
+  - type: STR_ASSASSINNEUTRAL_FEMSUIT
+    personalLight: 6
   - type: STR_DREAD_GK_ARMOR_UC
     personalLight: 6
   - type: STR_ELYSIAN_JUMP_ARMOR
@@ -420,9 +420,19 @@ armors:
     personalLight: 6
   - type: STR_FLYING_SUIT_UC                #TERMINATOR ASSAULT
     personalLight: 6
-  - type: STR_GK_APO_ARMOR_UC
+  - type: STR_GK_APO_LV1_UC
     personalLight: 6
-  - type: STR_GK_CHP_UC
+  - type: STR_GK_APO_LV2_UC
+    personalLight: 6
+  - type: STR_GK_APO_LV3_UC
+    personalLight: 6
+  - type: STR_GK_APO_LV4_UC
+    personalLight: 6
+  - type: STR_GK_CHP_LV1_UC
+    personalLight: 6
+  - type: STR_GK_CHP_LV2_UC
+    personalLight: 6
+  - type: STR_GK_CHP_LV3_UC
     personalLight: 6
   - type: STR_GK_LIB_LV1_UC
     personalLight: 6
@@ -446,6 +456,8 @@ armors:
     personalLight: 6
   - type: STR_GK_TEC_LV3_UC
     personalLight: 6
+  - type: STR_GK_TEC_LV4_UC
+    personalLight: 6
   - type: STR_GREYKNIGHT_UC                 #GREYKNIGHT ARMOR
     personalLight: 6
   - type: STR_GROTS_ARMOR
@@ -468,9 +480,9 @@ armors:
     personalLight: 6
   - type: STR_GSC_GUARD_CARAPACE_MEDIC_ARMOR
     personalLight: 6
-  - type: STR_GSC_GUARD_FLAK_ARMOR_FEMALE 
+  - type: STR_GSC_GUARD_FLAK_ARMOR_FEMALE
     personalLight: 6
-  - type: STR_GSC_GUARD_FLAK_ARMOR_MALE 
+  - type: STR_GSC_GUARD_FLAK_ARMOR_MALE
     personalLight: 6
   - type: STR_GSC_GUARD_FLAK_ARMOR_OFFICER
     personalLight: 6
@@ -486,7 +498,7 @@ armors:
     personalLight: 6
   - type: STR_GSC_JUDGEM_ARMOR #GSC JUDGE M
     personalLight: 6
-  - type: STR_GSC_KRIEG_ARMOR 
+  - type: STR_GSC_KRIEG_ARMOR
     personalLight: 6
   - type: STR_GSC_MEDICAE_ARMOR #female infector
     personalLight: 6
@@ -512,7 +524,7 @@ armors:
     personalLight: 6
   - type: STR_GSC_TANITH_ARMOR
     personalLight: 6
-  - type: STR_GSC_WARDEN_ARMOR #WARDEN MARSHAL 
+  - type: STR_GSC_WARDEN_ARMOR #WARDEN MARSHAL
     personalLight: 6
   - type: STR_GUARD_ARMORH_UC
     personalLight: 6
@@ -648,13 +660,13 @@ armors:
     personalLight: 6
   - type: STR_LIB_ARMOR_UC  #LIBRARIAN
     personalLight: 6
-  - type: STR_MARSHAL_ARMOR_UC 
+  - type: STR_MARSHAL_ARMOR_UC
     personalLight: 6
   - type: STR_MEDIC_CARAPACE_ARMOR
     personalLight: 6
-  - type: STR_MEDIC_CARAPACE_ARMOR    
+  - type: STR_MEDIC_CARAPACE_ARMOR
     personalLight: 6
-  - type: RAZORBACK_ARMOR  
+  - type: RAZORBACK_ARMOR
     personalLight: 6
   - type: STR_MKX_APO_UC
     personalLight: 6
@@ -802,7 +814,7 @@ armors:
     personalLight: 6
   - type: STR_PDF_PILOT
     personalLight: 6
-  - type: STR_PENAL_ARMOR_BROWN_UC 
+  - type: STR_PENAL_ARMOR_BROWN_UC
     personalLight: 6
   - type: STR_PENAL_ARMOR_UC
     personalLight: 6
@@ -882,7 +894,7 @@ armors:
     personalLight: 6
   - type: STR_SLAANCHOSEN_ASS    #SLAANESHI CHOSEN ASSASSIN Good armor
     personalLight: 6
-  - type: STR_SLAAN_DEVOTED_SUIT    #SLAANESHI DEVOTED 
+  - type: STR_SLAAN_DEVOTED_SUIT    #SLAANESHI DEVOTED
     personalLight: 6
   - type: STR_SLAANESH_ANOINTED_ARMOR
     personalLight: 6
@@ -914,7 +926,7 @@ armors:
     personalLight: 6
   - type: STR_SQUAT_FLAK_ARMOR
     personalLight: 6
-  - type: STR_SQUAT_FLAK_ARMOR 
+  - type: STR_SQUAT_FLAK_ARMOR
     personalLight: 6
   - type: STR_SQUAT_FLAK_ZOMBIE_FEMALE_ARMOR
     personalLight: 6
@@ -962,7 +974,7 @@ armors:
     personalLight: 6
   - type: STR_TRAITOR_CHIMERA_TURRET_ARMOR
     personalLight: 6
-  - type: STR_TRAITORGUARD_OGRYN_ARMOR 
+  - type: STR_TRAITORGUARD_OGRYN_ARMOR
     personalLight: 6
   - type: STR_TRAITORGUARD_OGRYN_REDBLACK_ARMOR
     personalLight: 6
@@ -972,7 +984,7 @@ armors:
     personalLight: 6
   - type: STR_TZAANGOR_ARMOR                                 #SLAANESH REGULAR
     personalLight: 6
-  - type: STR_TZCULTIST_FEM_ARMOR 
+  - type: STR_TZCULTIST_FEM_ARMOR
     personalLight: 6
   - type: STR_TZCULTIST_THRALL_ARMOR
     personalLight: 6
@@ -984,7 +996,7 @@ armors:
     personalLight: 6
   - type: STR_TZEENTCH_COMBAT_SERVITOR_ARMOR
     personalLight: 6
-  - type: STR_TZEENTCH_CULT_LEADER_ARMOR 
+  - type: STR_TZEENTCH_CULT_LEADER_ARMOR
     personalLight: 6
   - type: STR_TZEENTCH_CULT_LEADER_ASSASSIN_ARMOR
     personalLight: 6
@@ -1070,14 +1082,14 @@ armors:
     personalLight: 6
   - type: STR_ADEPTAS_ARMORREDBLACK    #ADEPTAS Red Black Bloody Rose Helmet
     personalLight: 6
-  - type: STR_ADEPTAS_ARMORREDWHITE    #ADEPTAS RED WHITE 
+  - type: STR_ADEPTAS_ARMORREDWHITE    #ADEPTAS RED WHITE
     personalLight: 6
   - type: STR_ADEPTAS_ARMOR_RETRIBUTOR     #ADEPTAS RETRIBUTOR
     personalLight: 6
   - type: STR_ADEPTAS_ARMORR_UC    #ADEPTAS Repentia
     personalLight: 6
   - type: STR_ADEPTAS_ARMORR_FIXED_UC    #ADEPTAS Repentia
-    personalLight: 6    
+    personalLight: 6
   - type: STR_ADEPTAS_ARMORS_UC    #ADEPTAS Seraph
     personalLight: 6
   - type: STR_ADEPTAS_ARMOR_SUPERIOR     #ADEPTAS Sister Superior Armor
@@ -1122,7 +1134,7 @@ armors:
     personalLight: 6
   - type: STR_ADEPTAS_SENTINEL_LANCE_UC #Adeptas Sentinel Thermal Lance Sariel Pattern
     personalLight: 6
-  - type: STR_ADEPTAS_ZOMBIE_ARMOR     #ADEPTAS zombie 
+  - type: STR_ADEPTAS_ZOMBIE_ARMOR     #ADEPTAS zombie
     personalLight: 6
   - type: STR_ASSASSINNEUTRAL_FEMSUIT    #IMPERIAL ASSASSIN SUIT
     personalLight: 6
@@ -1158,7 +1170,7 @@ armors:
     personalLight: 6
   - type: STR_WRAITHGUARD_ARMOR_P
     personalLight: 6
-  - type: STR_WRAITHGUARD_ARMOR_P_SHIELD 
+  - type: STR_WRAITHGUARD_ARMOR_P_SHIELD
     personalLight: 6
   - type: STR_ELDAR_ARMOR_M
     personalLight: 6
@@ -1172,21 +1184,21 @@ armors:
     personalLight: 6
   - type: STR_ELDAR_ARMOR2_P
     personalLight: 6
-  - type: STR_ELDAR_ARMOR2_P_SHIELD 
+  - type: STR_ELDAR_ARMOR2_P_SHIELD
     personalLight: 6
-  - type: STR_ELDAR_ARMOR3_P 
+  - type: STR_ELDAR_ARMOR3_P
     personalLight: 6
-  - type: STR_ELDAR_ARMOR3_P_SHIELD 
+  - type: STR_ELDAR_ARMOR3_P_SHIELD
     personalLight: 6
   - type: STR_ELDAR_ARMOR4_P
     personalLight: 6
-  - type: STR_ELDAR_ARMOR4_P_SHIELD 
+  - type: STR_ELDAR_ARMOR4_P_SHIELD
     personalLight: 6
   - type: STR_ELDAR_ARMOR5_P
     personalLight: 6
-  - type: STR_ELDAR_ARMOR5_P_SHIELD 
+  - type: STR_ELDAR_ARMOR5_P_SHIELD
     personalLight: 6
   - type: STR_ELDAR_ARMOR6_P
     personalLight: 6
-  - type: STR_ELDAR_ARMOR6_P_SHIELD 
+  - type: STR_ELDAR_ARMOR6_P_SHIELD
     personalLight: 6

--- a/Ruleset/SM/GREY KNIGHTS/armors_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/armors_GK.rul
@@ -8,7 +8,7 @@ armors:
     antiCamouflageAtDay: 5 #+1 Inq
     antiCamouflageAtDark: 5 #+1 Inq
     spriteSheet: INQ_STORMTROOPER_BS.PCK
-    spriteInv: INQ_STORMTROOPER_INV_ 
+    spriteInv: INQ_STORMTROOPER_INV_
     drawingRoutine: 0
     customArmorPreviewIndex: 580 #Unique
     storeItem: STR_NONE #STR_INQ_STORMTROOPER_CARAPACE_ARMOR
@@ -35,24 +35,24 @@ armors:
       - STR_INQ_STORMTROOPER
     loftempsSet: [ 3 ]
     stats:
-       firing: 10
-       reactions: 10
-       bravery: 10
+      firing: 10
+      reactions: 10
+      bravery: 10
 
   - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_HELLGUN
     refNode: *STR_INQ_ARMOR_CARAPACE_STORMTROOPER
     storeItem: STR_NONE
-    builtInWeapons:      
+    builtInWeapons:
       - STR_INQ_HELLGUN
       - INV_NULL_STORM_TROOPER_BACKPACK #needs a black version
 
   - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_MULTILAS
     refNode: *STR_INQ_ARMOR_CARAPACE_STORMTROOPER
     storeItem: STR_NONE
-    builtInWeapons:      
+    builtInWeapons:
       - STR_HAND_MULTILASER_PAI
       - INV_NULL_STORM_TROOPER_BACKPACK #needs a black version
-      
+
   - type: STR_DREAD_GK_ARMOR_UC
     visibilityAtDay: 40
     visibilityAtDark: 30
@@ -140,14 +140,132 @@ armors:
     refNode: *STR_GK_TAC
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 10
+    stats:
+      tu: 0
+      stamina: 10
+      health: 0
+      bravery: 0
+      reactions: 0
+      firing: -10
+      throwing: -10
+      strength: 20
+      melee: 0
+      psiStrength: 10
+      psiSkill: 10
+    builtInWeapons:
+      - STR_HOLOCAUST_TOME
+      - INV_NULL_3X3
+
 
   - type: STR_GK_LIB_LV2_UC
     refNode: *STR_GK_LIB
+    stats:
+      tu: 0
+      stamina: 20
+      health: 0
+      reactions: 0
+      firing: -10
+      throwing: -10
+      strength: 20
+      melee: 0
+      psiStrength: 20
+      psiSkill: 20
+    psiVision: 3 #gotta hug some walls, but potentially useful near doors and under ship overhangs
+    builtInWeapons:
+      - STR_HOLOCAUST_TOME
+      - INV_NULL_3X3
+
+
   - type: STR_GK_LIB_LV3_UC
     refNode: *STR_GK_LIB
+    stats:
+      tu: 0
+      stamina: 30
+      health: 0
+      bravery: 10
+      reactions: 0
+      firing: -10
+      throwing: -10
+      strength: 20
+      melee: 0
+      psiStrength: 30
+      psiSkill: 30
+    psiVision: 4 #gotta hug some walls, but potentially useful near doors and under ship overhangs
+    builtInWeapons:
+      - STR_PATCHSPEED
+      - STR_HOLOCAUST_TOME
+      - INV_NULL_3X3
 
-  - type: STR_GK_APO_ARMOR_UC
+
+  - &STR_GK_APO
+    type: STR_GK_APO_LV1_UC
     refNode: *STR_GK_TAC
+    antiCamouflageAtDay: 5
+    antiCamouflageAtDark: 5
+    stats:
+      tu: -10
+      stamina: -10
+      health: 10
+      bravery: 10
+      reactions: 0
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 0
+
+  - type: STR_GK_APO_LV2_UC
+    refNode: *STR_GK_APO
+    stats:
+      tu: -10
+      stamina: -10
+      health: 10
+      bravery: 10
+      reactions: 0
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 5
+    tags:
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 10
+      ARMOR_ENERGY_SHIELD_DECAY: 10
+
+  - type: STR_GK_APO_LV3_UC
+    refNode: *STR_GK_APO
+    stats:
+      tu: -10
+      stamina: -10
+      health: 20
+      bravery: 20
+      reactions: 0
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 10
+    builtInWeapons:
+      - STR_GK_NORTH_IMP
+    tags:
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 15
+      ARMOR_ENERGY_SHIELD_DECAY: 10
+
+  - type: STR_GK_APO_LV4_UC
+    refNode: *STR_GK_APO
+    stats:
+      tu: -10
+      stamina: -10
+      health: 30
+      bravery: 30
+      reactions: 0
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 20
+    builtInWeapons:
+      - STR_GK_NORTH_MC
+    tags:
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 20
+      ARMOR_ENERGY_SHIELD_DECAY: 10
+    units:
+      - STR_GK_LV5
 
   - &STR_GK_TEC
     type: STR_GK_TEC_LV1_UC
@@ -155,15 +273,15 @@ armors:
     antiCamouflageAtDay: 5
     antiCamouflageAtDark: 5
     stats:
-       tu: 0
-       stamina: 50
-       health: 10
-       bravery: 0
-       reactions: -10
-       firing: 0
-       throwing: 10
-       strength: 25
-       melee: 10
+      tu: 0
+      stamina: 50
+      health: 10
+      bravery: 0
+      reactions: -10
+      firing: 0
+      throwing: 10
+      strength: 25
+      melee: 10
     rearArmor: 110
 
   - type: STR_GK_TEC_LV2_UC
@@ -172,88 +290,71 @@ armors:
   - type: STR_GK_TEC_LV3_UC
     refNode: *STR_GK_TEC
 
-  - type: STR_GK_CHP_UC
-    refNode: *STR_GK_TAC
-    antiCamouflageAtDay: 10
-    antiCamouflageAtDark: 10
+  - type: STR_GK_TEC_LV4_UC
+    refNode: *STR_GK_TEC
     stats:
-       tu: 10
-       stamina: 10
-       health: 20
-       bravery: 0
-       reactions: -10
-       firing: 0
-       throwing: 0
-       strength: 0
-       melee: 0
+      tu: 0
+      stamina: 80
+      health: 20
+      bravery: 0
+      reactions: -10
+      firing: 0
+      throwing: 20
+      strength: 40
+      melee: 20
+    tags:
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 10
+      ARMOR_ENERGY_SHIELD_DECAY: 10
     units:
-      - STR_GK_LV3
+      - STR_GK_LV5
 
   - &STR_GK_CHP
-    type: STR_GK_CHP_LVL2_UC
+    type: STR_GK_CHP_LVL1_UC
     refNode: *STR_GK_TAC
-    selectUnitMale:     [{mod: 40k, index: 1256}, {mod: 40k, index: 1257}, {mod: 40k, index: 1258}, {mod: 40k, index: 1259}, {mod: 40k, index: 1260}]
-    selectUnitFemale:   [{mod: 40k, index: 1256}, {mod: 40k, index: 1257}, {mod: 40k, index: 1258}, {mod: 40k, index: 1259}, {mod: 40k, index: 1260}]
-    startMovingMale:    [{mod: 40k, index: 1251}, {mod: 40k, index: 1252}, {mod: 40k, index: 1253}, {mod: 40k, index: 1254}, {mod: 40k, index: 1255}]
-    startMovingFemale:  [{mod: 40k, index: 1251}, {mod: 40k, index: 1252}, {mod: 40k, index: 1253}, {mod: 40k, index: 1254}, {mod: 40k, index: 1255}]
-    selectWeaponMale:   [{mod: 40k, index: 1246}, {mod: 40k, index: 1247}, {mod: 40k, index: 1248}, {mod: 40k, index: 1249}, {mod: 40k, index: 1250}]
-    selectWeaponFemale: [{mod: 40k, index: 1246}, {mod: 40k, index: 1247}, {mod: 40k, index: 1248}, {mod: 40k, index: 1249}, {mod: 40k, index: 1250}]
-    annoyedMale:        [{mod: 40k, index: 1261}, {mod: 40k, index: 1262}, {mod: 40k, index: 1263}, {mod: 40k, index: 1264}, {mod: 40k, index: 1265}]
-    annoyedFemale:      [{mod: 40k, index: 1261}, {mod: 40k, index: 1262}, {mod: 40k, index: 1263}, {mod: 40k, index: 1264}, {mod: 40k, index: 1265}]
-    deathMale:     [{mod: 40k, index: 380}, {mod: 40k, index: 381}, {mod: 40k, index: 382}, {mod: 40k, index: 383}, {mod: 40k, index: 384}]
-    deathFemale:   [{mod: 40k, index: 380}, {mod: 40k, index: 381}, {mod: 40k, index: 382}, {mod: 40k, index: 383}, {mod: 40k, index: 384}]
-    spriteSheet: GKCHP.PCK
-    ufopediaType: STR_GK_CHP_UC
-    visibilityAtDay: 40
-    visibilityAtDark: 30
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 10
-    zombiImmune: true
-    corpseBattle:
-      - STR_GK_CHP_CORPSE
-    storeItem: STR_GK_CHP_ARMOR
-    corpseGeo: STR_FALLEN_CORPSE
     stats:
-       tu: 10
-       stamina: 10
-       health: 20
-       bravery: 10
-       reactions: -10
-       firing: 0
-       throwing: 0
-       strength: 0
-       melee: 0
-    forcedTorso: 1
-    units:
-      - STR_GK_LV4
-    builtInWeapons:
-      - STR_GK_HB_MC
-      - AUX_CROZIUS
-      - INV_NULL_3X3
-    specialWeapon: STR_UNARMED_GAUNTLET_PLUS
+      tu: 10
+      stamina: 10
+      health: 20
+      bravery: 0
+      reactions: -10
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 0
+
+  - type: STR_GK_CHP_LVL2_UC
+    refNode: *STR_GK_CHP
+    stats:
+      tu: 10
+      stamina: 10
+      health: 20
+      bravery: 10
+      reactions: -10
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 0
     tags:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 10
       ARMOR_ENERGY_SHIELD_DECAY: 12
 
-
   - type: STR_GK_CHP_LVL3_UC
     refNode: *STR_GK_CHP
     stats:
-       tu: 10
-       stamina: 10
-       health: 20
-       bravery: 20
-       reactions: -10
-       firing: 0
-       throwing: 0
-       strength: 0
-       melee: 0
+      tu: 10
+      stamina: 10
+      health: 20
+      bravery: 20
+      reactions: -10
+      firing: 0
+      throwing: 0
+      strength: 20
+      melee: 0
     tags:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 20
       ARMOR_ENERGY_SHIELD_DECAY: 13
-    units:
-      - STR_GK_LV5
-      
 
   - type: STR_ELDAR_FARSEER_ARMOR      #SEER
     tags:
@@ -289,5 +390,6 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     units:
-      - STR_ELDAR_FARSEER 
+      - STR_ELDAR_FARSEER
+    specialWeapon: STR_ELDAR_LIGHT_SAFE #no snap shot Eldar psychic light
     loftempsSet: [ 3 ]

--- a/Ruleset/SM/GREY KNIGHTS/armors_layers_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/armors_layers_GK.rul
@@ -1,6 +1,6 @@
 armors:
 
-  - type: STR_GK_CHP_LVL2_UC     #CHAPLAIN
+  - type: STR_GK_CHP_LV1_UC     #CHAPLAIN
     customArmorPreviewIndex: 202
     layersDefaultPrefix: 21
     layersSpecificPrefix:
@@ -20,7 +20,29 @@ armors:
       F4: ["0", "GKCHAP", "M11_FACE", "MEDAL3"]
       F5: ["0", "GKCHAP", "M12_FACE", "MEDAL3"]
       F6: ["0", "GKCHAP", "M13_FACE", "MEDAL3"]
-  - type: STR_GK_CHP_LVL3_UC     #CHAPLAIN
+
+  - type: STR_GK_CHP_LV2_UC     #CHAPLAIN
+    customArmorPreviewIndex: 202
+    layersDefaultPrefix: 21
+    layersSpecificPrefix:
+      21: GK
+    layersDefinition:
+      M0: ["0", "GKCHAP", "M0_FACE", "MEDAL1"]
+      M1: ["0", "GKCHAP", "M1_FACE", "MEDAL1"]
+      M2: ["0", "GKCHAP", "M2_FACE", "MEDAL1"]
+      M3: ["0", "GKCHAP", "M3_FACE", "MEDAL1"]
+      M4: ["0", "GKCHAP", "M4_FACE", "MEDAL1"]
+      M5: ["0", "GKCHAP", "M5_FACE", "MEDAL2"]
+      M6: ["0", "GKCHAP", "M6_FACE", "MEDAL2"]
+      F0: ["0", "GKCHAP", "M7_FACE", "MEDAL2"]
+      F1: ["0", "GKCHAP", "M8_FACE", "MEDAL2"]
+      F2: ["0", "GKCHAP", "M9_FACE", "MEDAL3"]
+      F3: ["0", "GKCHAP", "M10_FACE", "MEDAL3"]
+      F4: ["0", "GKCHAP", "M11_FACE", "MEDAL3"]
+      F5: ["0", "GKCHAP", "M12_FACE", "MEDAL3"]
+      F6: ["0", "GKCHAP", "M13_FACE", "MEDAL3"]
+
+  - type: STR_GK_CHP_LV3_UC     #CHAPLAIN
     customArmorPreviewIndex: 202
     layersDefaultPrefix: 21
     layersSpecificPrefix:

--- a/Ruleset/SM/GREY KNIGHTS/armors_scripts_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/armors_scripts_GK.rul
@@ -23,8 +23,13 @@ armors:
         return;
 
 
+  - type: STR_GK_CHP_LV1_UC
+    refNode: *STR_AEGIS_ARMOR
 
-  - type: STR_GK_CHP_UC
+  - type: STR_GK_CHP_LV2_UC
+    refNode: *STR_AEGIS_ARMOR
+
+  - type: STR_GK_CHP_LV3_UC
     refNode: *STR_AEGIS_ARMOR
 
   - type: STR_GK_TAC_LV1_UC
@@ -51,7 +56,16 @@ armors:
   - type: STR_GK_LIB_LV3_UC
     refNode: *STR_AEGIS_ARMOR
 
-  - type: STR_GK_APO_ARMOR_UC
+  - type: STR_GK_APO_LV1_UC
+    refNode: *STR_AEGIS_ARMOR
+
+  - type: STR_GK_APO_LV2_UC
+    refNode: *STR_AEGIS_ARMOR
+
+  - type: STR_GK_APO_LV3_UC
+    refNode: *STR_AEGIS_ARMOR
+
+  - type: STR_GK_APO_LV4_UC
     refNode: *STR_AEGIS_ARMOR
 
   - type: STR_GK_TEC_LV1_UC
@@ -61,4 +75,7 @@ armors:
     refNode: *STR_AEGIS_ARMOR
 
   - type: STR_GK_TEC_LV3_UC
+    refNode: *STR_AEGIS_ARMOR
+
+  - type: STR_GK_TEC_LV4_UC
     refNode: *STR_AEGIS_ARMOR

--- a/Ruleset/SM/GREY KNIGHTS/ufopaedia_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/ufopaedia_GK.rul
@@ -4,7 +4,7 @@ ufopaedia:
     section: STR_STRATEGY
     requires:
       - STR_CHAMBERMILITANT
-    image_id: INQUISITOR_CODEX.SPK 
+    image_id: INQUISITOR_CODEX.SPK
     text: STR_INQUISITION_FAVOR_CODEX
     listOrder: 21
 
@@ -13,7 +13,7 @@ ufopaedia:
     section: STR_STRATEGY
     requires:
       - STR_RADICAL_INQUISITOR_STRATEGY
-    image_id: INQUISITOR_CODEX.SPK 
+    image_id: INQUISITOR_CODEX.SPK
     text: STR_RADICAL_INQUISITOR_STRATEGY_DESCRIPTION
     listOrder: 21
 
@@ -22,7 +22,7 @@ ufopaedia:
       - STR_HERETICAL_INQUISITOR_STRATEGY
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
-    image_id: INQUISITOR_CODEX.SPK 
+    image_id: INQUISITOR_CODEX.SPK
     text: STR_HERETICAL_INQUISITOR_STRATEGY_DESCRIPTION
     listOrder: 21
 
@@ -31,10 +31,10 @@ ufopaedia:
       - STR_SUMMON_DAEMONS_RESEARCH
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
-    image_id: INQUISITOR_CODEX.SPK 
+    image_id: INQUISITOR_CODEX.SPK
     text: STR_SUMMON_DAEMONS_RESEARCH_DESCRIPTION
     listOrder: 6000
-    
+
   - id: STR_INQ_STORMTROOPER_CARAPACE_ARMOR         #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -63,7 +63,7 @@ ufopaedia:
     pages:
       - title: STR_HAND_MULTILASER_PAI
         text: STR_HAND_MULTILASER_UFOPEDIA
-        
+
   - id: STR_GK_TAC_LV1_UC
     pages:
       - title: STR_GK_TAC_LV1_UC
@@ -75,7 +75,12 @@ ufopaedia:
 #      - title: STR_GK_TAC_LV1_UC
 #        text: STR_GK_TAC_LEVELS_ARMOR_UFOPEDIA
 
-#  - id: STR_GK_APO_ARMOR_UC
+  - id: STR_GK_APO_LV1_UC
+    pages:
+      - title: STR_GK_APO_LV1_UC
+        text: STR_APOT_ARMOR_UFOPEDIA
+      - title: STR_GK_APO_LV1_UC
+        text: STR_GK_APO_LEVELS_STATS_UFOPEDIA
 
   - id: STR_GK_LIB_LV1_UC
     pages:
@@ -86,7 +91,7 @@ ufopaedia:
 #      - title: STR_GK_LIB_LV1_UC
 #        text: STR_GK_LIB_LEVELS_ARMOR_UFOPEDIA
 
-  - id: STR_GK_TEC_LV1_UC 
+  - id: STR_GK_TEC_LV1_UC
     pages:
       - title: STR_GK_TEC_LV1_UC
         text: STR_TECH_ARMOR_UFOPEDIA
@@ -95,7 +100,7 @@ ufopaedia:
 #      - title: STR_GK_TEC_LV1_UC
 #        text: STR_GK_TEC_LEVELS_ARMOR_UFOPEDIA
 
-  - id: STR_GK_CHP_UC                     #5901
+  - id: STR_GK_CHP_LV1_UC                     #5901
     type_id: 15
     section: STR_ARMORPEDIA
     image_id: 0GKC.SPK
@@ -104,9 +109,9 @@ ufopaedia:
       - STR_GREYKNIGHTS
       - STR_GK_CHP_ARMOR
     pages:
-      - title: STR_GK_CHP_UC
+      - title: STR_GK_CHP_LV1_UC
         text: STR_CHAP_ARMOR_UFOPEDIA
-      - title: STR_GK_CHP_UC
+      - title: STR_GK_CHP_LV1_UC
         text: STR_GK_CHP_LEVELS_STATS_UFOPEDIA
     listOrder: 5901
 

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -17,10 +17,10 @@ items:
       ToHealth: 1.0
       ToStun: 0.5
     bulletSpeed: 50
-    explosionSpeed: 5   
+    explosionSpeed: 5
     compatibleAmmo: !remove
       - STR_ASSC_CLIP
-      
+
   - type: STR_ROCKET_LAUNCHER
     armor: 200
     requiresBuy:
@@ -34,47 +34,47 @@ items:
       - STR_HEAVY_ROCKET_HE
       - STR_HEAVY_ROCKET_KRAK
       - STR_HEAVY_ROCKET
-    
-    
-  - type: STR_PISTOL_CLIP #              10210    
+
+
+  - type: STR_PISTOL_CLIP #              10210
     requiresBuy:
       - STR_ADEPTAS_MARINES_AND_INQUISITION
-  - type: STR_RIFLE_CLIP   
+  - type: STR_RIFLE_CLIP
     requiresBuy:
       - STR_ADEPTAS_MARINES_AND_INQUISITION
-  
-  - type: STR_PISTOL  #BOLTER PISTOL  10100    
+
+  - type: STR_PISTOL  #BOLTER PISTOL  10100
     armor: 200
     requiresBuy:
-      - STR_MARINES_AND_INQUISITION 
+      - STR_MARINES_AND_INQUISITION
   - type: STR_PISTOLB #BOLTER PISTOL  10110  TYPE BLUE
     armor: 200
     requiresBuy:
-      - STR_MARINES_AND_INQUISITION 
+      - STR_MARINES_AND_INQUISITION
   - type: STR_PISTOLS    #Stalker boltpistol
     armor: 200
     requiresBuy:
-      - STR_MARINES_AND_INQUISITION 
+      - STR_MARINES_AND_INQUISITION
   - type: STR_PISTOLH #BOLTER PISTOL  10130 TYPE HYBRID
     armor: 200
     requiresBuy:
-      - STR_MARINES_AND_INQUISITION 
-  
+      - STR_MARINES_AND_INQUISITION
+
   - type: STR_RIFLE #BOLTER #         10300
     armor: 200
     requiresBuy:
       - STR_MARINES_AND_INQUISITION
     costBuy: 10000
-    
+
   - type: STR_RIFLEB #BOLTER #        10310  TYPE BLUE
     armor: 200
     requiresBuy:
-      - STR_MARINES_AND_INQUISITION   
+      - STR_MARINES_AND_INQUISITION
   - type: STR_RIFLEC #BOLTER #        10320  TYPE STALKER           AIMED
     armor: 200
     requiresBuy:
-      - STR_MARINES_AND_INQUISITION 
-  
+      - STR_MARINES_AND_INQUISITION
+
   - type: STR_MCRIFLE #BOLTER                 10400                   MC no aim
     categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
     size: 0.3
@@ -109,14 +109,14 @@ items:
     armor: 200
     requiresBuy:
       - STR_MARINES_AND_INQUISITION
-  
+
   - type: STR_SHOTGUN
     weight: 10 #+3 from 7 vanilla, makes the low weight carbines more attractive.
     armor: 200
     compatibleAmmo:
       - STR_SHOTGUN_SHELLS
-      - STR_STUN_SHELLS 
-      - STR_STUN_GAS_SHELLS 
+      - STR_STUN_SHELLS
+      - STR_STUN_GAS_SHELLS
 
   - type: STR_MCSHOTGUN
     weight: 9 #+2 from 7 vanilla, makes the low weight carbines more attractive.
@@ -124,19 +124,19 @@ items:
     compatibleAmmo:
       - STR_SHOTGUN_SHELLS
       - STR_SHOTGUN_SHELLS_MC
-      - STR_STUN_SHELLS 
-      - STR_STUN_GAS_SHELLS  
+      - STR_STUN_SHELLS
+      - STR_STUN_GAS_SHELLS
 
   - type: STR_HC_AP_AMMO #SNIPER AP                   11910
     costBuy: 4000 #far better than hotshot cells or AP Stub Rifle rounds, but half the clipsize so2x the cost
-    costSell: 1000 
+    costSell: 1000
   - type: STR_HC_HE_AMMO #SNIPER HE                   11920
-    costBuy: 2000 
+    costBuy: 2000
     costSell: 500
   - type: STR_HC_I_AMMO #SNIPER I                     11930
-    costBuy: 1000 
+    costBuy: 1000
     costSell: 200
-    
+
   - type: STR_STUN_SHELLS
     categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT]
     shotgunBehavior: 1   #*** makes the shotgun a bit more useful at range bit tightening the spread ***
@@ -145,12 +145,12 @@ items:
     costBuy: 1500
     costSell: 150
     weight: 3
-    bigSprite: {mod: 40k, index: 236} #make new with alt color 
+    bigSprite: {mod: 40k, index: 236} #make new with alt color
     floorSprite: {mod: 40k, index: 119}
     handSprite: {mod: 40k, index: 464}
     hitSound: {mod: 40k, index: 22}
     hitAnimation: {mod: 40k, index: 26}
-    power: 40 #40 for normal shotgun shells 
+    power: 40 #40 for normal shotgun shells
     damageAlter: #DA SHOTGUN
       ToArmorPre: 0.05
       ArmorEffectiveness: 0.7
@@ -158,7 +158,7 @@ items:
       ToStun: 0.4
       ToEnergy: 1.0
       ToTime: 1.0
-    damageType: 5 #plasma energy shock 
+    damageType: 5 #plasma energy shock
     clipSize: 8
     battleType: 2
     listOrder: 10710
@@ -171,19 +171,19 @@ items:
     costBuy: 1500
     costSell: 150
     weight: 3
-    bigSprite: {mod: 40k, index: 236} #make new with alt color 
+    bigSprite: {mod: 40k, index: 236} #make new with alt color
     floorSprite: {mod: 40k, index: 119}
     handSprite: {mod: 40k, index: 464}
     hitSound: {mod: 40k, index: 832} #blight rocket
     hitAnimation: 1020 #pink skull splosion
-    power: 30 #40 for normal shotgun shells 
+    power: 30 #40 for normal shotgun shells
     damageAlter: #DA SHOTGUN
       ArmorEffectiveness: 0.6
       ToHealth: 0.1
       ToStun: 0.5
       ToEnergy: 1.5
       ToTime: 1.5
-    damageType: 8 #acid stun gas smoke bypasses 
+    damageType: 8 #acid stun gas smoke bypasses
     blastRadius: 3
     clipSize: 8
     battleType: 2
@@ -327,7 +327,7 @@ items:
       - STR_HWP_CANNON_SHELLS
 
   - type: AUX_RAM           #AUX   BIKE ARMOR AUX
-    bigSprite: {mod: 40k, index: 222} 
+    bigSprite: {mod: 40k, index: 222}
     meleeSound: {mod: 40k, index: 753} #753 Powerswrod miss
     meleeHitSound: {mod: 40k, index: 709} #709 chainhit
     meleeAnimation: {mod: 40k, index: 44}
@@ -409,10 +409,10 @@ items:
       ToArmor: 0.1
 
   - type: STR_HC_I_AMMO #SNIPER I
-    refNode: *STR_INC_AMMO    
-  
+    refNode: *STR_INC_AMMO
+
   - type: STR_INCENDIARY_ROCKET
-    refNode: *STR_INC_AMMO    
+    refNode: *STR_INC_AMMO
     # blastRadius: 7 # was 5; sure about turning it to 7?
     damageAlter:
       FixRadius: 7
@@ -467,15 +467,135 @@ items:
       ToHealth: 0.9
       RandomType: 2 #TFTD [50% - 150%]
 
-  
+
   - type: STR_HALLEBARD
     refNode: *STR_POWER_MELEE_WEAPON
     armor: 200
-    power: 100
+    fireSound: 753 #clawswipe
+    explosionHitSound: { mod: 40k, index: 101} #stabhit
+    hitAnimation: 2040 #Bloodgush sprite, X1.pck for ranged attacks, was 1070 #AOEMELEEGENE.png
+    hitAnimFrames: 8
+    powerForAnimation: 10
+    hitSound: { mod: 40k, index: 101} #stabhit
+    bulletSprite: 5
+    clipSize: -1
+    maxRange: 3
+    powerRangeThreshold: 4
+    powerRangeReduction: 99
+    power: 50 #lower base damage; compensated for by stat scaling
+    meleePower: 50
+    battleType: 1
+    damageType: 11 #melta damage; more effective against daemons
+    confSnap:
+      name: STR_HALLEBARD_SNAPSHOT_LUNGE
+      shots: 1
+    costSnap:
+      time: 15
+    accuracySnap: 90
+    accuracyMultiplier:
+      firing: 0.0
+      melee: 1
+    skillApplied: true
     damageBonus:
-      psiSkill: 1
+      strength: 0.3 #strength matters more than skill given weapon size in terms of damage scaling
+      melee: 0.2
+      psiSkill: 1 #infused by psychic power
+    meleeType: 11 #melta damage; more effective against daemons
+    tuMelee: 15
+    flatRate: true
     tags:
       ITEM_STRENGTH_REQUIREMENT: 100
+
+  - type: AUX_MEDI_KIT_ADVANCED      #AUX MEDI KIT - Advanced Narthecium for Level 4/Paladin GK Apothecary Armor
+    size: 0.1
+    costSell: 50
+    weight: 0
+    bigSprite: 24
+    floorSprite: 24
+    battleType: 6
+    invWidth: 2
+    invHeight: 3
+    painKiller: 40 #More uses from Advanced
+    heal: 40 #More uses from Advanced
+    stimulant: 40 #More uses from Advanced
+    woundRecovery: 1
+    healthRecovery: 5 #+2 HP recovery
+    stunRecovery: 6 #+2 Stun recovery
+    energyRecovery: 15 #+5 Energy recovery
+    tuUse: 10
+    experienceTrainingMode: 19 #*** makes the apothecary medikit item train bravery ***
+    medikitTargetSelf: true
+    flatRate: true
+    recover: false
+    fixedWeapon: true
+    #*** Melee
+    meleeSound: 753 #753 Powersword miss
+    meleeHitSound: 709 #709 chainhit
+    meleeAnimation: 44
+    meleeType: 7
+    meleePower: 50
+    accuracyMelee: 70
+    meleeBonus:
+      strength: 0.2
+      melee: 0.2
+    meleeAlter: #DA CHAIN
+      ToArmorPre: 0.3
+      ToHealth: 0.9
+      RandomType: 2 #TFTD [50% - 150%]
+      ToWound: 0.3
+      ToEnergy: 0.5
+    meleeMultiplier:
+      flatHundred: 0.5
+      melee: 0.5
+    tuMelee: 15
+    flatMelee:
+      time: true
+
+
+  - type: AUX_MEDI_KIT_MC      #AUX MEDI KIT - Mastercrafted Narthecium for Level 5/Captain GK Apothecary Armor
+    size: 0.1
+    costSell: 50
+    weight: 0
+    bigSprite: 24
+    floorSprite: 24
+    battleType: 6
+    invWidth: 2
+    invHeight: 3
+    painKiller: 50 #More uses from Mastercrafting
+    heal: 50 #More uses from Mastercrafting
+    stimulant: 50 #More uses from Mastercrafting
+    woundRecovery: 1
+    healthRecovery: 5
+    stunRecovery: 6
+    energyRecovery: 15
+    tuUse: 10
+    experienceTrainingMode: 19 #*** makes the apothecary medikit item train bravery ***
+    medikitTargetSelf: true
+    flatRate: true
+    recover: false
+    fixedWeapon: true
+    #*** Melee
+    meleeSound: 753 #753 Powerswrod miss
+    meleeHitSound: 709 #709 chainhit
+    meleeAnimation: 44
+    meleeType: 7
+    meleePower: 50
+    accuracyMelee: 90 #Improved accuracy from Mastercrafting
+    meleeBonus:
+      strength: 0.2
+      melee: 0.2
+    meleeAlter: #DA CHAIN
+      ToArmorPre: 0.3
+      ToHealth: 0.9
+      RandomType: 2 #TFTD [50% - 150%]
+      ToWound: 0.3
+      ToEnergy: 0.5
+    meleeMultiplier:
+      flatHundred: 0.5
+      melee: 0.5
+    tuMelee: 10 #Lower TU cost from Mastercrafting
+    flatMelee:
+      time: true
 
 
   - type: STR_CLAWS
@@ -533,7 +653,7 @@ items:
     tuAuto: 35 #+2 scoped malus, higher rate of fire
     accuracySnap: 85 #+5 scoped
     accuracyAuto: 60 #default
-    tuAimed: 85 
+    tuAimed: 85
     accuracyAimed: 90
     tuLoad: 30 #hassle to reload, flat number
     autoShots: 4 #midway between Volleygun and Hellgun
@@ -552,7 +672,7 @@ items:
     meleeHitSound: {mod: 40k, index: 101}
     meleeAnimation: 0
     meleeType: 7
-    meleePower: 55 #+5 Inquisition blessings  
+    meleePower: 55 #+5 Inquisition blessings
     meleeBonus:
       strength: 0.2
       melee: 0.2
@@ -576,7 +696,7 @@ items:
       ITEM_AIMED_POWER_BONUS: 20 #INQ BONUS
 
 #PLAYABLE CHAOS CORPSES AND STORE ITEMS
-  - type: STR_ALPHA_LEGION_CORPSE_PLAYER 
+  - type: STR_ALPHA_LEGION_CORPSE_PLAYER
     name: STR_CORPSE
     size: 0.2
     costSell: 0
@@ -601,7 +721,7 @@ items:
     armor: 40
     recover: false
     battleType: 11
-    
+
   - type: STR_IRON_WARRIOR_CORPSE_PLAYER
     name: STR_CORPSE
     size: 0.4
@@ -706,27 +826,27 @@ items:
     #battleType: 11
     #armor: 80
     #listOrder: 19600
-    
+
 #STOREITEMS
-  - type: STR_ALPHA_ARMOR_PLAYER               
+  - type: STR_ALPHA_ARMOR_PLAYER
     size: 0.8
   - type: STR_NIGHTLORD_CSM_ARMOR_PLAYER
     size: 0.8
-  - type: STR_IRON_WARRIOR_ARMOR_PLAYER                
+  - type: STR_IRON_WARRIOR_ARMOR_PLAYER
     size: 0.8
-  - type: STR_IRON_BERSERKER_ARMOR                
+  - type: STR_IRON_BERSERKER_ARMOR
     size: 0.8
-  - type: MUTON_ARMORSLAANESH_PLAYER                 
+  - type: MUTON_ARMORSLAANESH_PLAYER
     size: 0.8
-  - type: MUTON_ARMORNURGLEA_PLAYER               
+  - type: MUTON_ARMORNURGLEA_PLAYER
     size: 0.8
-  - type: MUTON_ARMORTZEENTCH_PLAYER                
-    size: 0.8 
-  - type: STR_KHORNECHAMP_ARMOR_PLAYER             
+  - type: MUTON_ARMORTZEENTCH_PLAYER
+    size: 0.8
+  - type: STR_KHORNECHAMP_ARMOR_PLAYER
     size: 0.8
 
 #Workaround for STR_HERETICAL_INQUISITOR_STRATEGY "item" crash (view report on finishing research project).
-  - type: STR_HERETICAL_INQUISITOR_STRATEGY #it now has an ITEM and doesnt crash. Weird.            
+  - type: STR_HERETICAL_INQUISITOR_STRATEGY #it now has an ITEM and doesnt crash. Weird.
     size: 0.8
-  - type: STR_SUMMON_DAEMONS_RESEARCH #same deal         
+  - type: STR_SUMMON_DAEMONS_RESEARCH #same deal
     size: 0.8

--- a/Ruleset/SM/scripts_SM.rul
+++ b/Ruleset/SM/scripts_SM.rul
@@ -1,0 +1,86 @@
+soldiers:
+
+  - type: STR_SOLDIER
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33 #Space Marines recover from wounds faster thanks to their superhuman physiology; 1/3rd normal time.
+
+
+  - type: STR_GK_LV1
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33 #Grey Knights recover from wounds faster thanks to their superhuman physiology; 1/3rd normal time.
+
+  - type: STR_GK_LV2
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33
+
+  - type: STR_GK_LV3
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33
+
+  - type: STR_GK_LV4
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33
+
+  - type: STR_GK_LV5
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33
+
+
+  - type: STR_PRIMARISLV1
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 25 #Primaris Space Marines recover from wounds even faster than normal Space Marines; 1/4th normal time.
+
+  - type: STR_PRIMARISLV2
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 25
+
+  - type: STR_PRIMARISLV3
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 25
+
+  - type: STR_PRIMARISLV4
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 25
+
+  - type: STR_PRIMARISLV5
+    tags:
+      SOLDIER_WOUND_TIME_MULTIPLIER: 25
+
+
+# Holocaust: Grey Knight exclusive armor-ignoring spell that does incendiary type damage
+  - type: STR_HOLOCAUST_TOME
+    weight: 10
+    accuracyUse: 20
+    hitSound: {mod: 40k, index: 861 }
+    hitAnimation: 2110
+    bigSprite: 33
+    invWidth: 2
+    invHeight: 2
+    battleType: 9
+    tuUse: 25
+    costUse:
+      energy: 25
+      stun: 10
+    tuPanic: 0
+    tuMindControl: 0
+    psiAttackName: STR_HOLOCAUST_SPELL
+    LOSRequired: true
+    flatRate: true
+    fixedWeapon: true
+    power: 25
+    damageBonus:
+      psi: 0.03
+    damageType: 2
+    damageAlter:
+      FireBlastCalc: false
+      IgnoreOverKill: false
+      FixRadius: 2
+      ToHealth: 3.0
+      ToTile: 0.3
+      ToItem: 0.3
+      ToMorale: 40.0
+      ArmorEffectiveness: 0.0
+    dropoff: 5 #power drops off rapidly with distance
+    recover: false
+    clipSize: -1
+    specialUseEmptyHand: true

--- a/Ruleset/SM/scripts_SM.rul
+++ b/Ruleset/SM/scripts_SM.rul
@@ -73,14 +73,16 @@ soldiers:
     damageType: 2
     damageAlter:
       FireBlastCalc: false
-      IgnoreOverKill: false
+      IgnoreOverKill: false #incinerates completely, leaving no trace
       FixRadius: 2
       ToHealth: 3.0
+      ToArmor: 1.0 #melts armor
       ToTile: 0.3
       ToItem: 0.3
-      ToMorale: 40.0
+      ToMorale: 40.0 #spiritual fire scours the soul
       ArmorEffectiveness: 0.0
-    dropoff: 5 #power drops off rapidly with distance
+    powerRangeReduction: 20.0 #power drops off rapidly with distance
+    powerRangeThreshold: 10.0
     recover: false
     clipSize: -1
     specialUseEmptyHand: true


### PR DESCRIPTION
Adds 2 tile Snap Shot thrust attack to Force Halberd that can be used for longer range pseudomelee.

Adds Captain level scaling to Techmarine and Apothecary Aegis armors. Apothecary Aegis has access to better Nartheciums at Paladin and Captain rank.

Rebalance of GK Armors.

GK Librarian now has the custom Holocaust short range fire based psychic power instead of Shield and Lockdown, and Psi Vision 3 and 4 respectively at Paladin and Captain rank. Deals incendiary damage, and deals damage to morale and armor, igniting and hitting a fixed Radius 2 AoE.

Player controlled Eldar Seers now can use their Eldar Light psychic power (aimed shot only)

Space Marines and Grey Knights now recover from wounds in 1/3rd the normal time like Ogryns due to their superior physiology.

Primaris Marines now recover from wounds in 1/4th the normal time.