### PR TITLE
Inquisition Stormtrooper Tweaks

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -1090,7 +1090,6 @@ en-US:
   STR_LAUNCH_GRENADE: "Launch Grenade"
   STR_LAUNCH_GRENADE_SHORT: "Grenade (x{0})"
   STR_HALLEBARD_SNAPSHOT_LUNGE: "Lunge"
-  STR_HOLOCAUST_TOME: "Tome of the Mind (Holocaust)"
   STR_ELDAR_LIGHT_PLAYER: "Eldar Lightning"
 
   STR_INCENDIARY_GRENADE40: "40mm Incendiary Grenade"
@@ -4105,6 +4104,9 @@ en-US:
   STR_INQ_HELLGUN: "Inquisition Hellgun"
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_HELLGUN: "Inquisition Hellgun Armor"
   STR_INQ_HELLGUN_UFOPEDIA: "{NEWLINE}The Inquisition Hellgun is a high quality, scoped Hellgun variant with a sanctified bayonet and finely tuned settings."
+  STR_INQ_FLAMER: "Inquisition Flamer"
+  STR_INQ_STORMTROOPER_CARAPACE_ARMOR_FLAMER: "Inquisition Flamer Armor"
+  STR_INQ_FLAMER_UFOPEDIA: "{NEWLINE}The Inquisition Flamer is a mastercrafted, consecrated Flamer variant with improved range and an optimized fuel mix."
   STR_REWARD_INQUISITION_STORMTROOPERS: "Inquisition Storm Troopers Activated"
   STR_REWARD_INQUISITION_STORMTROOPERS_SCRIPT: "Reward Inquisition Storm Troopers Script"
   STR_REWARD_INQUISITION_STORMTROOPERS_DESCRIPTION: "{NEWLINE}The Inquisition have taken note of your great progress and activated an available fireteam of Inquisition Storm Troopers to assist you."
@@ -4131,7 +4133,7 @@ en-US:
 
 ## Grey Knights Spells
 
-  STR_SMITE_TOME: "Tome of the Mind (Holocaust)"
+  STR_HOLOCAUST_TOME: "Tome of the Mind (Holocaust)"
   STR_HOLOCAUST_SPELL: "Holocaust"
   STR_HOLOCAUST_SPELL_UFOPEDIA: "{NEWLINE} A powerful evocation of spiritual flame exclusive to the Grey Knights that scours flesh and soul alike, echoing the God Emperor's final banishment of Horus; those so destroyed are consumed utterly, leaving no trace. Deals armor ignoring damage that reduces morale and scales with the user's psychic ability and Devotion."
   STR_ELDAR_LIGHT_SPELL_UFOPEDIA: "{NEWLINE} A discharge of psychic energy in the form of coruscating spectral lightning that phases effortlessly through even the thickest armor. Deals armor ignoring damage that scales with the user's psychic ability and skill."

--- a/Language/ru.yml
+++ b/Language/ru.yml
@@ -1090,7 +1090,6 @@ ru:
   STR_LAUNCH_GRENADE: "Гранатомет"
   STR_LAUNCH_GRENADE_SHORT: "Граната (x{0})"
   STR_HALLEBARD_SNAPSHOT_LUNGE: "Выпад"
-  STR_HOLOCAUST_TOME: "Том Разума (Истребление)"
 
   STR_INCENDIARY_GRENADE40: "40mm Граната-З"
   STR_PENITENCE_GRENADE40: "40mm Граната Покаяния"
@@ -4130,7 +4129,7 @@ ru:
 
 ## Grey Knights Spells
 
-  STR_SMITE_TOME: "Том Разума (Истребление)"
+  STR_HOLOCAUST_TOME: "Том Разума (Истребление)"
   STR_HOLOCAUST_SPELL: "Истребление"
   STR_HOLOCAUST_SPELL_UFOPEDIA: "{NEWLINE} Мощное воплощение духовного пламени, доступное только Серым Рыцарям, испепеляющее как плоть, так и душу, повторяя окончательное изгнание Хоруса Божественным Императором. Наносит урон огнем и ввергает в панику врага. Мощность психосилы зависит от психических способностей и веры."
 

