### PR TITLE
Minor GK Changes

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -1091,6 +1091,7 @@ en-US:
   STR_LAUNCH_GRENADE_SHORT: "Grenade (x{0})"
   STR_HALLEBARD_SNAPSHOT_LUNGE: "Lunge"
   STR_HOLOCAUST_TOME: "Tome of the Mind (Holocaust)"
+  STR_ELDAR_LIGHT_PLAYER: "Eldar Lightning"
 
   STR_INCENDIARY_GRENADE40: "40mm Incendiary Grenade"
   STR_PENITENCE_GRENADE40: "40mm Penitence Grenade"
@@ -4132,7 +4133,9 @@ en-US:
 
   STR_SMITE_TOME: "Tome of the Mind (Holocaust)"
   STR_HOLOCAUST_SPELL: "Holocaust"
-  STR_HOLOCAUST_SPELL_UFOPEDIA: "{NEWLINE} A powerful evocation of spiritual flame exclusive to the Grey Knights that scours flesh and soul alike, echoing the God Emperor's final banishment of Horus. Deals incendiary and morale damage that scales with the user's psychic ability and Devotion."
+  STR_HOLOCAUST_SPELL_UFOPEDIA: "{NEWLINE} A powerful evocation of spiritual flame exclusive to the Grey Knights that scours flesh and soul alike, echoing the God Emperor's final banishment of Horus; those so destroyed are consumed utterly, leaving no trace. Deals armor ignoring damage that reduces morale and scales with the user's psychic ability and Devotion."
+  STR_ELDAR_LIGHT_SPELL_UFOPEDIA: "{NEWLINE} A discharge of psychic energy in the form of coruscating spectral lightning that phases effortlessly through even the thickest armor. Deals armor ignoring damage that scales with the user's psychic ability and skill."
+
 
 ## Grey Knights Research
 
@@ -4192,27 +4195,27 @@ en-US:
   STR_GK_LIB_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL1:\tNot Available
     {ALT}{NEWLINE}LVL2:\tNot Available
-    {ALT}{NEWLINE}LVL3:\tSTA+10, FA-10, THR-10, DEV+10
+    {ALT}{NEWLINE}LVL3:\tSTA+10, FA-10, THR-10, MEL+5, PSY+10, DEV+10
     {NEWLINE} Spell: Holocaust"
 
   STR_GK_LIB_LEVELS_STATS_2_UFOPEDIA: "Promotion Stat Total Bonuses:
-    {ALT}{NEWLINE}LVL4:\tSTA+20, FA-10, THR-10, PSY+20, DEV+20, Psi Vision: 3
+    {ALT}{NEWLINE}LVL4:\tSTA+20, FA-10, THR-10, MEL+10, PSY+20, DEV+20, Psi Vision: 3
     {NEWLINE} Spell: Holocaust
-    {ALT}{NEWLINE}LVL5:\tSTA+30, BRV+10, FA-10, THR-10, PSY+30, DEV+30, Psi Vision: 4
+    {ALT}{NEWLINE}LVL5:\tSTA+30, BRV+10, FA-10, THR-10, MEL+20, PSY+30, DEV+30, Psi Vision: 5
     {NEWLINE} Spell: Speed + Holocaust"
 
   STR_GK_TEC_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL1:\tNot Available
     {ALT}{NEWLINE}LVL2:\tSTA+50, HP+10, REA-10, THR+10, STR+25, MEL+10
-    {NEWLINE} Analyser + Repair Module
+    {NEWLINE} Analyser/Repair Module
     {ALT}{NEWLINE}LVL3:\tSTA+50, HP+10, REA-10, THR+10, STR+25, MEL+10
-    {NEWLINE} Analyser + Repair Module + Tarantula Turret"
+    {NEWLINE} Analyser/Repair Module + Tarantula Turret"
 
   STR_GK_TEC_LEVELS_STATS_2_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL4:\tSTA+50, HP+10, REA-10, THR+10, STR+25, MEL+10
-    {NEWLINE} Analyser + Repair Module + Thunderfire Drone
+    {NEWLINE} Analyser/Repair Module + Thunderfire Drone
     {ALT}{NEWLINE}LVL5:\tSTA+80, HP+20, REA-10, THR+20, STR+40, MEL+20, Shield: 100
-    {NEWLINE} Adv. Analyser + Adv. Repair Module + Thunderfire Drone"
+    {NEWLINE} Adv. Analyser/Repair Module + Thunderfire Drone"
 
   STR_GK_CHP_LEVELS_STATS_UFOPEDIA: "Promotion Stat Total Bonuses:
     {ALT}{NEWLINE}LVL1:\tNot Available

