### PR TITLE
Minor Refactor/Functionality Improvement for Bomberman Scripts

### DIFF
--- a/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
+++ b/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
@@ -273,7 +273,7 @@ armors:
       - STR_NURGLING_CLAWS
     tags:
       INFECTION_RESIST: 100 #infection immune
-      ARMOR_IS_KAMIKAZI: 1 #used for bomberman scripts
+      ARMOR_IS_EXPLODE_ON_DEATH: 1 #used for bomberman scripts
 
 
   - type: STR_NURGLE_DAEMONETTE_ARMOR   #DAEMONETTE NURGLE ARMOR

--- a/Ruleset/ENEMY/NURGLE/units_nurgle.rul
+++ b/Ruleset/ENEMY/NURGLE/units_nurgle.rul
@@ -384,24 +384,24 @@ units:
     race: STR_CELATID
     rank: STR_LIVE_TERRORIST
     stats:
-      tu: 60 #No idea why they have high TUs; these are plodding
-      stamina: 200 #slow but tireless
-      health: 200
-      bravery: 110 #Increased from 90; Plaguebearers don't
-      reactions: 40
-      firing: 80 #Decreased from 100; why are these snipers?
-      throwing: 0
-      strength: 100 #Increased from 70; these are superhumanly strong
-      psiStrength: 80
+      tu: 60 #No idea why they had high TUs; these are plodding
+      stamina: 207 #slow but tireless
+      health: 207
+      bravery: 110 #Increased from 90; Plaguebearers don't panic
+      reactions: 47
+      firing: 77 #Decreased from 100; why are these snipers?
+      throwing: 77 #can't throw nurglings without this
+      strength: 107 #Increased from 70; these are superhumanly strong
+      psiStrength: 77
       psiSkill: 0
-      melee: 80
+      melee: 77
     armor: STR_CELATID_ARMOR
     intelligence: 3
-    aggression: 2
+    aggression: 8 #aggressive but not quite leeroy
     canPanic: false
     value: 15
     canBeMindControlled: false
-    energyRecovery: 90 #slow but tireless
+    energyRecovery: 77 #slow but tireless
     livingWeapon: true
     builtInWeaponSets:
       - - STR_NURGLE_WEAPON
@@ -410,6 +410,7 @@ units:
         - STR_NURGLINGSPAWNER_GRENADE
       - - STR_NURGLE_WEAPON
         - STR_NURGLINGSPAWNER_GRENADE
+        - STR_NURGLE_BOOM #can explode; will not actively use this like boomers though, only detonates on death
 
   - type: STR_NURGLE_CULTIST_LIGHT   #NURGLE CULT
     race: STR_NURGLE_CULT

--- a/Ruleset/ENEMY/armors_daemon.rul
+++ b/Ruleset/ENEMY/armors_daemon.rul
@@ -3,6 +3,7 @@ extended:
     RuleArmor:
       INFECTION_RESIST: int #reduces infection damage by this as a %
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
 
 armors:
   - type: CYBERDISC_ARMOR #Flying Deamon
@@ -77,6 +78,7 @@ armors:
     zombiImmune: true #It's a daemon; can't zombify this.
     tags:
       INFECTION_RESIST: 100 #infection immune
+      ARMOR_IS_EXPLODE_ON_DEATH: 1 #can have a boomer bomb that detonates on death
     painImmune: true #Most daemons don't care about pain; especially not Plaguebearers
     recovery: #Plaguebearers regenerate health
       health:

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -5,7 +5,8 @@ extended:
 #bomb/kamikazi scripts
       ITEM_IS_FOR_BOMBER: int
       ITEM_IS_BOMB: int
-      ITEM_IS_KAMIKAZI: int #does this blow up on death?
+      ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death?
+      ITEM_IS_RANDOM_FUSE: int #sets the fuse to a random value between 0 and ITEM_RANDOM_FUSE values.
 #infection system tags
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -7,8 +7,9 @@ extended:
       ITEM_MELEE_POWER_BONUS: int
 #bomb/kamikazi scripts
       ITEM_IS_FOR_BOMBER: int