--- a/Ruleset/ALLFACTIONS/personal_light.rul
+++ b/Ruleset/ALLFACTIONS/personal_light.rul
@@ -382,6 +382,8 @@ armors:
     personalLight: 6
   - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_MULTILAS
     personalLight: 6
+  - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_FLAMER
+    personalLight: 6
   - type: STR_ASSASSINNEUTRAL_FEMSUIT
     personalLight: 6
   - type: STR_DREAD_GK_ARMOR_UC

--- a/Ruleset/SM/GREY KNIGHTS/armors_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/armors_GK.rul
@@ -18,6 +18,10 @@ armors:
     sideArmor: 80 #+10 inq
     rearArmor: 55 #+5 inq
     underArmor: 50 #+10 inq
+    psiDefence:
+      flatHundred: 1.0 #Hexagrammic wards protect from psychic influence
+      psiSkill: 1.0 #Devotion protects from psychic influence
+      moraleCurrent: 1.0 #Discipline and training protects from psychic influence.
     damageModifier: #GUARD ARMOR
       - 1.0 #none
       - 1.0 #AP
@@ -52,6 +56,13 @@ armors:
     builtInWeapons:
       - STR_HAND_MULTILASER_PAI
       - INV_NULL_STORM_TROOPER_BACKPACK #needs a black version
+
+  - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_FLAMER
+    refNode: *STR_INQ_ARMOR_CARAPACE_STORMTROOPER
+    storeItem: STR_NONE
+    builtInWeapons:
+      - STR_INQ_FLAMER
+      - INV_NULL_STORM_TROOPER_BACKPACK_FLAMER
 
   - type: STR_DREAD_GK_ARMOR_UC
     visibilityAtDay: 40

--- a/Ruleset/SM/GREY KNIGHTS/soldiers_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/soldiers_GK.rul
@@ -1,5 +1,5 @@
 ﻿soldiers:
- 
+
   - type: STR_INQ_STORMTROOPER #Inquisition Stormtrooper
     requires:
       - STR_INQ_STORMTROOPER_REQUISITION
@@ -16,7 +16,7 @@
       throwing: 40 #+5 Inq
       strength: 20 #+5 Inq
       psiStrength: 0
-      psiSkill: 25 #Inq Hardened
+      psiSkill: 50 #Only the devoted may become an Inquisitorial Stormtrooper
       melee: 40
     maxStats: # doesn't matter
       tu: 60
@@ -27,8 +27,8 @@
       firing: 70
       throwing: 65
       strength: 35
-      psiStrength: 0
-      psiSkill: 50 #Inq Hardened
+      psiStrength: 100
+      psiSkill: 75 #Only the devoted may become an Inquisitorial Stormtrooper
       melee: 70
     statCaps:
       tu: 75 # was 70
@@ -39,8 +39,8 @@
       firing: 130
       throwing: 70
       strength: 65 # was 60
-      psiStrength: 70
-      psiSkill: 50
+      psiStrength: 100
+      psiSkill: 100 #Only the devoted may become an Inquisitorial Stormtrooper
       melee: 100
     trainingStatCaps:
       tu: 60
@@ -50,7 +50,7 @@
       throwing: 70 # was 65 # Scion was highest
       strength: 35
       psiStrength: 100
-      psiSkill: 100
+      psiSkill: 100 #Only the devoted may become an Inquisitorial Stormtrooper
       melee: 70
     dogfightExperience:
       bravery: 10
@@ -81,7 +81,7 @@
     value: 25
     moraleLossWhenKilled: 50
 
-  - type: STR_ELDAR_FARSEER 
+  - type: STR_ELDAR_FARSEER
     requires:
       - STR_XENO_ONLY #XENO EMBRACE
       - STR_ELDAR_SEER