--- a/Ruleset/SM/GREY KNIGHTS/armors_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/armors_GK.rul
@@ -148,8 +148,8 @@ armors:
       reactions: 0
       firing: -10
       throwing: -10
-      strength: 20
-      melee: -5
+      strength: 0
+      melee: 5
       psiStrength: 10
       psiSkill: 10
     builtInWeapons:
@@ -166,8 +166,8 @@ armors:
       reactions: 0
       firing: -10
       throwing: -10
-      strength: 20
-      melee: -5
+      strength: 00
+      melee: 10
       psiStrength: 20
       psiSkill: 20
     psiVision: 3 #gotta hug some walls, but potentially useful near doors and under ship overhangs
@@ -187,14 +187,17 @@ armors:
       firing: -10
       throwing: -10
       strength: 20
-      melee: -5
+      melee: 15
       psiStrength: 30
       psiSkill: 30
-    psiVision: 4 #gotta hug some walls, but potentially useful near doors and under ship overhangs
+    psiVision: 5 #gotta hug some walls, but potentially useful near doors and under ship overhangs
     builtInWeapons:
       - STR_PATCHSPEED
       - STR_HOLOCAUST_TOME
       - INV_NULL_3X3
+    tags:
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 10
+      ARMOR_ENERGY_SHIELD_DECAY: 12
 
   - type: STR_GK_APO_ARMOR_UC               #GREYKNIGHT ARMOR
     refNode: *STR_GK_TAC
@@ -227,7 +230,7 @@ armors:
     deathMale:     [{mod: 40k, index: 380}, {mod: 40k, index: 381}, {mod: 40k, index: 382}, {mod: 40k, index: 383}, {mod: 40k, index: 384}]
     deathFemale:   [{mod: 40k, index: 380}, {mod: 40k, index: 381}, {mod: 40k, index: 382}, {mod: 40k, index: 383}, {mod: 40k, index: 384}]
     spriteSheet: GKAPO.PCK
-    ufopediaType: STR_GK_APO_UC
+    ufopediaType: STR_GK_APO_ARMOR_UC
     visibilityAtDay: 40
     visibilityAtDark: 30
     antiCamouflageAtDay: 5
@@ -238,8 +241,8 @@ armors:
     storeItem: STR_GK_APO_ARMOR
     corpseGeo: STR_FALLEN_CORPSE
     stats:
-      tu: 10
-      stamina: 10
+      tu: -10
+      stamina: -10
       health: 20
       bravery: 10
       reactions: -10
@@ -295,7 +298,7 @@ armors:
       throwing: 0
       strength: 0
       melee: 20
-    builtInWeapons: #gains Mastwerwork Narthecium
+    builtInWeapons: #gains Masterwork Narthecium
       - INV_NULL_3X3
       - AUX_MEDI_KIT_MC
       - INV_NULL_2X1_RL
@@ -405,6 +408,10 @@ armors:
       psiSkill: 10
     units:
       - STR_GK_LV3
+    builtInWeapons:
+      - AUX_CROZIUS
+      - STR_GK_HB_MC
+      - INV_NULL_3X3
 
   - &STR_GK_CHP #Need to respecify all parameters in order for level scaling to work properly beyond Paladin/GK Level 4.
     type: STR_GK_CHP_LV2_UC
@@ -509,5 +516,5 @@ armors:
       - 1.0 #MELTA
     units:
       - STR_ELDAR_FARSEER
-    specialWeapon: STR_ELDAR_LIGHT_SAFE #no snap shot Eldar psychic light
+    specialWeapon: STR_ELDAR_LIGHT_PLAYER #no snap shot Eldar psychic light with psi scaling
     loftempsSet: [ 3 ]

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -458,16 +458,6 @@ items:
       ArmorEffectiveness: 0.4
 
 
-  - type: AUX_CROZIUS
-    # damageType: 5
-    meleeType: 5
-    meleeAlter:     #DA POWER
-      ArmorEffectiveness: 0.7
-      ToArmorPre: 0.2
-      ToHealth: 0.9
-      RandomType: 2 #TFTD [50% - 150%]
-
-
   - type: STR_HALLEBARD
     refNode: *STR_POWER_MELEE_WEAPON
     armor: 200
@@ -656,6 +646,15 @@ items:
     damageBonus:
       bravery: 0.5
       psi: 0.02