-      ITEM_IS_BOMB: int
-      ITEM_IS_KAMIKAZI: int #does this blow up on death?
+      ITEM_IS_BOMB: int #does this blow up with manual activation? The bomb fuse timer is equal to this value - 1.
+      ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death? The bomb fuse timer is equal to this value - 1.
+      ITEM_IS_RANDOM_FUSE: int #sets the fuse to a random value between 0 and ITEM_RANDOM_FUSE values.
 #vampiric on kill; weapons
       TAG_HP_RETURNED_ON_KILL: int
       TAG_ENERGY_RETURNED_ON_KILL: int
@@ -35,7 +36,7 @@ extended:
       YTAG_DAMAGE_RETURNED_AS_STUN_BUFF: int
       YTAG_DAMAGE_RETURNED_RESIST_TYPE_ARMOR: int
 #bomb/kamikazi scripts
-      ARMOR_IS_KAMIKAZI: int #do we check this unit for kamikazi bombs?
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
 
 items:
   - type: AUX_DAEMON_FIREBALL #frag                #4006
@@ -2479,7 +2480,7 @@ items:
     spawnUnitFaction: -1
     tags:
       ITEM_IS_BOMB: 1
-      ITEM_IS_KAMIKAZI: 1 #we blow this bomb up on death
+      ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
       INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
     specialChance: 50 #high chance of zombifying

--- a/Ruleset/scripts/scripts_bomberman.rul
+++ b/Ruleset/scripts/scripts_bomberman.rul
@@ -2,10 +2,11 @@ extended:
   tags:
     RuleItem:
       ITEM_IS_FOR_BOMBER: int
-      ITEM_IS_BOMB: int
-      ITEM_IS_KAMIKAZI: int #does this blow up on death?
+      ITEM_IS_BOMB: int #does this blow up with manual activation? The bomb fuse timer is equal to this value - 1.
+      ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death? The bomb fuse timer is equal to this value - 1.
+      ITEM_IS_RANDOM_FUSE: int #sets the fuse to a random value between 0 and ITEM_RANDOM_FUSE values.
     RuleArmor:
-      ARMOR_IS_KAMIKAZI: int #do we check this unit for kamikazi bombs?
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
 
   scripts:
     hitUnit:
@@ -16,23 +17,36 @@ extended:
           var int temp;
           var ptre BattleItem someItem;
           var int numInventoryItems;
+          var int randomFuse;
 
           damaging_item.getRuleItem ruleItem;
           ruleItem.getTag temp Tag.ITEM_IS_FOR_BOMBER;
 
-          if eq temp 1;
-            attacker.getInventoryItem.size numInventoryItems;
-            #debug_log "numInventoryItems" numInventoryItems;
-            loop var i numInventoryItems;
-              attacker.getInventoryItem someItem i;
-              someItem.getTag temp Tag.ITEM_IS_BOMB;
-              # attacker.setTag Tag.UNIT_TURNED_TRAITOR 1; # doesn't recolor fast enough
-              if eq temp 1;
-                attacker.setTimeUnits 0;
-                someItem.setFuseTimer 0;
-                someItem.setFuseEnabled 1;
-                return 0 part side;
+          if le temp 0; #if we don't have the tag, abort
+            #debug_log "Bomberman Scripts; hitUnit, offset 43: Aborted. No ITEM_IS_FOR_BOMBER Tag Detected";
+            return power part side;
+          end;
+
+          attacker.getInventoryItem.size numInventoryItems;
+          #debug_log "numInventoryItems" numInventoryItems;
+          loop var i numInventoryItems;
+            attacker.getInventoryItem someItem i;
+            someItem.getTag temp Tag.ITEM_IS_BOMB; #get the bomb timer
+            # attacker.setTag Tag.UNIT_TURNED_TRAITOR 1; # doesn't recolor fast enough
+            if ge temp 1;
+              someItem.getTag randomFuse Tag.ITEM_IS_RANDOM_FUSE; #check if the fuse is random
+              if ge randomFuse 1;
+                battle_game.randomRange temp 0 randomFuse;
+                #debug_log "Bomberman Scripts; hitUnit, offset 43: Random fuse. Random fuse upper limit:" randomFuse;
+              else;
+                sub temp 1;
               end;
+              attacker.setTimeUnits 0;
+              someItem.setFuseTimer temp;
+              someItem.setFuseEnabled 1;
+              #debug_log "Bomberman Scripts; hitUnit, offset 43: Successful. Bomb Triggered. Bomb Item:" someItem;
+              #debug_log "Bomberman Scripts; hitUnit, offset 43: Successful. Bomb Fuse. Fuse Timer:" temp;
+              return 0 part side;
             end;
           end;
 