@@ -151,7 +151,7 @@
     femaleFrequency: 100
     deathMale: [{mod: 40k, index: 836}, {mod: 40k, index: 837}, {mod: 40k, index: 838}]
     deathFemale: [{mod: 40k, index: 836}, {mod: 40k, index: 837}, {mod: 40k, index: 838}]
-    
+
   - type: STR_IMPERIAL_INQUISITOR
     requires:
       - STR_IMPERIAL_INQUISITOR_REQUISITION
@@ -230,7 +230,7 @@
     rankSprite: {mod: 40k, index: 850}
     rankBattleSprite: {mod: 40k, index: 233}
     rankTinySprite: {mod: 40k, index: 115}
-    
+
   - type: STR_FALLEN_GK
     costSalary: 20000
     minStats:

--- a/Ruleset/SM/GREY KNIGHTS/ufopaedia_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/ufopaedia_GK.rul
@@ -53,6 +53,15 @@ ufopaedia:
     text: STR_INQ_HELLGUN_UFOPEDIA
     listOrder: 11080
 
+  - id: STR_INQ_FLAMER
+    requires:
+      - STR_INQ_STORMTROOPER_REQUISITION
+    type_id: 14
+    section: STR_WEAPONS_AND_EQUIPMENT
+    image_id: 1MF.SPK
+    text: STR_INQ_FLAMER_UFOPEDIA
+    listOrder: 11081
+
   - id: STR_HAND_MULTILASER_PAI
     requires:
       - STR_HAND_MULTILASER_RESEARCH_INQUISITION

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -730,10 +730,11 @@ items:
     meleeHitSound: {mod: 40k, index: 101}
     meleeAnimation: 0
     meleeType: 7
-    meleePower: 55 #+5 Inquisition blessings
+    meleePower: 50
     meleeBonus:
       strength: 0.2
       melee: 0.2
+      devotion: 0.2 #consecrated weapon
     meleeAlter:
       ArmorEffectiveness: 0.9
       RandomType: 7  # 50-200 # was 0 (50-150)
@@ -752,6 +753,59 @@ items:
     tags:
       ITEM_SNAP_POWER_BONUS: 10 #INQ BONUS
       ITEM_AIMED_POWER_BONUS: 20 #INQ BONUS
+
+  - type: STR_INQ_FLAMER #Special Inquisition Stormtrooper only flamer
+    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL]
+    weight: 10
+    vaporColorSurface: {mod: 40k, index: 0}
+    vaporDensitySurface: 4
+    vaporProbabilitySurface: 100
+    bigSprite: {mod: 40k, index: 215}
+    bulletSprite: {mod: 40k, index: 5}
+    fireSound: {mod: 40k, index: 706}
+    accuracySnap: 70
+    accuracyAuto: 40
+    tuSnap: 20
+    tuAuto: 30
+    battleType: 1
+    twoHanded: false
+    arcingShot: true
+    autoRange: 10 #longer than normal range
+    snapRange: 12 #longer than normal range
+    dropoff: 5
+    maxRange: 15
+    invWidth: 2
+    invHeight: 3
+    autoShots: 6
+    confSnap: #Double Shot
+      shots: 2
+    hitSound: {mod: 40k, index: 12}
+    hitAnimation: {mod: 40k, index: 88} #XFIRE
+    power: 60
+    damageType: 2
+    damageAlter:
+      IgnoreDirection: false
+      FireBlastCalc: false
+      FixRadius: 2
+      RandomType: 2 #50-150% Flamer now respects armor values
+      ToHealth: 2.0 #Optimized promethium mix
+      ToTile: 0.3
+      ToItem: 0.3
+      ToMorale: 1.0 #especially painful
+      ArmorEffectiveness: 0.7 #Optimized promethium mix
+      ToArmorPre: 0.1 #Optimized promethium mix
+      ToTime: 0.3 #too busy being on fire to act; allows fire to suppress and snapshots to have stopping power
+    damageBonus:
+      psiSkill: 0.2 #consecrated weapon
+    clipSize: -1
+    bulletSpeed: 50
+    explosionSpeed: 10
+    recover: false
+    fixedWeapon: true
+    fixedWeaponShow: true
+    twoHanded: true
+    blockBothHands: true
+    listOrder: 10763
 
 #PLAYABLE CHAOS CORPSES AND STORE ITEMS
   - type: STR_ALPHA_LEGION_CORPSE_PLAYER