+    #melee
+    meleeType: 5
+    meleeAlter:     #DA POWER
+      ArmorEffectiveness: 0.7
+      ToArmorPre: 0.2
+      ToHealth: 0.9
+      RandomType: 2 #TFTD [50% - 150%]
+
+
 
   - type: STR_CLAWS
     refNode: *STR_POWER_MELEE_WEAPON

--- a/Ruleset/SM/scripts_SM.rul
+++ b/Ruleset/SM/scripts_SM.rul
@@ -63,6 +63,9 @@ items:
     hitAnimation: { mod: 40k, index: 88 } #XFIRE
     #Attack parameters
     accuracyAuto: 50
+    accuracyMultiplier: #psi has a slight influence
+      flatHundred: 0.8
+      psi: 0.004
     tuAuto: 25
     costUse:
       energy: 40 #exhausting
@@ -79,14 +82,14 @@ items:
       name: STR_HOLOCAUST_SPELL
     power: 20
     damageBonus:
-      psi: 0.007
+      psi: 0.005
     damageType: 11 #melta
     damageAlter:
-      RandomType: 2
+      RandomType: 6
       FireBlastCalc: false
       IgnoreOverKill: false #incinerates completely, leaving no trace
       FireThreshold: 0
-      ToHealth: 2.0
+      ToHealth: 1.0
       ToArmor: 1.0 #melts armor
       ToTile: 0.3
       ToItem: 0.3
@@ -102,3 +105,42 @@ items:
     flatRate: true
     fixedWeapon: true
     specialUseEmptyHand: true
+
+  - type: STR_ELDAR_LIGHT_PLAYER #Version of the Eldar Lightning spell that the player's Farseer users
+    weight: 0
+    bigSprite: { mod: 40k, index: 316}
+    fireSound: [{ mod: 40k, index: 854},{ mod: 40k, index: 855},{ mod: 40k, index: 856},{ mod: 40k, index: 857}]
+    power: 10
+    damageBonus: #player version scales with psi power
+      psi: 0.005
+    damageType: 5
+    accuracyAimed: 90
+    accuracyMultiplier: #psi has a slight influence
+      flatHundred: 0.8
+      psi: 0.005
+    confAimed:
+      shots: 1
+      name: STR_LH
+    tuAimed: 50
+    battleType: 1
+    damageAlter: #LIGHT
+      RandomType: 2 #TFTD [50% - 150%]
+      ArmorEffectiveness: 0.0
+      ToArmorPre: 0.0
+      ToArmor: 0.0
+      ToHealth: 2.0
+      ToStun: 0.2
+    invWidth: 2
+    invHeight: 3
+    clipSize: -1
+    bulletSprite: 17
+    blastRadius: 1
+    explosionHitSound: { mod: 40k, index: 864}
+    hitAnimation: { mod: 40k, index: 152}
+    twoHanded: false
+    skillApplied: false
+    strengthApplied: false
+    recover: false
+    fixedWeapon: true
+    specialIconSprite: 6
+    specialUseEmptyHand: false

--- a/Ruleset/ufopedia40k.rul
+++ b/Ruleset/ufopedia40k.rul
@@ -5214,3 +5214,14 @@ ufopaedia:
     requires:
       - STR_PSI_AMP
     listOrder: 30520
+
+#GK Eldar Lightning Ufopaedia entry.
+  - id: STR_ELDAR_LIGHT_PLAYER
+    type_id: 14
+    section: STR_BOOKS
+    image_id: 1BO.SPK
+    text: STR_ELDAR_LIGHT_SPELL_UFOPEDIA
+    requires:
+      - STR_PSI_AMP
+      - STR_ELDAR_SEER #need to have knowledge of psychic powers and need to have researched a live Eldar Seer
+    listOrder: 30521


### PR DESCRIPTION
-Added a player version of Eldar Lightning for player Farseers that scales somewhat with psi; UFOpaedia entry is unlocked upon researching psychic powers and a live Eldar Farseer.

-Fixed GK Apothecary armor for Castellans not displaying their UFOpaedia entry appropriately.

-Slightly nerfed the Holocaust spell; made its accuracy scale slightly with psi.

-Tweaked GK Librarian armor to be more competitive at Captain/Rank 5; gets Shield 80, Psi Vision 5 up from 4, and Melee Accuracy 15.

-Fixed bug with Chaplain not getting its Crozius.

-Improved/updated UFOpaedia entries.