### PR TITLE
Expanded Reinforcement TU Reduction Scripts

### DIFF
--- a/Ruleset/ENEMY/SLAANESH/weapons_slaanesh.rul
+++ b/Ruleset/ENEMY/SLAANESH/weapons_slaanesh.rul
@@ -1229,11 +1229,14 @@ items:
     damageType: 3
     damageAlter: #DA Slaanesh Gas
       ToHealth: 0.1
-      ToEnergy: 1.0
-      ToStun: 0.7
-      ToMorale: 2.0
+      ToEnergy: 0.5
+      ToStun: 0.3
+      ToMorale: 1.0
       ArmorEffectiveness: 0.3
       RandomType: 2 #TFTD [50% - 150%]
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50
+      INFECTION_TYPE: 3 #slaanesh corruption
     clipSize: 6
     battleType: 2
     invWidth: 2

--- a/Ruleset/ENEMY/armors_daemon.rul
+++ b/Ruleset/ENEMY/armors_daemon.rul
@@ -1,9 +1,13 @@
 extended:
   tags:
     RuleArmor:
+      #infection scripts
       INFECTION_RESIST: int #reduces infection damage by this as a %
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+      #bomberman scripts
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      #reinforcement TU scripts
+      ARMOR_REINFORCEMENT_TU_PERCENT: int #this is the % of TUs the unit spawns with; if unspecified, defaults to 25% of max.
 
 armors:
   - type: CYBERDISC_ARMOR #Flying Deamon
@@ -114,6 +118,7 @@ armors:
     zombiImmune: true #It's a daemon; can't zombify this. Daemonettes can feel and like pain so no pain immunity
     tags:
       INFECTION_RESIST: 100 #infection immune
+      ARMOR_REINFORCEMENT_TU_PERCENT: 10 #only spawns with 10% of max TU.
     damageModifier: #NAKED
       - 1.0 #none
       - 0.8 #AP

--- a/Ruleset/scripts/scripts_reinforcements_less_tus.rul
+++ b/Ruleset/scripts/scripts_reinforcements_less_tus.rul
@@ -1,19 +1,37 @@
 extended:
+  tags:
+    RuleArmor:
+      ARMOR_REINFORCEMENT_TU_PERCENT: int #this is the % of TUs the unit spawns with; if unspecified, defaults to 25% of max.
+
   scripts:
     createUnit:
       - new: ROSIGMA_cU_reinforcements_less_tus
         offset: 2
         code: |
+          var ptr RuleArmor armorRule;
           var int temp;
+          var int reinforcementTU;
 
           # might mess with spawner grenades but seems to be handled differently anyhow
-          # test done with the Daemonette Missle Pack created 0 TU units instead of 25 %
-          if gt turn 0; # is reinforcement of any side 
-            unit.getTimeUnitsMax temp;
-            muldiv temp 25 100;
-            unit.setTimeUnits temp;
-            # debug_log "unit: " unit;
-            # debug_log "set time units to " temp;
+          if le turn 0; #we don't care about Turn 0; abort.
+            # debug_log "createUnit | ROSIGMA_cU_reinforcements_less_tus | offset: 2 | Turn 0. Aborting.";
+            return;
           end;
+
+          unit.getRuleArmor armorRule;
+          armorRule.getTag reinforcementTU Tag.ARMOR_REINFORCEMENT_TU_PERCENT;
+
+          if le reinforcementTU 0; #default to 25% of max TUs if this tag is unspecified
+            set reinforcementTU 25;
+            # debug_log "createUnit | ROSIGMA_cU_reinforcements_less_tus | offset: 2 | No reinforcement TU tag detected. Defaulting to: " reinforcementTU;
+          else;
+            limit_upper reinforcementTU 100; #cannot exceed 100% of max TUs
+          end;
+
+          unit.getTimeUnitsMax temp;
+          muldiv temp reinforcementTU 100;
+          unit.setTimeUnits temp;
+            # debug_log "createUnit | ROSIGMA_cU_reinforcements_less_tus | offset: 2 | Unit: " unit;
+            # debug_log "createUnit | ROSIGMA_cU_reinforcements_less_tus | offset: 2 | Set time units to " temp;
 
           return;


### PR DESCRIPTION
-Added ARMOR_REINFORCEMENT_TU_PERCENT tag, allowing for the specification of the percentage of max TU reinforcements/spawned units are created with. Defaults to 25% of max TU if unspecified.

-Daemonettes now spawn with 10% of their max TUs instead of 25%.

-Added corruption/infection parameters to Slaanesh Missiles; reduced some of its debuff values to offset the infection damage.