--- a/Ruleset/SM/scripts_SM.rul
+++ b/Ruleset/SM/scripts_SM.rul
@@ -144,3 +144,14 @@ items:
     fixedWeapon: true
     specialIconSprite: 6
     specialUseEmptyHand: false
+
+  - type: INV_NULL_STORM_TROOPER_BACKPACK_FLAMER #flamer backpack
+    weight: 0
+    invWidth: 3
+    invHeight: 3
+    bigSprite: 296 #null_grenadier_backpack; placeholder
+    defaultInventorySlot: STR_BACK_PACK
+    fixedWeapon: true
+    recover: false
+    tags:
+      ITEM_CHANGES_SPRITE_WITH_ARMOR: 1

--- a/Ruleset/Voices_40k.rul
+++ b/Ruleset/Voices_40k.rul
@@ -123,7 +123,7 @@ armors:
     annoyedFemale:      [1616, 1617, 1618, 1619, 1620]
     deathMale:          [{mod: 40k, index: 456}, {mod: 40k, index: 457}, {mod: 40k, index: 458}, {mod: 40k, index: 459}, {mod: 40k, index: 450}]
     deathFemale:        [{mod: 40k, index: 456}, {mod: 40k, index: 457}, {mod: 40k, index: 458}, {mod: 40k, index: 459}, {mod: 40k, index: 460}]
-    
+
 #ChaosSisters
   - type: STR_SLAAN_ADEPTAS_CORRUPTED_ARMOR
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
@@ -158,7 +158,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_KHORNE_REVENGEANCE_SUIT 
+  - type: STR_KHORNE_REVENGEANCE_SUIT
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -180,7 +180,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_KHORNE_REPENTIA_LIGHT 
+  - type: STR_KHORNE_REPENTIA_LIGHT
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -191,7 +191,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_SLAANCHOSEN_ASS 
+  - type: STR_SLAANCHOSEN_ASS
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -224,7 +224,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_ADEPTAS_TZEENTCHNASSASSINARMOR 
+  - type: STR_ADEPTAS_TZEENTCHNASSASSINARMOR
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -246,7 +246,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_NURGLECHEM_SUIT 
+  - type: STR_NURGLECHEM_SUIT
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -279,7 +279,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_SLAANESH_CANTUSArmor 
+  - type: STR_SLAANESH_CANTUSArmor
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -323,7 +323,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_ADEPTAS_KHORNEPARMOR_BLESSED  
+  - type: STR_ADEPTAS_KHORNEPARMOR_BLESSED
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -334,7 +334,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [2009, 2010, 2011, 2012, 2013]
     deathFemale:        [2009, 2010, 2011, 2012, 2013]
-  - type: STR_KHORNE_RETRIBUTOR_ARMOR_BLESSED 
+  - type: STR_KHORNE_RETRIBUTOR_ARMOR_BLESSED
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -345,7 +345,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [2009, 2010, 2011, 2012, 2013]
     deathFemale:        [2009, 2010, 2011, 2012, 2013]