@@ -49,12 +63,13 @@ extended:
           var int numInventoryItems;
           var int remainingHealth;
           var ptr RuleArmor armorRule;
+          var int randomFuse;
 
           #if our armor doesn't have the kamikazi tag, cancel out
           unit.getRuleArmor armorRule;
-          armorRule.getTag temp Tag.ARMOR_IS_KAMIKAZI;
-          if neq temp 1;
-            #debug_log "Bomberman Scripts; damageUnit, offset 24: Aborted. No Kamikazi Armor Tag Detected";
+          armorRule.getTag temp Tag.ARMOR_IS_EXPLODE_ON_DEATH; #we check the armor for this tag to avoid having to cycle through items every time we damage something
+          if le temp 0;
+            #debug_log "Bomberman Scripts; damageUnit, offset 24: Aborted. No ARMOR_IS_EXPLODE_ON_DEATH Tag Detected";
             return;
           end;
 
@@ -71,13 +86,21 @@ extended:
           #debug_log "numInventoryItems" numInventoryItems;
           loop var i numInventoryItems;
             unit.getInventoryItem someItem i;
-            someItem.getTag temp Tag.ITEM_IS_KAMIKAZI;
+            someItem.getTag temp Tag.ITEM_IS_BOMB_ON_DEATH; #get the bomb timer
             # unit.setTag Tag.UNIT_TURNED_TRAITOR 1; # doesn't recolor fast enough
-            if eq temp 1;
+            if ge temp 1;
+              someItem.getTag randomFuse Tag.ITEM_IS_RANDOM_FUSE; #check if the fuse is random
+              if ge randomFuse 1;
+                battle_game.randomRange temp 0 randomFuse;
+                #debug_log "Bomberman Scripts; damageUnit, offset 24: Random fuse. Random fuse upper limit:" randomFuse;
+              else;
+                sub temp 1;
+              end;
               unit.setTimeUnits 0;
-              someItem.setFuseTimer 0;
+              someItem.setFuseTimer temp;
               someItem.setFuseEnabled 1;
-              #debug_log "Bomberman Scripts; damageUnit, offset 24: Successful. Kamikazi Bomb Triggered. Item:" someItem;
+              #debug_log "Bomberman Scripts; damageUnit, offset 24: Successful. Bomb Triggered. Bomb Item:" someItem;
+              #debug_log "Bomberman Scripts; damageUnit, offset 24: Successful. Bomb Fuse. Fuse Timer:" temp;
               return;
             end;
           end;

--- a/Ruleset/scripts/scripts_infection_mechanics.rul
+++ b/Ruleset/scripts/scripts_infection_mechanics.rul
@@ -401,7 +401,7 @@ extended:
             if eq infectionType 2;
               set_color new_pixel COLOR_X1_PURPLE0; #GSC infection
             end;
-            if eq infectionType 2;
+            if eq infectionType 3;
               set_color new_pixel COLOR_X1_PURPLE1; #Slaanesh infection
             end;
           end;
@@ -429,7 +429,7 @@ extended:
                 if eq infectionType 2;
                   set_color new_pixel COLOR_X1_PURPLE0; #GSC infection
                 end;
-                if eq infectionType 2;
+                if eq infectionType 3;
                   set_color new_pixel COLOR_X1_PURPLE1; #Slaanesh infection
                 end;
               end;

--- a/Ruleset/scripts/scripts_infection_mechanics.rul
+++ b/Ruleset/scripts/scripts_infection_mechanics.rul
@@ -494,7 +494,8 @@ extended:
           else;
             battle_game.flashMessage "STR_SCRIPT_INFECTION_HEAL_INCOMPLETE" infectionDamage;
           end;
-
+          set wound_recovery 0; #the charge is expended healing the infection, not wounds
+          set health_recovery 0; #the charge is expended healing the infection, not wounds
           target.setTag Tag.CURRENT_INFECTION_DAMAGE infectionDamage;
 
           return;


### PR DESCRIPTION
Per title.

1. You can now choose to give Bomberman script grenades a set or random duration.

2. Plaguebearers can now spawn with a Boomer bomb with certain loadouts; they've also been given stat tweaks so they can actually throw their Nurgling grenades and more of Nurgle's sacred number.