-  - type: STR_KHORNE_RETRIBUTOR_ARMOR_SUPERIOR_BLESSED 
+  - type: STR_KHORNE_RETRIBUTOR_ARMOR_SUPERIOR_BLESSED
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -400,7 +400,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_ADEPTAS_SLAANDOM 
+  - type: STR_ADEPTAS_SLAANDOM
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -411,7 +411,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_ADEPTAS_ARMORPURPLE 
+  - type: STR_ADEPTAS_ARMORPURPLE
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -433,7 +433,7 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690]
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
-  - type: STR_SLAANESH_DEMONPRINCESSARMOR 
+  - type: STR_SLAANESH_DEMONPRINCESSARMOR
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -506,7 +506,7 @@ armors:
     annoyedFemale:      [{mod: 40k, index: 336}, {mod: 40k, index: 337}, {mod: 40k, index: 338}, {mod: 40k, index: 338}, {mod: 40k, index: 338}]
     deathMale:     [{mod: 40k, index: 385}, {mod: 40k, index: 386}, {mod: 40k, index: 387}, {mod: 40k, index: 388}]
     deathFemale:   [{mod: 40k, index: 394}, {mod: 40k, index: 395}, {mod: 40k, index: 396}, {mod: 40k, index: 397}, {mod: 40k, index: 398}]
-  - type: STR_FRATERIS_MILITIA_HEAVY_VETERAN_ARMOR 
+  - type: STR_FRATERIS_MILITIA_HEAVY_VETERAN_ARMOR
     selectUnitMale:     [{mod: 40k, index: 953}, {mod: 40k, index: 954}, {mod: 40k, index: 955}]
     selectUnitFemale:   [{mod: 40k, index: 331}, {mod: 40k, index: 332}, {mod: 40k, index: 334}, {mod: 40k, index: 335}]
     startMovingMale:    [{mod: 40k, index: 946}, {mod: 40k, index: 947}, {mod: 40k, index: 948}, {mod: 40k, index: 949}, {mod: 40k, index: 950}]
@@ -544,6 +544,8 @@ armors:
     ref: *STR_INQ_STORMTROOPER_CARAPACE_VOICE
   - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_MULTILAS
     ref: *STR_INQ_STORMTROOPER_CARAPACE_VOICE
+  - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_FLAMER
+    ref: *STR_INQ_STORMTROOPER_CARAPACE_VOICE
   - type: STR_ADEPTAS_ARMORI_UC    #ADEPTAS INQUISITOR
     selectUnitMale:     [{mod: 40k, index: 71}, {mod: 40k, index: 72}, {mod: 40k, index: 73}, {mod: 40k, index: 74}, {mod: 40k, index: 75}]
     selectUnitFemale:   [{mod: 40k, index: 151}, {mod: 40k, index: 152}, {mod: 40k, index: 153}, {mod: 40k, index: 154}, {mod: 40k, index: 155}]
@@ -557,7 +559,7 @@ armors:
     deathFemale:   [{mod: 40k, index: 111}, {mod: 40k, index: 112}, {mod: 40k, index: 113}, {mod: 40k, index: 114}, {mod: 40k, index: 115}]
 
 #PLAYER ELDAR
-  - type: STR_ELDAR_FARSEER_ARMOR     
+  - type: STR_ELDAR_FARSEER_ARMOR
     selectUnitMale:     [2851, 2852, 2853, 2854, 2855, 2856, 2857, 2858]
     selectUnitFemale:   [2851, 2852, 2853, 2854, 2855, 2856, 2857, 2858]
     startMovingMale:    [2821, 2822, 2823, 2824, 2825, 2826, 2827, 2828, 2829]
@@ -572,7 +574,7 @@ armors:
     berserkFemale: [2831, 2832, 2833]
     deathMale: [{mod: 40k, index: 836}, {mod: 40k, index: 837}, {mod: 40k, index: 838}]
     deathFemale: [{mod: 40k, index: 836}, {mod: 40k, index: 837}, {mod: 40k, index: 838}]
-      
+
 #CHAOS PLAYER ARMOR VOICES
   - type: STR_CHAOS_ADEPTAS_UNDIVIDED_ARMOR
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
@@ -598,7 +600,7 @@ armors:
     deathMale:          [1700, 1701]
     deathFemale:        [1700, 1701]
 
-  - type: STR_CHAOS_ADEPTAS_KHORNE_ARMOR 
+  - type: STR_CHAOS_ADEPTAS_KHORNE_ARMOR
     selectUnitMale:     [1650, 1651, 1652, 1653, 1654]
     selectUnitFemale:   [1650, 1651, 1652, 1653, 1654]
     startMovingMale:    [1665, 1666, 1667, 1668, 1669]
@@ -645,8 +647,8 @@ armors:
     annoyedFemale:      [1686, 1687, 1688, 1689, 1690, 2213]
     deathMale:          [1700, 1701, 2217]
     deathFemale:        [1700, 1701, 2217]
-    
-  - type: STR_CHAOS_ADEPTAS_IRON_MAIDEN_ARMOR 
+
+  - type: STR_CHAOS_ADEPTAS_IRON_MAIDEN_ARMOR
     selectUnitMale:     [2247, 2246, 2245]
     selectUnitFemale:   [2247, 2246, 2245]
     startMovingMale:    [2255, 2256, 2262, 2252]
@@ -657,7 +659,7 @@ armors:
     annoyedFemale:      [2253, 2252, 2245]
     deathMale:          [2258, 2259, 2260]
     deathFemale:        [2258, 2259, 2260]
-    
+
 #CSM
   - type: STR_ALPHA_ARMOR_PLAYER #REGULAR
     selectUnitMale:     [{mod: 40k, index: 971}, {mod: 40k, index: 972}, {mod: 40k, index: 973}, {mod: 40k, index: 974}, {mod: 40k, index: 975}]
@@ -682,8 +684,8 @@ armors:
     annoyedFemale:      [{mod: 40k, index: 996}, {mod: 40k, index: 997}, {mod: 40k, index: 998}, {mod: 40k, index: 999}, {mod: 40k, index: 1000}]
     deathMale:     [{mod: 40k, index: 676}, {mod: 40k, index: 677}, {mod: 40k, index: 678}, {mod: 40k, index: 679}, {mod: 40k, index: 680}]
     deathFemale:   [{mod: 40k, index: 681}, {mod: 40k, index: 682}, {mod: 40k, index: 683}, {mod: 40k, index: 684}, {mod: 40k, index: 685}]
-    
-  - type: STR_IRON_WARRIOR_ARMOR_PLAYER 
+
+  - type: STR_IRON_WARRIOR_ARMOR_PLAYER
     selectUnitMale:     [{mod: 40k, index: 971}, {mod: 40k, index: 972}, {mod: 40k, index: 973}, {mod: 40k, index: 974}, {mod: 40k, index: 975}]
     selectUnitFemale:   [{mod: 40k, index: 991}, {mod: 40k, index: 992}, {mod: 40k, index: 993}, {mod: 40k, index: 994}, {mod: 40k, index: 995}]
     startMovingMale:    [{mod: 40k, index: 966}, {mod: 40k, index: 967}, {mod: 40k, index: 968}, {mod: 40k, index: 969}, {mod: 40k, index: 970}]
@@ -694,8 +696,8 @@ armors:
     annoyedFemale:      [{mod: 40k, index: 996}, {mod: 40k, index: 997}, {mod: 40k, index: 998}, {mod: 40k, index: 999}, {mod: 40k, index: 1000}]
     deathMale:     [{mod: 40k, index: 676}, {mod: 40k, index: 677}, {mod: 40k, index: 678}, {mod: 40k, index: 679}, {mod: 40k, index: 680}]
     deathFemale:   [{mod: 40k, index: 681}, {mod: 40k, index: 682}, {mod: 40k, index: 683}, {mod: 40k, index: 684}, {mod: 40k, index: 685}]
-    
-  - type: STR_IRON_BERSERKER_ARMOR 
+
+  - type: STR_IRON_BERSERKER_ARMOR
     selectUnitMale:     [3300, 3301, 3302, 3303, 3304]
     selectUnitFemale:   [3340, 3341, 3342, 3343, 3344]
     startMovingMale:    [3310, 3311, 3312, 3313, 3314, 3315]
@@ -706,7 +708,7 @@ armors:
     annoyedFemale:      [3345, 3346, 3347, 3348, 3349]
     deathMale:     [{mod: 40k, index: 676}, {mod: 40k, index: 677}, {mod: 40k, index: 678}, {mod: 40k, index: 679}, {mod: 40k, index: 680}]
     deathFemale:   [{mod: 40k, index: 681}, {mod: 40k, index: 682}, {mod: 40k, index: 683}, {mod: 40k, index: 684}, {mod: 40k, index: 685}]
-    
+
   - type: STR_KHORNECHAMP_ARMOR_PLAYER #Berzerker armor. not champion
     selectUnitMale:     [3300, 3301, 3302, 3303, 3304]
     selectUnitFemale:   [3340, 3341, 3342, 3343, 3344]
@@ -719,7 +721,7 @@ armors:
     deathMale:     [{mod: 40k, index: 676}, {mod: 40k, index: 677}, {mod: 40k, index: 678}, {mod: 40k, index: 679}, {mod: 40k, index: 680}]
     deathFemale:   [{mod: 40k, index: 681}, {mod: 40k, index: 682}, {mod: 40k, index: 683}, {mod: 40k, index: 684}, {mod: 40k, index: 685}]
 
-  - type: MUTON_ARMORTZEENTCH_PLAYER    
+  - type: MUTON_ARMORTZEENTCH_PLAYER
     selectUnitMale:     [3700, 3701, 3702, 3703, 3704]
     selectUnitFemale:   [3740, 3741, 3742, 3743, 3744, 3745, 3746, 3747]
     startMovingMale:    [3710, 3711, 3712, 3713]
@@ -730,7 +732,7 @@ armors:
     annoyedFemale:      [3748, 3749, 3750, 3751, 3752]
     deathMale:     [3730, 3731, 3732]
     deathFemale:   [3730, 3731, 3732]
-    
+
   - type: MUTON_ARMORNURGLEA_PLAYER #NURGLE ANIMATED
     selectUnitMale:     [3600, 3601, 3602, 3603, 3604, 3605]
     selectUnitFemale:   [3640, 3641, 3642, 3643, 3644, 3645]
@@ -742,8 +744,8 @@ armors:
     annoyedFemale:      [3646, 3647, 3648, 3649]
     deathMale:     [3630, 3631, 3632, 3633]
     deathFemale:   [3670, 3671, 3672]
-    
-  - type: MUTON_ARMORSLAANESH_PLAYER 
+
+  - type: MUTON_ARMORSLAANESH_PLAYER
     selectUnitMale:     [3400, 3401, 3402, 3403, 3404, 3405]
     selectUnitFemale:   [3500, 3501, 3502, 3503, 3504, 3505, 3506, 3507]
     startMovingMale:    [3410, 3411, 3412, 3413, 3414, 3415, 3416, 3417]
@@ -754,4 +756,4 @@ armors:
     annoyedFemale:      [3508, 3509, 3510, 3511]
     deathMale:     [{mod: 40k, index: 676}, {mod: 40k, index: 677}, {mod: 40k, index: 678}, {mod: 40k, index: 679}, {mod: 40k, index: 680}]
     deathFemale:   [3535, 2021, 2022, 2017, 2016, 2015, 2014]
-   
+


### PR DESCRIPTION
-Whitespace removal.

-Added Inquisition Flamer Stormtrooper subtype; grants access to a mastercrafted flamer with some bonus range and accuracy and double tap Snap Shots. Deals TU and extra Morale damage.

-Fixed Inquisition Stormtroopers having a max psy strength of 0.

-Inquisition Stormtroopers now start with a fairly high Devotion because they are elite servants of the Inquisition who are rigorously screened and tested for loyalty.

-Inquisition Stormtroopers PsiDefense enhanced: they now gain a bonus to it equal to 100 + their Devotion and their current Morale, reflecting the impact of their training, discipline and Hexagrammic wards.

-Fixed minor UFOpaedia redundancy/bugs.