### PR TITLE
Tzeentch Overall + Tzeentch Corruption/Infection Functionality

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -3365,6 +3365,10 @@ en-US:
   STR_BLUEHORROR_ARMOR_UFOPEDIA: "{NEWLINE}{NEWLINE} CODEX ARMOR DETAIL"
   STR_BLUEHORROR_AUTOPSY: "Blue Horror Origins"
   STR_BLUEHORROR_AUTOPSY_UFOPEDIA: "{NEWLINE}Blue Horrors are lesser daemons of Tzeentch, twisted twins spawned from the corpse of their larger Pink Horror cousins. Displaying a cruel disposition, they will use both magic and engage in melee."
+  STR_TZEENTCH_GLIMMERING_WEAPON_SCATTER: "Warpfire Blast"
+  STR_TZEENTCH_GLIMMERING_WEAPON_RAPIDFIRE: "Warpfire Cascade"
+  STR_TZEENTCH_FLAMER_WEAPON_BLUE: "Blue Warpfire"
+  STR_TZEENTCH_FLAMER_WEAPON_PINK: "Pink Warpfire"
 
   STR_TZAANGOR: "Tzaangor"
   STR_TZAANGOR_ARMOR: "Tzaangor"
@@ -3455,9 +3459,9 @@ en-US:
   STR_TZEENTCH_LESSER_DAEMON_ARMOR: "Gleaming One"
   STR_TZEENTCH_LESSER_DAEMON_CORPSE: "Gleaming One Corpse"
   STR_TZEENTCH_LESSER_DAEMON_UFOPEDIA: "{NEWLINE}{NEWLINE} CODEX ARMOR DETAIL"
-  STR_TZEENTCH_LESSER_DAEMON_ARMOR_UFOPEDIA: "{NEWLINE}Tzeentch Lesser Daemons have a hard shell armor formed out of warp matter, and crushing claws and talons that can rip through even power armor."
+  STR_TZEENTCH_LESSER_DAEMON_ARMOR_UFOPEDIA: "{NEWLINE}Tzeentch Gleaming Ones have a strange, scintillating shell-like armor formed from warp energy and ephermal claws and talons that can phase through most forms of unwarded matter, twisting their victim with debased warp energy. From varied appendages they can discharge gouts of glimmering warpfire that mutate and corrupt as surely as they burn, melting through armor with ease. They have proven resistant to heat and energy based weapons."
   STR_TZEENTCH_LESSER_DAEMON_AUTOPSY: "Tzeentch Lesser Daemons"
-  STR_TZEENTCH_LESSER_DAEMON_AUTOPSY_UFOPEDIA: "{NEWLINE}Tzeentch Lesser Daemons come in countless forms and shapes, dubbed the Gleaming Ones for the unnerving light they give off when materializing, rather than their often crustacean appearance, for they have no true form at all but what their prey fears deep down. They are often summoned together with other types of lesser Daemons such as Horrors and Screamers by Tzeentch summoners and witches."
+  STR_TZEENTCH_LESSER_DAEMON_AUTOPSY_UFOPEDIA: "{NEWLINE}Tzeentch Gleaming Ones come in countless forms and shapes, dubbed the Gleaming Ones for the unnerving light they give off when materializing, rather than their often crustacean appearance, for they have no true form at all but what their prey fears deep down. They are often summoned together with other types of lesser Daemons such as Horrors and Screamers by Tzeentch summoners and witches."
 
 
   STR_TZEENTCH_SCREAMER: "Screamer" #use something like the holodrone or biodrone for animation of this manta thing
@@ -3737,6 +3741,7 @@ en-US:
 
   STR_CAT_ADEPTAS: "Sisters of Battle"
   STR_CAT_NURGLE: "Nurgle"
+  STR_CAT_TZEENTCH: "Tzeentch"
 
 #GSC
   STR_GSC_RETALIATION: "Spiral Revenge"

--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -149,7 +149,7 @@
       melee: 80
     armor: STR_FLAMER_ARMOR
     intelligence: 4
-    aggression: 3
+    aggression: 8 #aggressive lesser daemon
     canPanic: false
     value: 15
     canBeMindControlled: false
@@ -157,15 +157,13 @@
     energyRecovery: 40
     livingWeapon: true
     builtInWeaponSets:
-      - - FLAMER_WEAPON
-        - STR_SCORCHA_TANK_BUILTIN
-        - STR_BURNA_TANK_BUILTIN
-      - - FLAMER_WEAPON
-        - STR_SCORCHA_TANK_BUILTIN
-        - STR_BURNA_TANK_BUILTIN
-      - - FLAMER_WEAPON
-        - STR_SCORCHA_TANK_BUILTIN
-        - STR_BURNA_TANK_BUILTIN
+      - - STR_TZEENTCH_FLAMER_WEAPON_PINK
+        - STR_TZEENTCH_FLAMER_WEAPON_BLUE
+      - - STR_TZEENTCH_FLAMER_WEAPON_PINK
+        - STR_TZEENTCH_FLAMER_WEAPON_BLUE
+      - - STR_TZEENTCH_FLAMER_WEAPON_PINK
+        - STR_TZEENTCH_FLAMER_WEAPON_BLUE
+
   - type: STR_PINK_HORROR_TERRORIST
     race: STR_TZEENTCH
     rank: STR_LIVE_TERRORIST
@@ -173,7 +171,7 @@
       tu: 90
       stamina: 95
       health: 80
-      bravery: 100
+      bravery: 110
       reactions: 55
       firing: 65
       throwing: 85
@@ -198,11 +196,14 @@
     livingWeapon: true
     builtInWeaponSets:
       - - BLUE_HORROR_WEAPON #Indigo fire Horror Mutator
-        - STR_BLUEHORRORSPAWNER_GRENADE
+        - STR_PINK_HORROR_DEATH_GRENADE #spawns Blue Horror on death
       - - STR_RED_FIRE #Red fire AoE
         - BLUE_HORROR_WEAPON #Indigo fire Horror Mutator
+        - STR_PINK_HORROR_DEATH_GRENADE #spawns Blue Horror on death
       - - STR_BLUE_FIRE_WEAPON  #Blue Fire Magic Missiles
         - BLUE_HORROR_WEAPON #Indigo fire Horror Mutator
+        - STR_PINK_HORROR_DEATH_GRENADE #spawns Blue Horror on death
+
   - type: STR_BLUE_HORROR_TERRORIST
     race: STR_TZEENTCH
     rank: STR_LIVE_TERRORIST
@@ -210,7 +211,7 @@
       tu: 90
       stamina: 80
       health: 30
-      bravery: 90
+      bravery: 110
       reactions: 45
       firing: 60
       throwing: 75
@@ -488,20 +489,19 @@
     value: 5
     deathSound: [2236, 2237, 2238, 2239]
     intelligence: 2
-    aggression: 5
+    aggression: 8 #mindless and aggressive lesser daemon
     berserkChance: 66
     energyRecovery: 40
     sniper: 20
     moraleLossWhenKilled: 33
     livingWeapon: true
     builtInWeaponSets:
-      - - STR_FLAMETHROWERTZ
-        - STR_FLAMETHROWER_CLIP
-        - STR_FLAMETHROWER_CLIP
-      - - STR_BOLTPISTOL_TZEENTCH
-        - STR_TZ_LIGHT_BOLTER_AMMO_R
-      - - STR_PLASMA_PISTOL_TZEENTCH
-        - STR_PLASMA_PISTOL_CLIP
+      - - STR_TZEENTCH_GLIMMERING_WEAPON_SCATTER
+        - STR_TZEENTCH_GLIMMERING_WEAPON_RAPIDFIRE
+      - - STR_TZEENTCH_GLIMMERING_WEAPON_SCATTER
+        - STR_TZEENTCH_GLIMMERING_WEAPON_RAPIDFIRE
+      - - STR_TZEENTCH_GLIMMERING_WEAPON_SCATTER
+        - STR_TZEENTCH_GLIMMERING_WEAPON_RAPIDFIRE
 
   - type: STR_TZEENTCH_ACOLYTE   #TZEENTCH FEMALE CULTIST
     race: STR_TZEENTCH_CULT

--- a/Ruleset/ENEMY/GENE/weapons_gene.rul
+++ b/Ruleset/ENEMY/GENE/weapons_gene.rul
@@ -4,7 +4,7 @@ extended:
 #infection system tags
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
 items:
   - type: STR_LIBERATOR_AUTOSTUB_KELER #big iron on his hips
@@ -177,7 +177,7 @@ items:
     clipSize: -1
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 10
     zombieUnit: STR_GSC_ZOMBIE #generic placeholder
     zombieUnitByArmorMale: { STR_JARMOR_UCM: STR_MARINE_ZOMBIE_TACTICAL_M, STR_JARMORH_UC: STR_MARINE_ZOMBIE_TACTICAL_M,
@@ -521,7 +521,7 @@ items:
     invHeight: 3
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 25
     zombieUnit: STR_GSC_ZOMBIE #generic placeholder
     zombieUnitByArmorMale: { STR_JARMOR_UCM: STR_MARINE_ZOMBIE_TACTICAL_M, STR_JARMORH_UC: STR_MARINE_ZOMBIE_TACTICAL_M,
@@ -908,7 +908,7 @@ items:
       ToArmor: 0.3
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 50
     zombieUnit: STR_GSC_ZOMBIE #generic placeholder
     zombieUnitByArmorMale: { STR_JARMOR_UCM: STR_MARINE_ZOMBIE_TACTICAL_M, STR_JARMORH_UC: STR_MARINE_ZOMBIE_TACTICAL_M,

--- a/Ruleset/ENEMY/SLAANESH/weapons_slaanesh.rul
+++ b/Ruleset/ENEMY/SLAANESH/weapons_slaanesh.rul
@@ -4,7 +4,7 @@ extended:
 #infection system tags
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
 items:
 
@@ -139,7 +139,7 @@ items:
     hiddenOnMinimap: true
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_SLAANGOR_CLAW_GIMPIFY #For Ritualist, zombifies
     weight: 10
@@ -184,7 +184,7 @@ items:
     recover: false
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
 
   - type: STR_SLAANGOR_DOUBLECLAW #                        DA POWER
@@ -873,7 +873,7 @@ items:
     throwRange: 16
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_BOLTERSLAAN #BOLTER SLAANESH  10340
     categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]

--- a/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
@@ -6,6 +6,8 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+      ARMOR_IS_EXPLODE_ON_DEATH: int #used for bomberman scripts
+
 
 armors:
 
@@ -533,6 +535,7 @@ armors:
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 20
+    psiVision: 5 #daemonic psi sense
     spriteSheet: TZEENTCH_LESSER_DAEMON.PCK
     spriteInv: TZEENTCH_LESSER_DAEMON_INV.SPK
     corpseBattle:
@@ -545,18 +548,23 @@ armors:
     drawingRoutine: 0
     damageModifier: #TZ DAEMON ARMOR
       - 1.0 #none
-      - 1.2 #AP
-      - 1.0 #FLAMES
-      - 0.7 #HE
-      - 1.2 #LASCANON
-      - 1.2 #PLASMA
+      - 1.2 #AP; vulnerable to physical damage
+      - 0.5 #FLAMES; resistant to energy/heat
+      - 1.3 #HE; vulnerable to physical damage
+      - 0.6 #LASCANON; resistant to energy/heat
+      - 0.7 #PLASMA; resistant to energy/heat
       - 1.0 #STUN
-      - 1.4 #MELEE
+      - 1.4 #MELEE; vulnerable to physical damage
       - 1.0 #ACID
       - 0.0 #SMOKE
       - 1.0 #IMPACT
-      - 1.4 #MELTA
+      - 0.8 #MELTA; resistant to energy/heat
     loftempsSet: [ 3 ]
+    painImmune: true #daemon; pain immune
+    zombiImmune: true #daemon; zombie immune
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+
 
   - type: STR_TZCULTIST_FEM_ARMOR
     visibilityAtDay: 40
@@ -962,12 +970,10 @@ armors:
     loftempsSet: [ 3 ]
 
   - type: STR_PINKHORROR_ARMOR                               #SLAANESH REGULAR
-    tags:
-      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 40
-      ARMOR_ENERGY_SHIELD_DECAY: 50
     visibilityAtDay: 40
     visibilityAtDark: 30
     heatVision: 30
+    psiVision: 5 #daemonic psi sense
     spriteSheet: pinkhorror_bs.PCK
     spriteInv: PINKHORROR_INV.SPK
     allowInv: false
@@ -978,27 +984,35 @@ armors:
     rearArmor: 15
     underArmor: 15
     drawingRoutine: 4
-    damageModifier: #DAEMON ARMOR
+    specialWeapon: STR_TZEENTCH_FIEND_CLAWS
+    damageModifier: #DAEMON ARMOR; Blue Horror resists physical, Pink Horror resists energy
       - 1.0 #none
-      - 0.9 #AP
-      - 1.2 #FLAMES
-      - 0.9 #HE
-      - 1.0 #LASCANON
-      - 1.0 #PLASMA
+      - 1.2 #AP
+      - 0.5 #FLAMES
+      - 1.2 #HE
+      - 0.6 #LASCANON
+      - 0.7 #PLASMA
       - 0.8 #STUN
       - 1.3 #MELEE
       - 1.0 #ACID
       - 0.0 #SMOKE
       - 1.0 #IMPACT
-      - 1.2 #MELTA
+      - 0.8 #MELTA
     loftempsSet: [ 3 ]
-  - type: STR_BLUEHORROR_ARMOR                               #SLAANESH REGULAR
+    painImmune: true #daemon; pain immune
+    zombiImmune: true #daemon; zombie immune
     tags:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 40
       ARMOR_ENERGY_SHIELD_DECAY: 50
+      INFECTION_RESIST: 100 #infection immune
+      ARMOR_IS_EXPLODE_ON_DEATH: 1 #for triggering the Blue Horror on-death spawn grenades
+
+
+  - type: STR_BLUEHORROR_ARMOR                               #SLAANESH REGULAR
     visibilityAtDay: 40
     visibilityAtDark: 30
     heatVision: 30
+    psiVision: 5 #daemonic psi sense
     spriteSheet: bluehorror_bs.PCK
     spriteInv: BLUEHORROR_INV.SPK #create in extrasprites
     allowInv: false
@@ -1009,17 +1023,24 @@ armors:
     rearArmor: 15
     underArmor: 10
     drawingRoutine: 4
-    damageModifier: #DAEMON ARMOR
+    specialWeapon: STR_TZEENTCH_FIEND_CLAWS
+    damageModifier: #DAEMON ARMOR; Blue Horror resists physical, Pink Horror resists energy
       - 1.0 #none
-      - 0.9 #AP
-      - 1.2 #FLAMES
-      - 0.9 #HE
-      - 1.0 #LASCANON
-      - 1.0 #PLASMA
+      - 0.5 #AP
+      - 1.1 #FLAMES
+      - 0.6 #HE
+      - 1.2 #LASCANON
+      - 1.3 #PLASMA
       - 0.8 #STUN
-      - 1.3 #MELEE
+      - 0.7 #MELEE
       - 1.0 #ACID
       - 0.0 #SMOKE
       - 1.0 #IMPACT
-      - 1.2 #MELTA
+      - 1.4 #MELTA
     loftempsSet: [ 2 ] #Lore wise hard to hit due to magical shenanigans and writhing body
+    painImmune: true #daemon; pain immune
+    zombiImmune: true #daemon; zombie immune
+    tags:
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: 40
+      ARMOR_ENERGY_SHIELD_DECAY: 50
+      INFECTION_RESIST: 100 #infection immune

--- a/Ruleset/ENEMY/TZEENTCH/weapons_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/weapons_tzeentch.rul
@@ -5,6 +5,10 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+    #Infection system vars
+      INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
+      INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
 items:
   - type: STR_NIGHTLORD_HORROR
@@ -13,7 +17,7 @@ items:
     explosionHitSound: [{mod: 40k, index: 1110}, {mod: 40k, index: 1111}, {mod: 40k, index: 1112}, {mod: 40k, index: 1113}, {mod: 40k, index: 1114}, {mod: 40k, index: 1115}, {mod: 40k, index: 1116}, {mod: 40k, index: 1117}, {mod: 40k, index: 1118}, {mod: 40k, index: 1119}, {mod: 40k, index: 1120}, {mod: 40k, index: 1121}]
     # replace HitSound with something fitting like a scream? what does the lore say?
     hitAnimation: {mod: 40k, index: 96}
-    power: 50 
+    power: 50
     damageType: 3 # doesn't really matter but HE is a good preset
     damageAlter:
       RadiusReduction: 0.0
@@ -39,7 +43,7 @@ items:
 
 #Tzeentch Las weapons
   - type: STR_TZEENTCH_LASPISTOL #Nihilis Pattern High Tech laspistol
-    categories: [STR_CAT_LASGUN, STR_CAT_TACTICAL]
+    categories: [STR_CAT_LASGUN, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     size: 0.2
     dropoff: 5 #low drop off, precise
     requires:
@@ -79,10 +83,10 @@ items:
     invWidth: 1
     invHeight: 2
     bulletSpeed: 50
-    listOrder: 11056   
+    listOrder: 11056
 
   - type: STR_TZEENTCH_LASGUN #Nihilis Pattern High Tech lasgun
-    categories: [STR_CAT_LASGUN, STR_CAT_TACTICAL]
+    categories: [STR_CAT_LASGUN, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     size: 0.2
     dropoff: 4 #low drop off, precise
     requires:
@@ -122,7 +126,7 @@ items:
       - STR_LASGUN_CLIP_HOTSHOT_CHAOS
     tags:
       ITEM_SNAP_POWER_BONUS: 10
-      ITEM_AUTO_POWER_BONUS: 10    
+      ITEM_AUTO_POWER_BONUS: 10
       ITEM_AIMED_POWER_BONUS: 20
     battleType: 1
     twoHanded: false #compact carbine, enough to use single handed
@@ -132,7 +136,7 @@ items:
     listOrder: 11056
 
   - type: STR_LONGLAS_TZEENTCH
-    categories: [STR_CAT_LASGUN, STR_CAT_SNIPER]
+    categories: [STR_CAT_LASGUN, STR_CAT_SNIPER, STR_CAT_TZEENTCH]
     size: 0.2
     dropoff: 4
     requires:
@@ -155,7 +159,7 @@ items:
       - STR_LASGUN_CLIP
       - STR_LASGUN_CLIP_HOTSHOT_CHAOS
     tags:
-      ITEM_SNAP_POWER_BONUS: 10 
+      ITEM_SNAP_POWER_BONUS: 10
       ITEM_AIMED_POWER_BONUS: 20
     battleType: 1
     twoHanded: true
@@ -163,10 +167,10 @@ items:
     invHeight: 3
     bulletSpeed: 50
     listOrder: 11056
-    
+
 #Tzeentch Plasma
   - type: STR_PLASMA_PISTOL_TZEENTCH #                       11210
-    categories: [STR_CAT_PLASMA, STR_CAT_TACTICAL, STR_CAT_CHAOS]
+    categories: [STR_CAT_PLASMA, STR_CAT_TACTICAL, STR_CAT_CHAOS, STR_CAT_TZEENTCH]
     requires:
       - STR_ALIENS_ONLY
       - STR_PLASMA_PISTOL
@@ -197,7 +201,7 @@ items:
     listOrder: 11210
 
   - type: STR_TZ_PLASMA_GUN_TWINCORE #                 11600
-    categories: [STR_CAT_PLASMA, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_PLASMA, STR_CAT_DEVASTATOR, STR_CAT_TZEENTCH]
     size: 0.3
     dropoff: 5
     requires:
@@ -228,10 +232,10 @@ items:
     armor: 50
     attraction: 1
     listOrder: 11500
-    
-#Tzeentch Bolter weapons Inferno etc     
+
+#Tzeentch Bolter weapons Inferno etc
   - type: STR_BOLTPISTOL_TZEENTCH  #TZEENTCH BOLTER PISTOL SCOPED  10140
-    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     size: 0.2
     dropoff: 5
     requires:
@@ -243,7 +247,7 @@ items:
     floorSprite: 2943
     handSprite: 2930
     bulletSprite: 6
-    fireSound: {mod: 40k, index: 707} 
+    fireSound: {mod: 40k, index: 707}
     compatibleAmmo:
       - STR_PISTOL_CLIP
       - STR_TZ_LIGHT_BOLTER_AMMO_R
@@ -261,7 +265,7 @@ items:
 
 
   - type: STR_TZEENTCH_BOLTER_LIGHT_SOLO #Light Inferno Bolter
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TZEENTCH]
     requires:
       - STR_ALIENS_ONLY
       - STR_LIGHT_BOLTERS
@@ -273,7 +277,7 @@ items:
     floorSprite: 2944
     handSprite: 2940
     bulletSprite: {mod: 40k, index: 6} #change
-    fireSound: {mod: 40k, index: 707} 
+    fireSound: {mod: 40k, index: 707}
     compatibleAmmo: #No EX or Mastercraft rounds
       - STR_LIGHT_BOLTER_AMMO_SHORT #Short magazines, drawback
       - STR_TZ_LIGHT_BOLTER_AMMO_R
@@ -297,7 +301,7 @@ items:
       ITEM_COLOR_CHANGES_WITH_AMMO: 15
 
   - type: STR_TZEENTCH_BOLTER_LIGHT_SOLO_SCOPED
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TZEENTCH]
     requires:
       - STR_ALIENS_ONLY
     size: 0.3
@@ -313,7 +317,7 @@ items:
     fireSound: {mod: 40k, index: 707}
     compatibleAmmo:
       - STR_LIGHT_BOLTER_AMMO_SHORT
-      - STR_TZ_LIGHT_BOLTER_AMMO_R 
+      - STR_TZ_LIGHT_BOLTER_AMMO_R
     accuracySnap: 85 #5 points more accurate vs light ULTRA
     #accuracyAuto: 66 #No autoshot functionality
     accuracyAimed: 115 #battle rifle scoped
@@ -342,11 +346,14 @@ items:
     costSell: 250
     weight: 3
     damageAlter: #DA BOLTER TZZ
-      ToArmorPre: 0.05
-      ArmorEffectiveness: 0.7 #give Rubric rounds a armor pen bonus for magic bolts
-      ToArmor: 0.1
+      RandomType: 1 #swingy random damage
+      ToArmorPre: 0.5 #melts armor on the way in
+      FireThreshold: 35 #can ignite
+      ArmorEffectiveness: 0.9
+      ToArmor: 0.0 #does damage on the way in
       ToHealth: 0.8 #compensates a bit for the extra AP and power
-      ToStun: 0.5
+      ToWound: 0.05 #melta type injuries
+      RandomWound: false
       ToMorale: 0.5
     explosionSpeed: 5
     power: 70 #buff, chaos hellguns have 80-90 power
@@ -357,9 +364,9 @@ items:
     invWidth: 1
     invHeight: 2
     listOrder: 10460
-    
+
   - type: STR_TZ_LIGHT_BOLTER_AMMO_R #          10460                      ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     requires:
       - STR_ALIENS_ONLY
     size: 0.1
@@ -371,19 +378,21 @@ items:
     hitSound: {mod: 40k, index: 708}
     hitAnimation: {mod: 40k, index: 26}
     damageAlter: #DA BOLTER TZZ
-      ToArmorPre: 0.05
-      ArmorEffectiveness: 0.7 #more armor pen, magic
-      ToArmor: 0.1
-      ToHealth: 0.9 #10% less
-      ToStun: 0.5
+      RandomType: 1 #swingy random damage
+      ToArmorPre: 0.5 #melts armor on the way in
+      FireThreshold: 35 #can ignite
+      ArmorEffectiveness: 0.9
+      ToArmor: 0.0 #does armor damage on the way in
+      ToHealth: 0.8 #compensates a bit for the extra AP and power
+      ToWound: 0.05 #melta type injuries
+      RandomWound: false
       ToMorale: 0.5
     explosionSpeed: 5
     power: 60 #buff, chaos hellguns have 80-90 power
-    damageType: 1 #change to plasma or melta for INFERNO properties? 
+    damageType: 1 #change to plasma or melta for INFERNO properties?
     clipSize: 20
     battleType: 2
     armor: 30
     invWidth: 1
     invHeight: 2
     listOrder: 10460
-    

--- a/Ruleset/ENEMY/armors_chaos.rul
+++ b/Ruleset/ENEMY/armors_chaos.rul
@@ -4,6 +4,9 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+      INFECTION_RESIST: int #reduces infection damage by this as a %
+      INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+      INFECTION_RESIST_TYPE: int #bitmask; type of infection the unit resists. 0 = All, 1 = Nurgle, 2 = GSC, 4 = Slaanesh; 3 = Nurgle + GSC, 5 = Nurgle + Slaanesh, 6 = GSC
 
 armors:
   - type: STR_IRON_WARRIOR_ARMOR
@@ -107,7 +110,7 @@ armors:
     rearArmor: 95
     underArmor: 120
     specialWeapon: AUX_MORTAR #cyclone
-    moveSound: {mod: 40k, index: 700} 
+    moveSound: {mod: 40k, index: 700}
     damageModifier: #TERMINATOR ARMOR
       - 1.0 #none
       - 1.0 #AP
@@ -121,8 +124,8 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.1 #MELTA
-    loftempsSet: [ 5 ] 
-    
+    loftempsSet: [ 5 ]
+
   - type: STR_IRON_WARRIOR_WARSMITH_ARMOR
     tags:
       #ARMOR_ENERGY_SHIELD_CAPACITY: 20
@@ -155,7 +158,7 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 4 ]
-    
+
   - type: OBLITERATOR_ARMOR #
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -181,7 +184,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 5 ]
-         
+
 
   - type: STR_MUTON_ARMOR0 #REGULAR
     visibilityAtDay: 40
@@ -527,7 +530,7 @@ armors:
       - 1.2 #MELTA
 
 
-  - type: STR_CHAOS_MARINE_LEADER_ARMOR 
+  - type: STR_CHAOS_MARINE_LEADER_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 20
     heatVision: 30
@@ -553,7 +556,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
-    
+
   - type: STR_BLACK_LEGION_CSM_ARMOR #ELITE TIER 5 CSM
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -582,7 +585,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
-    
+
   - type: STR_CULTIST_SQUATS_ARMOR
     visibilityAtDay: 25
     visibilityAtDark: 23 #Darkvision
@@ -609,7 +612,7 @@ armors:
       - 0.0 #SMOKE
       - 0.5 #IMPACT
       - 1.1 #MELTA
-    loftempsSet: [ 3 ] 
+    loftempsSet: [ 3 ]
 
   - type: STR_CULTIST_SQUATS_ARMOR_LEADER
     visibilityAtDay: 25
@@ -637,7 +640,7 @@ armors:
       - 0.0 #SMOKE
       - 0.5 #IMPACT
       - 1.1 #MELTA
-    loftempsSet: [ 3 ] 
+    loftempsSet: [ 3 ]
 
   - type: STR_TRAITOR_SQUATS_ARMOR
     visibilityAtDay: 25
@@ -665,7 +668,7 @@ armors:
       - 0.0 #SMOKE
       - 0.5 #IMPACT
       - 1.1 #MELTA
-    loftempsSet: [ 3 ] 
+    loftempsSet: [ 3 ]
 
   - type: STR_CHAOS_SQUATS_ARMOR
     visibilityAtDay: 40
@@ -693,7 +696,7 @@ armors:
       - 0.0 #SMOKE
       - 0.5 #IMPACT
       - 1.1 #MELTA
-    loftempsSet: [ 3 ] 
+    loftempsSet: [ 3 ]
 
   - type: STR_CHAOS_SQUATS_ARMOR_HEAVY
     visibilityAtDay: 40
@@ -752,8 +755,8 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.2 #MELTA
-    loftempsSet: [ 4 ] 
-    
+    loftempsSet: [ 4 ]
+
   - type: STR_CHAOS_SQUATS_ARMOR_LEADER
     visibilityAtDay: 40
     visibilityAtDark: 25 #Darkvision
@@ -786,7 +789,7 @@ armors:
   - type: STR_ALPHA_ARMOR #REGULAR
     visibilityAtDay: 40
     visibilityAtDark: 32
-    camouflageAtDay: 10 
+    camouflageAtDay: 10
     camouflageAtDark: 5
     antiCamouflageAtDay: 15
     antiCamouflageAtDark: 10
@@ -816,11 +819,11 @@ armors:
       - 1.0 #IMPACT
       - 1.2 #MELTA
     loftempsSet: [ 3 ] #stealth tech bonus
-    
+
   - type: STR_ALPHA_CORVUS_ARMOR #Beakie
     visibilityAtDay: 40
     visibilityAtDark: 32
-    camouflageAtDay: 10 
+    camouflageAtDay: 10
     camouflageAtDark: 5
     antiCamouflageAtDay: 15
     antiCamouflageAtDark: 10
@@ -849,7 +852,7 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.3 #MELTA
-    loftempsSet: [ 3 ] #stealth tech bonus  
+    loftempsSet: [ 3 ] #stealth tech bonus
 
   - type: STR_DEATHSKULL_ORK_KAP_ARMOR_ALPHA
     visibilityAtDay: 40
@@ -858,7 +861,7 @@ armors:
     spriteSheet: ALPHADEATHSKULL_KAPBOYZ_BS.PCK
     spriteInv: DEATHSKULL_KAPBOYZ_INV.SPK
     corpseBattle:
-      - STR_DEATHSKULL_ORK_KAP_CORPSE 
+      - STR_DEATHSKULL_ORK_KAP_CORPSE
     frontArmor: 20 #lower
     sideArmor: 20
     rearArmor: 10
@@ -877,7 +880,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
-    
+
   - type: STR_ALPHA_ARMOR_ULTRA #Ultramarine disguise
     visibilityAtDay: 40
     visibilityAtDark: 32
@@ -909,11 +912,11 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.2 #MELTA
-    loftempsSet: [ 4 ]    
+    loftempsSet: [ 4 ]
   - type: STR_ALPHA_SCOUT_ARMOR_ULTRA #Ultramarine scout disguise
     visibilityAtDay: 40
     visibilityAtDark: 30
-    camouflageAtDay: 10 
+    camouflageAtDay: 10
     camouflageAtDark: 5
     antiCamouflageAtDay: 20
     antiCamouflageAtDark: 10
@@ -977,7 +980,7 @@ armors:
       - 1.2 #MELTA
     loftempsSet: [ 4 ]
 
-  - type: STR_ALPHA_DEV_ARMOR_ULTRA 
+  - type: STR_ALPHA_DEV_ARMOR_ULTRA
     visibilityAtDay: 40
     visibilityAtDark: 30
     antiCamouflageAtDay: 15
@@ -1046,7 +1049,7 @@ armors:
   - type: STR_ALPHA_ARMOR_DAEMONETTE     #SEDUCTRESS
     visibilityAtDay: 40
     visibilityAtDark: 30
-    camouflageAtDay: 12 
+    camouflageAtDay: 12
     camouflageAtDark: 5
     antiCamouflageAtDay: 15
     antiCamouflageAtDark: 10
@@ -1083,7 +1086,7 @@ armors:
       UNIT_IMMOBILIZED_UNTIL_MISSION_TIMER: 1
     visibilityAtDay: 40
     visibilityAtDark: 30
-    camouflageAtDay: 6 
+    camouflageAtDay: 6
     camouflageAtDark: 2
     antiCamouflageAtDay: 15
     antiCamouflageAtDark: 10
@@ -1114,7 +1117,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
-    
+
   - type: STR_NIGHTLORD_CSM_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 30 #Nightlord bonus
@@ -1171,7 +1174,7 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 4 ]
-    
+
   - type: STR_NIGHTLORD_RAPTOR_ARMOR0
     visibilityAtDay: 40
     visibilityAtDark: 30
@@ -1222,7 +1225,7 @@ armors:
     underArmor: 70
     drawingRoutine: 0
     movementType: 1
-    #specialWeapon: STR_NIGHT_LORDS_PANIC 
+    #specialWeapon: STR_NIGHT_LORDS_PANIC
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 0.85 #AP
@@ -1240,11 +1243,11 @@ armors:
   - type: STR_NIGHTLORDS_WARPTALON_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 30
-    camouflageAtDay: 12 
+    camouflageAtDay: 12
     camouflageAtDark: 5
     antiCamouflageAtDay: -10
     antiCamouflageAtDark: -10
-    heatVision: 33    
+    heatVision: 33
     spriteSheet: warptalon_nightlord_bs.PCK
     spriteInv: warptalon_nightlord_inv.SPK
     corpseBattle:
@@ -1277,7 +1280,7 @@ armors:
     antiCamouflageAtDark: 10
     heatVision: 30
     spriteSheet: GREYK_ALPHA_TRANSFORMBS.PCK
-    spriteInv: GKINV.SPK 
+    spriteInv: GKINV.SPK
     corpseBattle:
       - STR_GREYK_CORPSE
     corpseGeo: STR_ALPHA_LEGION_CORPSE
@@ -1301,4 +1304,18 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.2 #MELTA
-    loftempsSet: [ 3 ]   
+    loftempsSet: [ 3 ]
+
+  - type: MUTON_ARMORTZEENTCH                                     #TZEENTCH REGULAR
+    painImmune: true #Rubric Marines are dust
+    bleedImmune: true #Rubric Marines are dust
+    zombiImmune: true #Rubric Marines are dust
+    tags:
+      INFECTION_RESIST: 100 #Rubric Marines are dust
+
+  - type: MUTON_ARMORHAVOCT #HAVOC                                #TZEENTCH
+    painImmune: true #Rubric Marines are dust
+    bleedImmune: true #Rubric Marines are dust
+    zombiImmune: true #Rubric Marines are dust
+    tags:
+      INFECTION_RESIST: 100 #Rubric Marines are dust

--- a/Ruleset/ENEMY/armors_daemon.rul
+++ b/Ruleset/ENEMY/armors_daemon.rul
@@ -268,6 +268,7 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 2 ]
+
   - type: STR_FLAMER_ARMOR                          #TZ     Deamon
     visibilityAtDay: 40
     visibilityAtDark: 30

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -10,7 +10,7 @@ extended:
 #infection system tags
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 #vampiric on kill; weapons
       TAG_HP_RETURNED_ON_KILL: int
       TAG_ENERGY_RETURNED_ON_KILL: int
@@ -1018,7 +1018,7 @@ items:
       time: true
     tags:
       INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 5 #tiny chance of zombifying its victims
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -1365,7 +1365,7 @@ items:
     listOrder: 15253
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 20 #high chance of zombifying its victims
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -1710,7 +1710,7 @@ items:
     listOrder: 10141
     tags:
       INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_PISTOL_CLIP_BLIGHT #              10210                    ToStun
     categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
@@ -1739,7 +1739,7 @@ items:
     listOrder: 10142
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_BOLTERN_LIGHT #LIGHT BOLTER NURGLE CHAOS
     categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
@@ -1773,7 +1773,7 @@ items:
     listOrder: 10350
     tags:
       INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_BOLTERN_LIGHT_GRENADELAUNCHER #LIGHT BOLTER NURGLE CHAOS with grenade launcher
     categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
@@ -1826,7 +1826,7 @@ items:
     listOrder: 10351
     tags:
       INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_BLIGHT_GRENADE40 #STR_BOLTERN_LIGHT_GRENADELAUNCHER underslung grenade
     categories: [ STR_CAT_GRENADES, STR_CAT_NURGLE]
@@ -1861,7 +1861,7 @@ items:
     listOrder: 10352
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 5 #low chance of zombifying its victims, lower due to having AoE
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -2236,7 +2236,7 @@ items:
     listOrder: 10295
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
 
   - type: STR_BOLTERN #BOLTER NURGLE CHAOS   10350
@@ -2271,7 +2271,7 @@ items:
     listOrder: 10350
     tags:
       INFECTION_DAMAGE_PERCENT: 25 #Inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_HEAVY_BOLTER_CHAOSNURGLE     #CHAOS NURGLE HBOLTER ROSEMOD
     categories: [STR_CAT_BOLTER]
@@ -2313,7 +2313,7 @@ items:
     listOrder: 10529
     tags:
       INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_AC_N_AMMO #HEAVYBOLTER Nurgle Ammo                 12030
     categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
@@ -2342,7 +2342,7 @@ items:
     listOrder: 10530
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_NURGLE_ROCKET_LAUNCHER #                12120
     categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR]
@@ -2375,7 +2375,7 @@ items:
     listOrder: 12111
     tags:
       INFECTION_DAMAGE_PERCENT: 10 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_PLAGUE_SPEWER
     categories: [STR_CAT_TACTICAL, STR_CAT_CHAOS]
@@ -2455,7 +2455,7 @@ items:
     #explosionSpeed: 10
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 10 #high chance of zombifying its victims; it spews plague, adjusted chance due to being AoE
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -2832,7 +2832,7 @@ items:
     listOrder: 10450
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_RIFLE_CLIP_R #          10460                      ToStun
     categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
@@ -3289,8 +3289,9 @@ items:
     autoShots: 6
     attraction: 7
     listOrder: 10505
+
   - type: STR_FLAMETHROWERTZ #                        10510   TZEENTCH
-    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_CHAOS]
+    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_CHAOS, STR_CAT_TZEENTCH]
     requires:
       - STR_ALIENS_ONLY
     size: 0.2
@@ -3313,6 +3314,9 @@ items:
     autoShots: 6
     attraction: 7
     listOrder: 10510
+    tags:
+      INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_AUTO_CANNON_CHAOSRETRIBUTOR                      #CHAOS Retributor Pattern ROSEMOD
     categories: [STR_CAT_BOLTER]
@@ -3379,7 +3383,7 @@ items:
       - STR_ALIENS_ONLY
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_SNIPER_CHAOS  #SNIPER                    11905                         AIMED
     categories: [STR_CAT_SNIPER, STR_CAT_CHAOS]
@@ -3457,7 +3461,7 @@ items:
     listOrder: 12120
     tags:
       INFECTION_DAMAGE_PERCENT: 10 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_BLIGHT_ROCKET #                         12160
     categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR]
@@ -3486,7 +3490,7 @@ items:
     listOrder: 12160
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 5 #low chance of zombifying its victims, adjusted down for AoE balance
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -4183,7 +4187,7 @@ items:
     listOrder: 15252
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 20 #high chance of Nurgle zombifying
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -4570,7 +4574,7 @@ items:
 
 #Tzeentch
   - type: STR_CSERVITOR_HPLASMA  #Chaos servitor heavy plasma              12000
-    categories: [STR_CAT_PLASMA, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_PLASMA, STR_CAT_DEVASTATOR, STR_CAT_TZEENTCH]
     size: 0.3
     requires:
       - STR_ALIENS_ONLY
@@ -5050,4 +5054,4 @@ items:
     listOrder: 12120
     tags:
       INFECTION_DAMAGE_PERCENT: 10 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -19,7 +19,7 @@ extended:
 #infection system tags
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 #vampiric on damage; weapons
       YTAG_DAMAGE_RETURNED_AS_HP: int
       YTAG_DAMAGE_RETURNED_AS_ENERGY: int
@@ -82,8 +82,9 @@ items:
     flatRate: true
     fixedWeapon: false
     recover: false
+
   - type: BLUE_HORROR_WEAPON  #Indigo Fire            #4006
-    categories: [STR_CAT_GRENADES, STR_CAT_TACTICAL]
+    categories: [STR_CAT_GRENADES, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     size: 0.2
     costSell: 6500
     weight: 1
@@ -95,8 +96,6 @@ items:
     explosionHitSound: { mod: 40k, index: 771 }
     hitAnimation: 2030 #Indigofireex
     powerForAnimation: 20
-    zombieUnit: STR_BLUE_HORROR_TERRORIST
-    specialChance: 20
     arcingShot: true
     accuracySnap: 40
     costSnap:
@@ -124,39 +123,13 @@ items:
     flatRate: true
     fixedWeapon: true
     recover: false
-    #*** Melee Claws
-    #bigSprite:  {mod: 40k, index: 817}
-    meleeSound: {mod: 40k, index: 48}
-    meleeAnimation: {mod: 40k, index: 12}
-    strengthApplied: false
-    meleeType: 7
-    meleePower: 50
-    meleeBonus:
-      strength: 0.2
-      melee: 0.2
-    meleeAlter:
-      RandomType: 2 #TFTD [50% - 150%]
-      ToArmorPre: 0.2
-      ToArmor: 0.1
-      ToHealth: 0.5
-      ToStun: 0.2
-      ToMorale: 0.5
-      ToWound: 0.05
-      ToEnergy: 1.0
-      ArmorEffectiveness: 0.6
-    accuracyMelee: 80
-    #zombieUnit: STR_TZEENTCH_WARP_THRALL #does having a melee zombieUnit work vs the ranged component? #no it doesn't
-    #specialChance: 33
-    meleeMultiplier:
-      flatHundred: 0.5
-      melee: 0.5
-    tuMelee: 14
-    flatMelee:
-      time: true
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     hiddenOnMinimap: true
 
   - type: STR_BLUE_FIRE_WEAPON  #Blue Fire Magic Missiles            #4006
-    categories: [STR_CAT_GRENADES, STR_CAT_TACTICAL]
+    categories: [STR_CAT_GRENADES, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     size: 0.2
     costSell: 6500
     weight: 1
@@ -195,39 +168,13 @@ items:
     flatRate: true
     fixedWeapon: true
     recover: false
-    #*** Melee Claws
-    #bigSprite:  {mod: 40k, index: 817}
-    meleeSound: {mod: 40k, index: 48}
-    meleeAnimation: {mod: 40k, index: 12}
-    strengthApplied: false
-    meleeType: 7
-    meleePower: 50
-    meleeBonus:
-      strength: 0.2
-      melee: 0.2
-    meleeAlter:
-      RandomType: 2 #TFTD [50% - 150%]
-      ToArmorPre: 0.2
-      ToArmor: 0.1
-      ToHealth: 0.5
-      ToStun: 0.2
-      ToMorale: 0.5
-      ToWound: 0.05
-      ToEnergy: 1.0
-      ArmorEffectiveness: 0.6
-    accuracyMelee: 80
-    zombieUnit: STR_TZEENTCH_WARP_THRALL #does having a melee zombieUnit work vs the ranged component?
-    specialChance: 33
-    meleeMultiplier:
-      flatHundred: 0.5
-      melee: 0.5
-    tuMelee: 14
-    flatMelee:
-      time: true
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     hiddenOnMinimap: true
 
   - type: STR_RED_FIRE  #RED FIRE Tzeentch magic         #4006
-    categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL]
+    categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
     vaporColorSurface: {mod: 40k, index: 0}
     vaporDensitySurface: 4
     vaporProbabilitySurface: 100
@@ -269,35 +216,9 @@ items:
     flatRate: true
     fixedWeapon: true
     recover: false
-    #*** Melee Claws
-    #bigSprite:  {mod: 40k, index: 817}
-    meleeSound: {mod: 40k, index: 48}
-    meleeAnimation: {mod: 40k, index: 12}
-    strengthApplied: false
-    meleeType: 7
-    meleePower: 50
-    meleeBonus:
-      strength: 0.2
-      melee: 0.2
-    meleeAlter:
-      RandomType: 2 #TFTD [50% - 150%]
-      ToArmorPre: 0.2
-      ToArmor: 0.1
-      ToHealth: 0.5
-      ToStun: 0.2
-      ToMorale: 0.5
-      ToWound: 0.05
-      ToEnergy: 1.0
-      ArmorEffectiveness: 0.6
-    accuracyMelee: 80
-    zombieUnit: STR_TZEENTCH_WARP_THRALL #does having a melee zombieUnit work vs the ranged component?
-    specialChance: 33
-    meleeMultiplier:
-      flatHundred: 0.5
-      melee: 0.5
-    tuMelee: 14
-    flatMelee:
-      time: true
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     hiddenOnMinimap: true
 
   - type: STR_GREEN_FIRE #Panic and Mindcontrol fire
@@ -327,6 +248,9 @@ items:
       ToArmor: 0.0
       ArmorEffectiveness: 0.0   #how effective armor is against this damage. Default `0.0` for smoke and stun, `1.0` rest.
     damageType: 7
+    tags:
+      INFECTION_DAMAGE_PERCENT: 10 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     clipSize: -1
 
   - type: STR_SILACOID_WEAPON #Bloodletter Hellblade
@@ -450,7 +374,7 @@ items:
     flatRate: true
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 20 #high chance of zombifying its victims
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -793,7 +717,7 @@ items:
     arcingShot: true
     tags:
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 10 #low chance of zombifying, adjusted for AoE
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -1155,7 +1079,7 @@ items:
     hiddenOnMinimap: true
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 10 #low chance of zombifying
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -1502,7 +1426,7 @@ items:
     arcingShot: true
     tags:
       INFECTION_DAMAGE_PERCENT: 75 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_NEVERBORN_WEAPON #Deamon Shredder
     weight: 10
@@ -1601,7 +1525,7 @@ items:
       YTAG_DAMAGE_RETURNED_AS_STUN: 16
       YTAG_DAMAGE_RETURNED_RESIST_TYPE: 0 #untyped damage so no modifications
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 3 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 20 #high chance of corrupting
     zombieUnitByArmorMale: { STR_JARMOR_UCM: STR_MARINE_ZOMBIE_TACTICAL_M, STR_JARMORH_UC: STR_MARINE_ZOMBIE_TACTICAL_M,
       STR_JARMOR_UC: STR_MARINE_ZOMBIE_TACTICAL_M, STR_LIB_ARMOR_UC: STR_MARINE_ZOMBIE_TACTICAL_M, STR_SIGNAL_ARMOR_UC: STR_MARINE_ZOMBIE_TACTICAL_M,
@@ -1760,7 +1684,7 @@ items:
     invHeight: 3
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 20 #high chance of zombifying
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -2117,7 +2041,7 @@ items:
     clipSize: -1
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
       ITEM_AIMED_POWER_BONUS: 30 #sniper weapon; aimed shots target vitals
     specialChance: 10 #low chance of zombifying
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
@@ -2454,7 +2378,7 @@ items:
     tags:
       ITEM_IS_FOR_BOMBER: 1
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_NURGLE_BOOM #blight
     bulletSprite: {mod: 40k, index: 22}
@@ -2486,7 +2410,7 @@ items:
       ITEM_IS_BOMB: 1
       ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 50 #high chance of zombifying
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -2801,7 +2725,7 @@ items:
     }
 
   - type: STR_TZEENTCH_FIEND_CLAWS #For Tzeentch fiends
-    categories: [STR_CAT_MELEE]
+    categories: [STR_CAT_MELEE, STR_CAT_TZEENTCH]
     size: 0.2
     weight: 1
     bigSprite:  {mod: 40k, index: 817}
@@ -2825,6 +2749,9 @@ items:
     meleeMultiplier: #light and fast weapon that utilizes reactions
       melee: 0.75
       reactions: 0.25
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     tuMelee: 15
     clipSize: -1
     battleType: 3
@@ -2834,3 +2761,253 @@ items:
     armor: 200
     recover: false
     fixedWeapon: true
+
+  - type: STR_TZEENTCH_FLAMER_WEAPON_PINK #built in flamer
+    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
+    weight: 0
+    vaporColorSurface: 15 #pink warpfire
+    vaporDensitySurface: 4
+    vaporProbabilitySurface: 100
+    bigSprite: {mod: 40k, index: 377}
+    bulletSprite: {mod: 40k, index: 5}
+    fireSound: {mod: 40k, index: 706}
+    hitSound: { mod: 40k, index: 12 }
+    hitAnimation: { mod: 40k, index: 88 } #XFIRE
+    accuracyAuto: 60
+    accuracySnap: 75
+    tuAuto: 33
+    tuSnap: 20
+    battleType: 1
+    twoHanded: false
+    arcingShot: true
+    confSnap:
+      shots: 2
+    autoRange: 9
+    snapRange: 12 #longer than normal range
+    maxRange: 15
+    dropoff: 5
+    invWidth: 2
+    invHeight: 3
+    autoShots: 6
+    power: 69
+    damageType: 2
+    damageAlter:
+      IgnoreDirection: false
+      FireBlastCalc: false
+      FixRadius: 2
+      RandomType: 1 #Swingy damage
+      ToArmorPre: 0.2
+      RandomArmorPre: true #random armor degradation
+      ArmorEffectiveness: 0.5 #ephermal and magical; passes through most armor with ease
+      ToMorale: 1.0 #Tzeentch attacks assail the mind and are stunning
+      ToHealth: 0.9
+      ToArmor: 0.0
+      ToStun: 0.5 #Tzeentch attacks assail the mind and are stunning
+      ToTime: 0.4 #Tzeentch attacks assail the mind and are stunning
+      IgnoreSelfDestruct: false
+      IgnoreOverKill: true
+    clipSize: -1
+    bulletSpeed: 50
+    explosionSpeed: 10
+    recover: false
+    fixedWeapon: true
+    defaultInventorySlot: STR_LEFT_HAND
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+
+  - type: STR_TZEENTCH_FLAMER_WEAPON_BLUE #built in melta
+    categories: [ STR_CAT_MELTA, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
+    weight: 0
+    bigSprite: {mod: 40k, index: 377}
+    floorSprite: {mod: 40k, index: 132}
+    handSprite: {mod: 40k, index: 400}
+    bulletSprite: {mod: 40k, index: 16}
+    fireSound: {mod: 40k, index: 739}
+    vaporColorSurface: 14 #blue warpfire
+    vaporDensitySurface: 2
+    vaporProbabilitySurface: 85
+    accuracySnap: 80
+    accuracyAimed: 100
+    tuSnap: 20
+    tuAimed: 33
+    battleType: 1
+    twoHanded: false
+    snapRange: 15
+    aimRange: 18
+    maxRange: 25
+    dropoff: 5
+    invWidth: 2
+    invHeight: 3
+    power: 9
+    damageType: 11
+    damageAlter: #DA MELTA Double
+      RandomType: 1 #Swingy damage
+      FireThreshold: 0
+      FireBlastCalc: false
+      ToArmorPre: 1.0
+      ArmorEffectiveness: 0.5 #ephermal and magical; passes through most armor with ease
+      ToMorale: 1.0 #Tzeentch attacks assail the mind and are stunning
+      ToHealth: 0.9
+      ToStun: 0.5 #Tzeentch attacks assail the mind and are stunning
+      ToTime: 0.4 #Tzeentch attacks assail the mind and are stunning
+      ToTile: 6.0
+      ToWound: 0.05
+      RandomWound: false
+      TileDamageMethod: 2
+      IgnoreOverKill: true
+    shotgunBehavior: 1
+    shotgunPellets: 10
+    shotgunSpread: 50
+    powerRangeReduction: 0.5
+    powerRangeThreshold: 18.0
+    clipSize: -1
+    recover: false
+    fixedWeapon: true
+    defaultInventorySlot: STR_RIGHT_HAND
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+
+  - type: STR_TZEENTCH_GLIMMERING_WEAPON_SCATTER #built in long range shotgun melta
+    categories: [ STR_CAT_MELTA, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
+    weight: 0
+    bigSprite: {mod: 40k, index: 377}
+    floorSprite: {mod: 40k, index: 132}
+    handSprite: {mod: 40k, index: 400}
+    bulletSprite: {mod: 40k, index: 16}
+    fireSound: {mod: 40k, index: 739}
+    vaporColorSurface: 14 #blue warpfire
+    vaporDensitySurface: 2
+    vaporProbabilitySurface: 85
+    accuracySnap: 80
+    tuSnap: 30
+    confSnap:
+      shots: 2
+    battleType: 1
+    twoHanded: false
+    snapRange: 15
+    maxRange: 25
+    dropoff: 5
+    invWidth: 2
+    invHeight: 3
+    power: 9
+    damageType: 11
+    damageAlter: #DA MELTA Double
+      RandomType: 1 #Swingy damage
+      FireThreshold: 0
+      ToArmorPre: 1.0
+      FireBlastCalc: false
+      FixRadius: 1
+      ArmorEffectiveness: 0.5 #ephermal and magical; passes through most armor with ease
+      ToMorale: 1.0 #Tzeentch attacks assail the mind and are stunning
+      ToHealth: 0.6 #damage is as spiritual as physical
+      ToStun: 0.5 #Tzeentch attacks assail the mind and are stunning
+      ToTime: 0.4 #Tzeentch attacks assail the mind and are stunning
+      ToTile: 6.0
+      ToWound: 0.00
+      RandomWound: false
+      TileDamageMethod: 2
+    shotgunBehavior: 1
+    shotgunPellets: 9
+    shotgunSpread: 25
+    powerRangeReduction: 0.5
+    powerRangeThreshold: 16.0
+    clipSize: -1
+    recover: false
+    fixedWeapon: true
+    defaultInventorySlot: STR_RIGHT_HAND
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+
+  - type: STR_TZEENTCH_GLIMMERING_WEAPON_RAPIDFIRE #built in close range rapid fire light plasma
+    categories: [ STR_CAT_PLASMA, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
+    weight: 0
+    bigSprite: {mod: 40k, index: 377}
+    floorSprite: {mod: 40k, index: 132}
+    handSprite: {mod: 40k, index: 400}
+    bulletSprite: {mod: 40k, index: 16}
+    fireSound: {mod: 40k, index: 739}
+    vaporColorSurface: 15 #pink warpfire
+    vaporDensitySurface: 6
+    vaporProbabilitySurface: 50
+    accuracySnap: 70
+    accuracyAuto: 50
+    tuSnap: 25
+    confSnap:
+      shots: 3
+    confAuto:
+      shots: 10
+    battleType: 1
+    twoHanded: false
+    autoRange: 9
+    snapRange: 12
+    maxRange: 15
+    dropoff: 5
+    invWidth: 2
+    invHeight: 3
+    power: 29
+    damageType: 5 #plasma
+    damageAlter: #DA MELTA Double
+      RandomType: 1 #Swingy damage
+      FireThreshold: 0
+      ToArmorPre: 1.0
+      FireBlastCalc: false
+      FixRadius: 1
+      ArmorEffectiveness: 0.5 #ephermal and magical; passes through most armor with ease
+      ToMorale: 1.0 #Tzeentch attacks assail the mind and are stunning
+      ToHealth: 0.6 #damage is as spiritual as physical
+      ToStun: 0.5 #Tzeentch attacks assail the mind and are stunning
+      ToTime: 0.4 #Tzeentch attacks assail the mind and are stunning
+      ToTile: 6.0
+      ToWound: 0.05
+      RandomWound: false
+      TileDamageMethod: 2
+      IgnoreOverKill: true
+    powerRangeReduction: 5.0
+    powerRangeThreshold: 13.0
+    clipSize: -1
+    recover: false
+    fixedWeapon: true
+    defaultInventorySlot: STR_LEFT_HAND
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+
+
+  - type: STR_PINK_HORROR_DEATH_GRENADE #Tzeentch Blue Horror spawner; meant to trigger when Pink Horror dies
+    categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL, STR_CAT_TZEENTCH]
+    bigSprite: 2912
+    floorSprite: 2914
+    hitAnimation: 2160 #WarpBurn
+    explosionHitSound: {mod: 40k, index: 771}
+    hitSound: {mod: 40k, index: 788}
+    power: 25
+    damageType: 2
+    damageAlter:
+      RandomType: 1
+      IgnoreOverKill: false
+      FireBlastCalc: false
+      FixRadius: 4
+      ToHealth: 0.1
+      ToTime: 0.5
+      ToEnergy: 2.0
+      ToMorale: 6.0
+      ArmorEffectiveness: 0.5
+    battleType: 4 # grenade
+    recover: false
+    tuThrow: 999
+    tuPrime: 999
+    armor: 30
+    fixedWeapon: false #has to be false so kamikazi tag and scripts work properly
+    isExplodingInHands: true
+    hiddenOnMinimap: true
+    defaultInventorySlot: STR_BELT
+    spawnUnit: STR_BLUE_HORROR_TERRORIST
+    spawnUnitFaction: -1
+    tags:
+      ITEM_IS_BOMB: 1
+      ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch

--- a/Ruleset/itemCategories.rul
+++ b/Ruleset/itemCategories.rul
@@ -5,5 +5,8 @@ itemCategories:
   - type: STR_CAT_NURGLE
     listOrder: 204
 
+  - type: STR_CAT_TZEENTCH
+    listOrder: 205
+
   - type: STR_GSC_FACTION_TRUE
     listOrder: 3000 # high offset because I don't know what things go into the categories

--- a/Ruleset/research40k.rul
+++ b/Ruleset/research40k.rul
@@ -3,7 +3,7 @@ research:
   - delete: STR_LASER_RIFLE
 
 #The Emperor Protects Beginner Mode Options
-  
+
   - name: STR_THE_EMPEROR_PROTECTS_RESEARCH #The Emperor Protects (Beginner Mode Options)
     cost: 10
     points: 100
@@ -22,20 +22,20 @@ research:
     cost: 10
     points: 250
     dependencies:
-      - STR_THE_EMPEROR_PROTECTS_RESEARCH      
+      - STR_THE_EMPEROR_PROTECTS_RESEARCH
   - name: STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH #"Request Additional Astartes Support"
     cost: 10
     points: 250
     dependencies:
-      - STR_THE_EMPEROR_PROTECTS_RESEARCH        
-  
+      - STR_THE_EMPEROR_PROTECTS_RESEARCH
+
   - name: STR_BASIC_SPAWN_PENAL_SQUAD_RESEARCH #"Request Penal Squad"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
       - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH
-      
+
   - name: STR_BASIC_SPAWN_PDF_SQUAD_RESEARCH #"Request PDF Squad"
     cost: 10
     points: 100
@@ -47,96 +47,96 @@ research:
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_ARBITES_SUPPORT_RESEARCH   
-      
+      - STR_THE_EMPEROR_PROTECTS_ARBITES_SUPPORT_RESEARCH
+
   - name: STR_BASIC_SPAWN_GUARD_VETERANS_RESEARCH #"Request Veterans"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH  
+      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_GUARD_VETERANS_RESEARCH #"Request Veterans"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH  
+      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_OGRYN_RESEARCH #"Request Ogryns"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH 
+      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_STORMTROOPERS_RESEARCH #"Request Stormtroopers"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH       
+      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_SANCTIONED_PSYKER_RESEARCH #"Request Psykers"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH     
-  
+      - STR_THE_EMPEROR_PROTECTS_GUARD_SUPPORT_RESEARCH
+
   - name: STR_BASIC_SPAWN_FRATERIS_MILITIA_VETERAN_RESEARCH #"Request Frateris Militia Veterans"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH   
+      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_REPENTIA_RESEARCH #"Summon Sister Repentia"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH         
+      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_ADEPTAS_RESEARCH #"Request Battle Sisters"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH         
+      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_ADEPTAS_SERAPHIM_RESEARCH #"Request Seraphim"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH         
+      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_VETERAN_ADEPTAS_RESEARCH #"Request Elohim"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH    
+      - STR_THE_EMPEROR_PROTECTS_ADEPTAS_SUPPORT_RESEARCH
 
   - name: STR_BASIC_SPAWN_MARINE_SCOUTS_RESEARCH #"Request Astartes Scouts"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH 
+      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_TACTICAL_MARINES_RESEARCH #"Request Tactical Marines"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH   
+      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_DEVASTATOR_MARINES_RESEARCH #"Request Devastator Marines"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH    
+      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH
   - name: STR_BASIC_SPAWN_ASSAULT_MARINES_RESEARCH #"Request Assault Marines"
     cost: 10
     points: 100
     dependencies:
       - STR_THE_EMPEROR_PROTECTS_RESEARCH
-      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH      
-  
-  
+      - STR_THE_EMPEROR_PROTECTS_MARINE_SUPPORT_RESEARCH
+
+
 
 #---MAIN STORY----------------------------------------------------
 
@@ -152,7 +152,7 @@ research:
       - STR_ALIEN_ORIGINS
       - STR_PSI_LAB
     needItem: true
-    
+
   - name: STR_HERETIC_SISTERCELEST
     unlocks:
       - STR_LEADER_PLUS
@@ -176,7 +176,7 @@ research:
     cost: 25
     points: 10
     needItem: true
-    
+
   - name: STR_NURGLE_ZOMBIE
     cost: 50
     points: 25
@@ -188,8 +188,8 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED 
-      
+      - STR_INTERROGATION_COMPLETED
+
   - name: STR_NURGLE_DAEMONETTE
     cost: 50
     points: 25
@@ -205,7 +205,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      
+
   - name: STR_NURGLE_CULTIST
     cost: 50
     points: 25
@@ -213,13 +213,13 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
 
-  - name: STR_NURGLE_CULTIST_FEM 
+  - name: STR_NURGLE_CULTIST_FEM
     cost: 50
     points: 25
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-     
+
   - name: STR_NURGLE_CULTIST_HEAVY
     cost: 75
     points: 25
@@ -227,7 +227,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-      
+
   - name: STR_NURGLE_OGRYN
     cost: 75
     points: 25
@@ -248,7 +248,7 @@ research:
       - STR_THREAT_ONE
       - STR_CHAOS_PATH
       - STR_PSI_LAB
-      
+
   - name: STR_DEATHGUARD_SPEWER
     cost: 100
     points: 25
@@ -307,12 +307,12 @@ research:
       - STR_STANDARD_SMALL_ARMS_RESEARCH_REQ
   - name: STR_STANDARD_SMALL_ARMS_RESEARCH_REQ
     cost: 0
-    points: 0  
+    points: 0
     dependencies:
       - STR_GENERIC_HEAVY_STUBBER
       - STR_PUMP_SHOTGUN
       - STR_SMG_STUB_GUN
-  - name: STR_HEAVY_WEAPONS_RESEARCH 
+  - name: STR_HEAVY_WEAPONS_RESEARCH
     cost: 0
     points: 0
     dependencies:
@@ -346,7 +346,7 @@ research:
 # currently all of these are available by default. This means that they are available to all strategies currently
   - name: STR_ADEPTAS_RECRUITMENT_REQ
   - name: STR_HEAVY_WEAPONS_RESEARCH_REQ
-  - name: STR_TACTICAL_KIT_REQ    
+  - name: STR_TACTICAL_KIT_REQ
   - name: STR_ASSAULT_KIT_REQ
   - name: STR_ASSAULT_AND_TACTICAL_KIT_REQ
   - name: STR_SCOUT_AND_TACTICAL_KIT_REQ
@@ -386,8 +386,8 @@ research:
     cost: 25
     points: 15
     needItem: true
-    
-    
+
+
   # marines
   - name: STR_HFLAMERR
     cost: 1000
@@ -417,14 +417,14 @@ research:
     dependencies:
       - STR_FLOATER_SOLDIER
       - STR_FLOATER_MEDIC
-      - STR_FLOATER_NAVIGATOR  
+      - STR_FLOATER_NAVIGATOR
       - STR_FLOATER_ENGINEER
       - STR_FLOATER_LEADER
       - STR_FLOATER_COMMANDER
       - STR_WARPTALON_SOLDIER
       - STR_WARPTALON_COMMANDER
       - STR_ORK_STORMBOY
-      - STR_BLACKSTONE_JUMPTROOPER    
+      - STR_BLACKSTONE_JUMPTROOPER
       - STR_NIGHTLORDS_RAPTOR_SOLDIER
       - STR_NIGHTLORDS_RAPTOR_NAVIGATOR
       - STR_NIGHTLORDS_RAPTOR_MEDIC
@@ -434,8 +434,8 @@ research:
       - STR_NIGHTLORDS_RAPTOR_LEADER
       - STR_NIGHTLORDS_RAPTOR_COMMANDER
       - STR_NIGHTLORDS_WARPTALON_SOLDIER
-      - STR_NIGHTLORDS_WARPTALON_COMMANDER 
-      
+      - STR_NIGHTLORDS_WARPTALON_COMMANDER
+
   - name: STR_FLOATER_SOLDIER
     cost: 50
     points: 50
@@ -456,7 +456,7 @@ research:
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_FLOATER_NAVIGATOR 
+  - name: STR_FLOATER_NAVIGATOR
     cost: 75
     points: 50
     needItem: true
@@ -546,7 +546,7 @@ research:
       - STR_INTERROGATION_COMPLETED
       - STR_LEADER_PLUS
       - STR_THREAT_ONE
-      
+
   - name: STR_NIGHTLORDS_CSM_SOLDIER
     cost: 100
     points: 50
@@ -612,7 +612,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_NIGHTLORDS_RAPTOR_RESEARCH  
+      - STR_NIGHTLORDS_RAPTOR_RESEARCH
       - STR_LEADER_PLUS
       - STR_ADEPTAS_ARMORS_DEP1
       - STR_ASS_ARMOR_DEP1
@@ -624,7 +624,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_NIGHTLORDS_RAPTOR_RESEARCH 
+      - STR_NIGHTLORDS_RAPTOR_RESEARCH
       - STR_LEADER_PLUS
       - STR_COMMANDER_PLUS
       - STR_ALIEN_ORIGINS
@@ -633,12 +633,12 @@ research:
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
       - STR_THREAT_ONE
       - STR_PSI_LAB
-      
+
   - name: STR_SCARE_GRENADE
     cost: 50
     points: 15
     needItem: true
-    
+
   - name: STR_NIGHTLORDS_RAPTOR_RESEARCH
     cost: 192
     points: 50
@@ -671,7 +671,7 @@ research:
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
       - STR_THREAT_ONE
       - STR_PSI_LAB
-      
+
   - name: STR_NIGHTLORDS_WARPTALON_RESEARCH
     cost: 192
     points: 50
@@ -701,8 +701,8 @@ research:
     cost: 50
     points: 25
     needItem: true
-    
-  - name: STR_BLACKSTONE_JUMPTROOPER   
+
+  - name: STR_BLACKSTONE_JUMPTROOPER
     cost: 75
     points: 50
     needItem: true
@@ -711,7 +711,7 @@ research:
       - STR_ASS_ARMOR_DEP1
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
- 
+
 
   #arbites
 
@@ -737,14 +737,14 @@ research:
       - STR_MARINES_STRATEGY
       - STR_CHAPTER_PURITY
       - STR_NOT_PRIMARIS
- 
+
   - name: STR_CASSC
     cost: 200
     points: 25
     unlocks:
       - STR_ASSC_DEP1
     needItem: true
-    
+
   - name: STR_ASSC_CLIP # instant unlock
     cost: 0
     points: 0
@@ -754,18 +754,18 @@ research:
       - STR_CASSC
       - STR_IW_AUTOCANNON
 
-  - name: STR_PLASMA_RIFLE_ADEPTAS 
+  - name: STR_PLASMA_RIFLE_ADEPTAS
     cost: 500
     points: 20
     dependencies:
       - STR_ADEPTAS_MIDTIER
       - STR_PLASMA_SPRAYGUN_CHAOS
       - STR_PLASMA_CARBINE_CHAOS
-  - name: STR_PLASMA_SPRAY_CLIP 
+  - name: STR_PLASMA_SPRAY_CLIP
     cost: 120
     points: 10
     dependencies:
-      - STR_PLASMA_RIFLE_CLIP 
+      - STR_PLASMA_RIFLE_CLIP
     needItem: true
   - name: STR_BARRAGE_PLASMA_CLIP
     cost: 120
@@ -822,7 +822,7 @@ research:
     cost: 50
     points: 15
     needItem: true
-    
+
   - name: STR_SLAANESH_ROCKET_LAUNCHER
     cost: 50
     points: 15
@@ -844,7 +844,7 @@ research:
     cost: 50
     points: 15
     needItem: true
-    
+
   - name: STR_LIGHT_BOLTER_CHAOS
     cost: 25
     points: 15
@@ -854,7 +854,7 @@ research:
     cost: 25
     points: 15
     needItem: true
-    
+
   - name: STR_SLAAN_CONSTRICTOR_WEBBER
     cost: 100
     points: 15
@@ -915,7 +915,7 @@ research:
     cost: 50
     points: 15
     needItem: true
-  
+
 #Khorne equipment:
   - name: STR_VALKIA_SHIELD
     cost: 200
@@ -923,7 +923,7 @@ research:
     needItem: true
 
 #Traitor Guard equipment
-  - name: STR_CSERVITOR_HB    
+  - name: STR_CSERVITOR_HB
     cost: 100
     points: 15
     needItem: true
@@ -939,7 +939,7 @@ research:
     cost: 50
     points: 15
     needItem: true
-  - name: STR_CSERVITOR_MILAUNCHER   
+  - name: STR_CSERVITOR_MILAUNCHER
     cost: 100
     points: 15
     needItem: true
@@ -955,9 +955,9 @@ research:
     cost: 50
     points: 15
     needItem: true
-        
+
 #Adeptas research
-  - name: STR_PLASMA_CARBINE_ADEPTAS 
+  - name: STR_PLASMA_CARBINE_ADEPTAS
     cost: 500
     points: 20
     dependencies:
@@ -971,7 +971,7 @@ research:
       - STR_HIGHTIER_PREREQ
     needItem: true
     unlocks:
-      - STR_PLASMA_BATTLERIFLE_DEP1 
+      - STR_PLASMA_BATTLERIFLE_DEP1
   - name: STR_TZ_PLASMA_GUN_TWINCORE
     cost: 700
     points: 20
@@ -979,17 +979,17 @@ research:
       #- STR_HIGHTIER_PREREQ
     needItem: true
     unlocks:
-      - STR_PLASMA_BATTLERIFLE_DEP1 
+      - STR_PLASMA_BATTLERIFLE_DEP1
 
-  - name: STR_PLASMA_BATTLERIFLE_DEP1 
+  - name: STR_PLASMA_BATTLERIFLE_DEP1
     dependencies:
       - STR_GENERALLOCK
-      
+
   - name: STR_PLASMA_GUN_TWINCORE_DEKKER
     cost: 700
     points: 20
     dependencies:
-      - STR_PLASMA_BATTLERIFLE_DEP1 
+      - STR_PLASMA_BATTLERIFLE_DEP1
       #- STR_PLASMA_GUN_TWINCORE
       #- STR_TZ_PLASMA_GUN_TWINCORE
   - name: STR_PLASMA_GUN_TWINCORE_ADEPTAS
@@ -999,8 +999,8 @@ research:
       - STR_PLASMA_GUN_TWINCORE_ADEPTAS_DEPENDENCY
   - name: STR_PLASMA_GUN_TWINCORE_ADEPTAS_DEPENDENCY
     dependencies:
-      - STR_PLASMA_BATTLERIFLE_DEP1 
-      - STR_ADEPTAS_HIGHTIER 
+      - STR_PLASMA_BATTLERIFLE_DEP1
+      - STR_ADEPTAS_HIGHTIER
     unlocks:
       - STR_PLASMA_GUN_TWINCORE_ADEPTAS
   - name: STR_PLASMA_TWINCORE_CLIP
@@ -1015,46 +1015,46 @@ research:
     dependencies:
       - STR_LASCAN
       - STR_MIDTIER_PREREQ
-  - name: STR_LASCANNON_CLIP_MALTHUS 
+  - name: STR_LASCANNON_CLIP_MALTHUS
     cost: 120
     points: 10
     dependencies:
       - STR_LASCAN_MALTHUS
 
-  - name: STR_SMALL_LAUNCHER 
+  - name: STR_SMALL_LAUNCHER
     cost: 500
     points: 30
   - name: STR_GRAVGUN_AOE_CHAOS
     cost: 500
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_GRAVGUN_NURGLE
     cost: 500
     points: 25
-    needItem: true 
-  - name: STR_GRAVCANNON_NURGLE 
+    needItem: true
+  - name: STR_GRAVCANNON_NURGLE
     cost: 1000
     points: 25
-    needItem: true 
-  - name: STR_GRAVCANNON_AMMO 
+    needItem: true
+  - name: STR_GRAVCANNON_AMMO
     cost: 250
     points: 25
-    needItem: true 
+    needItem: true
     dependencies:
-      - STR_GRAVCANNON_NURGLE 
+      - STR_GRAVCANNON_NURGLE
   - name: STR_NURGLE_KOMBIBOLTER_GRAV
     cost: 300
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_NURGLE_GRAVPISTOL
     cost: 250
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: STR_NURGLE_NEEDLER_RIFLE
     cost: 250
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: NURGLING_SPIT
     cost: 100
@@ -1068,7 +1068,7 @@ research:
     cost: 100
     points: 15
     needItem: true
-    
+
 #Tzeentch weapons
   - name: STR_TZLESSER_DAEMON_SPAWNER_GRENADE
     cost: 50
@@ -1091,7 +1091,7 @@ research:
     cost: 100
     points: 15
     needItem: true
-  - name: STR_BLUE_FIRE_WEAPON 
+  - name: STR_BLUE_FIRE_WEAPON
     cost: 100
     points: 15
     needItem: true
@@ -1103,7 +1103,7 @@ research:
     cost: 100
     points: 15
     needItem: true
-    
+
   - name: STR_CSERVITOR_HPLASMA
     cost: 50
     points: 15
@@ -1143,7 +1143,7 @@ research:
     dependencies:
       - STR_MIDTIER_PREREQ
     needItem: true
-  - name: STR_PLASMA_PISTOL_TZEENTCH 
+  - name: STR_PLASMA_PISTOL_TZEENTCH
     cost: 600
     points: 20
     unlocks:
@@ -1154,25 +1154,25 @@ research:
     cost: 50
     points: 15
     needItem: true
-    
+
   - name: STR_ADEPTAS_GRAVGUN_DEP1
     requires:
       - STR_ADEPTAS
     dependencies:
-      - STR_SMALL_LAUNCHER 
+      - STR_SMALL_LAUNCHER
       - STR_GRAVGUN_AOE_CHAOS
       - STR_GRAVGUN_NURGLE
       - STR_NURGLE_KOMBIBOLTER_GRAV
       - STR_NURGLE_GRAVPISTOL
-      - STR_GRAVCANNON_NURGLE 
-      
-  - name: STR_GRAVGUN_ADEPTAS 
+      - STR_GRAVCANNON_NURGLE
+
+  - name: STR_GRAVGUN_ADEPTAS
     cost: 860
     points: 20
     dependencies:
       - STR_ADEPTAS_GRAVGUN_DEP1
-      - STR_ADEPTAS_HIGHTIER 
-  - name: STR_GRAVGUN_AOE_AMMO 
+      - STR_ADEPTAS_HIGHTIER
+  - name: STR_GRAVGUN_AOE_AMMO
     cost: 120
     points: 10
     dependencies:
@@ -1197,7 +1197,7 @@ research:
       - STR_GSC_WEBBER_PISTOL
       - STR_SLAAN_CONSTRICTOR_WEBBER
 
-  - name: STR_HARMONIC_MELTAGUN 
+  - name: STR_HARMONIC_MELTAGUN
     cost: 400
     points: 20
     dependencies:
@@ -1214,7 +1214,7 @@ research:
     dependencies:
       - STR_HEAVY_LASER
       - STR_ADEPTAS
-      
+
   - name: STR_AUTO_CANNON_POTESTAS #needs manufacture
     cost: 860
     points: 20
@@ -1231,23 +1231,23 @@ research:
   - name: STR_AUTO_CANNON_CHAOSRETRIBUTOR
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_HEAVY_BOLTER_CHAOSNURGLE
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_AC_N_AMMO
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_GRAVPISTOL_AMMO
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_PLAGUE_KNIFE
     cost: 100
     points: 25
-    needItem: true    
+    needItem: true
   - name: STR_NURGLE_BALESWORD
     cost: 100
     points: 25
@@ -1259,35 +1259,35 @@ research:
   - name: STR_PLAGUE_SPEWER_TANK
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_BOLTPISTOL_NURGLE
     cost: 75
     points: 25
-    needItem: true     
+    needItem: true
   - name: STR_PISTOL_CLIP_BLIGHT
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_BOLTERN_LIGHT
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_BOLTERN_LIGHT_GRENADELAUNCHER
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_LIGHT_BOLTER_AMMO_NURGLE
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_BLIGHT_GRENADE40
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_ACIDRUST_GRENADE40
     cost: 50
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: STR_NURGLE_ROCKET_LAUNCHER
     cost: 50
@@ -1298,7 +1298,7 @@ research:
     points: 25
     dependencies:
      - STR_MIDTIER_PREREQ
-    needItem: true 
+    needItem: true
 
   - name: STR_CHOIR_GUN #needs manufacture
     cost: 600
@@ -1319,14 +1319,14 @@ research:
     dependencies:
       - STR_ADEPTAS
       - STR_UFO_CONSTRUCTION
-      
+
   - name: STR_ADEPTAS_ZWEIHANDER
     cost: 1200
     points: 20
     dependencies:
       - STR_ADEPTAS
       - STR_UFO_CONSTRUCTION
-   
+
 #*** armors ***
   # marines
 
@@ -1373,7 +1373,7 @@ research:
     dependencies:
       - STR_MARINES_STRATEGY #pretty superflous, plenty of ways to "unlock" chaos path now - only Guard and Arbites are more limited in how to take advantage.
       - STR_PLASMA_PISTOL
-      - STR_PLASMA_PISTOL_TZEENTCH 
+      - STR_PLASMA_PISTOL_TZEENTCH
       - STR_PLASMA_RIFLE
       - STR_HEAVY_PLASMA
       - STR_ALIEN_ORIGINS
@@ -1385,7 +1385,7 @@ research:
       - STR_CASSC
     unlocks:
       - STR_CONVINCE_CHAOS_RESEARCH
-      
+
   - name: STR_CHAMBER_CHAOS_PATH #Inquisition Chaos Path got the most freedom
     cost: 150
     points: 0
@@ -1393,7 +1393,7 @@ research:
       - STR_CHAOS_PATH
       - STR_CHAMBERMILITANT
       - STR_HERETICAL_INQUISITOR_STRATEGY
-    unlocks: 
+    unlocks:
       - STR_CHAOS_ALL_HIRE_CHAOS_ADEPTAS_LATER_RESEARCH
       - STR_CHAOS_MARINE_HIRE_RESEARCH
       - STR_CHAOS_ALL_HIRE_CHAOS_ADEPTAS_LATER_RESEARCH #Leads to the actual research that allows Chaos Adeptas research
@@ -1404,18 +1404,18 @@ research:
     dependencies:
       - STR_MARINES_STRATEGY
       - STR_CHAOS_PATH
-    unlocks: 
+    unlocks:
       - STR_CHAOS_MARINE_HIRE_RESEARCH
- 
+
   - name: STR_CHAOS_SISTERS_CSM_ACCESS_LATER
     cost: 1500
     points: 0
     dependencies:
       - STR_ALIENS_ONLY2
       - STR_UFO_CONSTRUCTION #Ceramite Tier
-    unlocks: 
+    unlocks:
       - STR_CHAOS_MARINE_HIRE_RESEARCH
-      
+
   - name: STR_CHAOS_MARINE_HIRE_RESEARCH
     cost: 1000
     points: 0
@@ -1423,17 +1423,17 @@ research:
       - STR_CHAMBER_CHAOS_PATH #Was this STR_CHAOS_PATH, now split to give CHAMBER and MARINES this right away, but not Chaos Sisters path
       - STR_MARINE_CHAOS_PATH #marine chaos path
       - STR_CHAOS_SISTERS_CSM_ACCESS_LATER #Ceramite Tier
-      
+
   - name: STR_ALIEN_ORIGINS
     cost: 500
     points: 100
-    unlocks: 
+    unlocks:
       - STR_CHAOS_PATH #new way to get access to this research without being MARINES
 
   - name: STR_CHAOS_CROZIUS
     cost: 500
     points: 100
-    unlocks: 
+    unlocks:
       - STR_CHAOS_PATH #new way to get access to this research without being MARINES
 
   - name: STR_CONVINCE_CHAOS_RESEARCH
@@ -1442,13 +1442,13 @@ research:
     dependencies:
       - STR_CHAOS_PATH
       - STR_HERETICAL_INQUISITOR_STRATEGY
-      
+
   - name: STR_CONVERT_TO_CHAOS_RESEARCH
     cost: 500
     points: 100
     dependencies:
       - STR_CHAOS_PATH
-      
+
   - name: STR_NURGLE_OPTIONS
     cost: 500
     points: 100
@@ -1464,18 +1464,18 @@ research:
       - STR_TZEENTCH_PATH
       - STR_KHORNE_PATH
       - STR_SLAANESH_PATH
-      
+
   - name: STR_TZEENTCH_OPTIONS
     cost: 500
     points: 100
     dependencies:
       - STR_CHAOS_PATH
-      
+
   - name: STR_TZEENTCH_PATH
     cost: 1000
     points: 100
     dependencies:
-      - STR_TZEENTCH_OPTIONS   
+      - STR_TZEENTCH_OPTIONS
     disables:
       - STR_NURGLE_PATH
       - STR_KHORNE_PATH
@@ -1486,7 +1486,7 @@ research:
     points: 100
     dependencies:
       - STR_CHAOS_PATH
-      
+
   - name: STR_KHORNE_PATH
     cost: 1000
     points: 100
@@ -1502,7 +1502,7 @@ research:
     points: 100
     dependencies:
       - STR_CHAOS_PATH
-      
+
   - name: STR_SLAANESH_PATH
     cost: 1000
     points: 100
@@ -1512,7 +1512,7 @@ research:
       - STR_NURGLE_PATH
       - STR_TZEENTCH_PATH
       - STR_KHORNE_PATH
-       
+
   - name: STR_NECRONTECH_RESEARCH #grant access to Necron Weapons
     cost: 2000
     points: -250
@@ -1522,7 +1522,7 @@ research:
       - STR_HYPERPHASESWORD
       - STR_SYNAPTIC_DISINTEGRATOR
       - STR_GAUSS_FLAYER
-      
+
   - name: STR_XENO_ONLY #grant access to Xeno Weapons (not chaos)
     cost: 250
     points: -100
@@ -1553,7 +1553,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_XENO_ONLY #added, unlocks XENO_ONLY (Xeno embrace) for research, which allows for recruiting captured Farseer.
-      
+
 #SISTERS OF CHAOS path
   - name: STR_ALIENS_ONLY2 #CHAOS PATH FOR SISTERS
     cost: 1000
@@ -1567,7 +1567,7 @@ research:
       - STR_CHAOS_ADEPTAS_HIRE_RESEARCH
       - STR_ALIENS_ONLY #chaos weapon use restrictor
     disables:
-      - STR_CHAPTER_PURITY 
+      - STR_CHAPTER_PURITY
 
   - name: STR_CHAOS_ADEPTAS_HIRE_RESEARCH #can be researched right away after going chaos path adeptas
     cost: 500
@@ -1588,23 +1588,23 @@ research:
       - STR_SLAANESH_OPTIONS
       - STR_KHORNE_OPTIONS
       - STR_ALIENS_ONLY
-    unlocks: 
+    unlocks:
       - STR_CHAOS_ADEPTAS_HIRE_RESEARCH
-      
+
   - name: STR_TZEENTCH_ADEPTAS_HIRE_RESEARCH
     cost: 250
     points: 100
     dependencies:
       - STR_TZEENTCH_PATH
       - STR_CHAOS_ADEPTAS_HIRE_RESEARCH
-      
+
   - name: STR_KHORNE_ADEPTAS_HIRE_RESEARCH
     cost: 250
     points: 100
     dependencies:
       - STR_KHORNE_PATH
       - STR_CHAOS_ADEPTAS_HIRE_RESEARCH
-      
+
   - name: STR_SLAANESH_ADEPTAS_HIRE_RESEARCH
     cost: 250
     points: 100
@@ -1618,7 +1618,7 @@ research:
     dependencies:
       - STR_NURGLE_PATH
       - STR_CHAOS_ADEPTAS_HIRE_RESEARCH
-      
+
 #---CORPSES AND FOES------------------------------------------------------
 #ChaosSisters Interrogation (Needed for Ufopedia hooks)
 
@@ -1626,8 +1626,8 @@ research:
     cost: 50
     points: 25
     needItem: true
-    
-  - name: STR_HERETIC_SISTERCANONESS 
+
+  - name: STR_HERETIC_SISTERCANONESS
     cost: 192
     points: 50
     needItem: true
@@ -1638,7 +1638,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_HERETIC_SISTERINQ 
+  - name: STR_HERETIC_SISTERINQ
     cost: 192
     points: 50
     needItem: true
@@ -1649,8 +1649,8 @@ research:
       - STR_COMMANDER_PLUS
       - STR_ALIEN_ORIGINS
       - STR_PSI_LAB
-    
-  - name: STR_HERETIC_SISTERPALATINE 
+
+  - name: STR_HERETIC_SISTERPALATINE
     cost: 192
     points: 50
     needItem: true
@@ -1670,13 +1670,13 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_HERETIC_SISTERCELEST 
+  - name: STR_HERETIC_SISTERCELEST
     cost: 192
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_ADEPTAS_ARMORS_DEP1 
+      - STR_ADEPTAS_ARMORS_DEP1
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
       - STR_THREAT_ONE
   - name: STR_SLAANESH_SISTER_SERAPH
@@ -1685,10 +1685,10 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_ADEPTAS_ARMORS_DEP1  
+      - STR_ADEPTAS_ARMORS_DEP1
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
       - STR_THREAT_ONE
-  
+
   - name: STR_ADEPTAS_SLAANCEL_CORPSE
     cost: 50
     points: 25
@@ -1725,7 +1725,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_HERETIC_SISTER_SERAPH 
+  - name: STR_HERETIC_SISTER_SERAPH
     cost: 150
     points: 50
     needItem: true
@@ -1734,14 +1734,14 @@ research:
       - STR_THREAT_ONE
       - STR_ADEPTAS_ARMORS_DEP1
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
-  - name: STR_NURGLE_SISTERHOSPITALLER 
+  - name: STR_NURGLE_SISTERHOSPITALLER
     cost: 192
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_NURGLE_BLIGHTED 
+  - name: STR_NURGLE_BLIGHTED
     cost: 100
     points: 50
     needItem: true
@@ -1765,8 +1765,8 @@ research:
   - name: STR_FILTH_SISTER_CORPSE
     cost: 50
     points: 25
-    needItem: true 
-  - name: STR_NURGLE_REBORNSISTER 
+    needItem: true
+  - name: STR_NURGLE_REBORNSISTER
     cost: 125
     points: 50
     needItem: true
@@ -1807,24 +1807,24 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE      
+      - STR_THREAT_ONE
 
-      
-  - name: STR_TZEENTCH_SISTERASS 
+
+  - name: STR_TZEENTCH_SISTERASS
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_REPENTIA_SUPERIOR 
+  - name: STR_REPENTIA_SUPERIOR
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_KHORNE_SISTERREPENT 
+  - name: STR_KHORNE_SISTERREPENT
     cost: 100
     points: 50
     needItem: true
@@ -1835,7 +1835,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_KHORNE_SISREPENTINFERIOR 
+  - name: STR_KHORNE_SISREPENTINFERIOR
     cost: 192
     points: 50
     needItem: true
@@ -1846,21 +1846,21 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_KHORNE_RETRIBUTOR_SUPERIOR  
+  - name: STR_KHORNE_RETRIBUTOR_SUPERIOR
     cost: 192
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_KHORNE_RETRIBUTOR 
+  - name: STR_KHORNE_RETRIBUTOR
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_ADEPTA_KHORNERETRIBUTOR_CORPSE 
+  - name: STR_ADEPTA_KHORNERETRIBUTOR_CORPSE
     cost: 50
     points: 25
     needItem: true
@@ -1900,7 +1900,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_KHORNE_SISTERASS 
+  - name: STR_KHORNE_SISTERASS
     cost: 150
     points: 50
     needItem: true
@@ -1918,27 +1918,27 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_FALLEN_SISTERDAEMONETTE 
+  - name: STR_FALLEN_SISTERDAEMONETTE
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_CANTUS 
+  - name: STR_SLAANESH_CANTUS
     cost: 100
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_NOVICE 
+  - name: STR_SLAANESH_NOVICE
     cost: 75
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-  - name: STR_SLAANESH_SISTERPALATINE  
+  - name: STR_SLAANESH_SISTERPALATINE
     cost: 150
     points: 50
     needItem: true
@@ -1953,7 +1953,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_SLAANESH_SISTERDOM_SUPERIOR   
+  - name: STR_SLAANESH_SISTERDOM_SUPERIOR
     cost: 192
     points: 50
     needItem: true
@@ -1967,28 +1967,28 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_PURPLESISTER 
+  - name: STR_SLAANESH_PURPLESISTER
     cost: 100
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_SISTER_BLESSED_TRUE 
+  - name: STR_SLAANESH_SISTER_BLESSED_TRUE
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_SISTER_BLESSED_FALSE 
+  - name: STR_SLAANESH_SISTER_BLESSED_FALSE
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_CHOSENASS 
+  - name: STR_SLAANESH_CHOSENASS
     cost: 192
     points: 50
     needItem: true
@@ -1999,7 +1999,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_SLAANESH_SISTERASS  
+  - name: STR_SLAANESH_SISTERASS
     cost: 150
     points: 50
     needItem: true
@@ -2010,7 +2010,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_SLAANESH_SISDEVOTED  
+  - name: STR_SLAANESH_SISDEVOTED
     cost: 150
     points: 50
     needItem: true
@@ -2021,14 +2021,14 @@ research:
     cost: 50
     points: 25
     needItem: true
-  - name: STR_SLAANESH_FBLESSED  
+  - name: STR_SLAANESH_FBLESSED
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_FBLESSED_FALSE 
+  - name: STR_SLAANESH_FBLESSED_FALSE
     cost: 150
     points: 50
     needItem: true
@@ -2046,7 +2046,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_DEMI_DAEMONETTE 
+  - name: STR_DEMI_DAEMONETTE
     cost: 150
     points: 50
     needItem: true
@@ -2060,7 +2060,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SLAANESH_CHOSEN 
+  - name: STR_SLAANESH_CHOSEN
     cost: 192
     points: 50
     needItem: true
@@ -2071,12 +2071,12 @@ research:
       - STR_COMMANDER_PLUS
       - STR_ALIEN_ORIGINS
       - STR_PSI_LAB
-    
-  - name: STR_SLAANSUP_CORPSE1   
+
+  - name: STR_SLAANSUP_CORPSE1
     cost: 50
     points: 25
     needItem: true
- 
+
   - name: STR_KHORNE_DEMIBLOODLETTERIN
     cost: 192
     points: 50
@@ -2105,7 +2105,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_KHORNE_DEMIBLOODLETTERIN_SUPERIOR 
+  - name: STR_KHORNE_DEMIBLOODLETTERIN_SUPERIOR
     cost: 192
     points: 50
     needItem: true
@@ -2130,11 +2130,11 @@ research:
       - STR_THREAT_ONE
       - STR_CHAOS_PATH
 
-  - name: STR_DIRE_DAEMONETTE_CORPSE 
+  - name: STR_DIRE_DAEMONETTE_CORPSE
     cost: 25
     points: 10
     needItem: true
-    
+
   - name: STR_SLAANESH_DEMIMONDE
     cost: 75
     points: 25
@@ -2148,7 +2148,7 @@ research:
     cost: 25
     points: 10
     needItem: true
-    
+
   - name: STR_SLAANGOR_FIENDGOR
     cost: 192
     points: 50
@@ -2197,7 +2197,7 @@ research:
     cost: 50
     points: 25
     needItem: true
- 
+
   - name: STR_SLAANFIENDGOR_CORPSE
     cost: 50
     points: 25
@@ -2236,21 +2236,21 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_IRON_WARRIOR 
+  - name: STR_IRON_WARRIOR
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_IRON_WARRIOR_BREACHER 
+  - name: STR_IRON_WARRIOR_BREACHER
     cost: 150
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_IRON_WARRIOR_HEAVY 
+  - name: STR_IRON_WARRIOR_HEAVY
     cost: 150
     points: 50
     needItem: true
@@ -2263,7 +2263,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE      
+      - STR_THREAT_ONE
   - name: STR_IRON_BERSERKER
     cost: 150
     points: 50
@@ -2298,12 +2298,12 @@ research:
   - name: STR_BLASTER_LAUNCHER
     dependencies: !remove
       - STR_HEAVY_PLASMA
-      
+
   - name: STR_IRON_MAIDEN_CORPSE
     cost: 50
     points: 25
     needItem: true
-    
+
   - name: STR_IRON_WARRIOR_CORPSE
     cost: 50
     points: 25
@@ -2346,9 +2346,9 @@ research:
       - STR_THREAT_ONE
       - STR_LEADER_PLUS
       - STR_CHAOS_PATH
-      
+
 #Alpha Legion
-  - name: STR_ALPHA_SOLDIER 
+  - name: STR_ALPHA_SOLDIER
     cost: 400
     points: 100
     needItem: true
@@ -2390,7 +2390,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_ALPHA_ELOHIM 
+  - name: STR_ALPHA_ELOHIM
     cost: 400
     points: 100
     needItem: true
@@ -2403,7 +2403,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE 
+      - STR_THREAT_ONE
   - name: STR_ALPHA_DAEMONETTE
     cost: 400
     points: 100
@@ -2423,14 +2423,14 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SECTOID_FEMCULTIST 
+  - name: STR_SECTOID_FEMCULTIST
     cost: 100
     points: 25
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_SECTOID_DARKDISCIPLE 
+  - name: STR_SECTOID_DARKDISCIPLE
     cost: 125
     points: 30
     needItem: true
@@ -2443,36 +2443,36 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE      
+      - STR_THREAT_ONE
   - name: STR_SECTOID_DARK_DISCIPLE_DAEMONETTE
     cost: 250
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE  
+      - STR_THREAT_ONE
   - name: STR_SECTOID_DARK_DISCIPLE_NEVERBORN
     cost: 250
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE  
+      - STR_THREAT_ONE
   - name: STR_DARK_APOSTLE_ALPHA
     cost: 250
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE    
-  - name: STR_NEVERBORN_TERRORIST 
+      - STR_THREAT_ONE
+  - name: STR_NEVERBORN_TERRORIST
     cost: 250
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE  
-      
+      - STR_THREAT_ONE
+
   - name: STR_ALPHA_LEGION_CORPSE
     cost: 50
     points: 25
@@ -2504,12 +2504,12 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-  - name: STR_KHORNEUNGOR_CORPSE 
+  - name: STR_KHORNEUNGOR_CORPSE
     cost: 50
     points: 25
     needItem: true
 
-  - name: STR_KHORNE_GOR 
+  - name: STR_KHORNE_GOR
     cost: 100
     points: 25
     needItem: true
@@ -2522,17 +2522,17 @@ research:
     needItem: true
 
 #Chaos Squats Interrogation
-  - name: STR_CHAOS_SQUATS 
+  - name: STR_CHAOS_SQUATS
     cost: 150
     points: 40
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-  - name: STR_CHAOS_SQUATS_CORPSE 
+  - name: STR_CHAOS_SQUATS_CORPSE
     cost: 50
     points: 25
     needItem: true
-  - name: STR_CHAOS_SQUATS_RANGER 
+  - name: STR_CHAOS_SQUATS_RANGER
     cost: 100
     points: 25
     needItem: true
@@ -2543,9 +2543,9 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED 
-      - STR_THREAT_ONE   
-  - name: STR_CHAOS_SQUATS_EXO 
+      - STR_INTERROGATION_COMPLETED
+      - STR_THREAT_ONE
+  - name: STR_CHAOS_SQUATS_EXO
     cost: 192
     points: 50
     needItem: true
@@ -2561,8 +2561,8 @@ research:
     points: 150
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED      
-  - name: STR_CHAOS_SQUATS_LEADER_CORPSE 
+      - STR_INTERROGATION_COMPLETED
+  - name: STR_CHAOS_SQUATS_LEADER_CORPSE
     cost: 50
     points: 25
     needItem: true
@@ -2578,7 +2578,7 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED      
+      - STR_INTERROGATION_COMPLETED
   - name: STR_TRAITOR_SQUATS_CORPSE
     cost: 50
     points: 25
@@ -2590,8 +2590,8 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE      
-  - name: STR_CULTIST_SQUATS_LEADER_CORPSE 
+      - STR_THREAT_ONE
+  - name: STR_CULTIST_SQUATS_LEADER_CORPSE
     cost: 50
     points: 25
     needItem: true
@@ -2600,13 +2600,13 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED 
+      - STR_INTERROGATION_COMPLETED
   - name: STR_CULTIST_SQUATS
     cost: 100
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED 
+      - STR_INTERROGATION_COMPLETED
   - name: STR_CULTIST_SQUATS_CORPSE
     cost: 50
     points: 25
@@ -2633,15 +2633,15 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE    
-  - name: STR_BLACKSTONE_STORMTROOPER_ELITE 
+      - STR_THREAT_ONE
+  - name: STR_BLACKSTONE_STORMTROOPER_ELITE
     cost: 192
     points: 50
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      - STR_THREAT_ONE          
-      
+      - STR_THREAT_ONE
+
   - name: STR_BLACKSTONE_STORMTROOPER_CORPSE
     cost: 50
     points: 25
@@ -2679,7 +2679,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
-      
+
 #Tzeentch cult
   - name: STR_PINK_HORROR_TERRORIST
     cost: 200
@@ -2707,7 +2707,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      
+
   - name: STR_TZAANGOR
     cost: 125
     points: 50
@@ -2749,7 +2749,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
 
-  - name: STR_TZEENTCH_FEM_CULTIST 
+  - name: STR_TZEENTCH_FEM_CULTIST
     cost: 100
     points: 25
     needItem: true
@@ -2787,7 +2787,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-      
+
   - name: STR_TZEENTCH_ACOLYTE
     cost: 125
     points: 40
@@ -2806,9 +2806,9 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED      
- 
-  - name: STR_TZEENTCH_CULT_WITCH     
+      - STR_INTERROGATION_COMPLETED
+
+  - name: STR_TZEENTCH_CULT_WITCH
     cost: 125
     points: 50
     needItem: true
@@ -2822,7 +2822,7 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED    
+      - STR_INTERROGATION_COMPLETED
 
   - name: STR_TZEENTCH_CULT_LEADER
     cost: 150
@@ -2853,7 +2853,7 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED    
+      - STR_INTERROGATION_COMPLETED
 
   - name: STR_TZEENTCH_CULT_POSSESSED
     cost: 150
@@ -2868,7 +2868,7 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED   
+      - STR_INTERROGATION_COMPLETED
 
   - name: STR_TZEENTCH_CULT_SUMMONER
     cost: 192
@@ -2880,13 +2880,13 @@ research:
       - STR_ALIEN_ORIGINS
       - STR_THREAT_ONE
       - STR_PSI_LAB
-      
+
   - name: STR_TZEENTCH_CULT_SUMMONER_CORPSE
     cost: 50
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED   
+      - STR_INTERROGATION_COMPLETED
 
 #Tzeentch traitor guard research
   - name: STR_TZEENTCH_BATTLE_SERVITOR_PLASMA
@@ -2900,7 +2900,7 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED   
+      - STR_INTERROGATION_COMPLETED
 
   - name: STR_TZEENTCH_COMBAT_SERVITOR
     cost: 192
@@ -2913,7 +2913,7 @@ research:
     points: 25
     needItem: true
     unlocks:
-      - STR_INTERROGATION_COMPLETED   
+      - STR_INTERROGATION_COMPLETED
 
   - name: STR_TZEENTCH_TRAITORGUARD_BASIC
     cost: 192
@@ -3019,23 +3019,23 @@ research:
       - STR_GSC_PENETANTE_FEMALE
       - STR_GSC_PENETANTE_LEEROY
       - STR_GSC_ENFORCER_MEDIC
- 
+
   - name: STR_GSC_DISCOVERY_INFECTION #1B
     requires:
      - STR_GSC_INITIAL_DISCOVERY
-     
+
   - name: STR_GSC_CULT_INITIAL_REPORT_ORIGINS #2A
     requires:
      - STR_GSC_INITIAL_DISCOVERY
-     
+
   - name: STR_ORDO_XENOS_INVESTIGATION #3A some sort of event chain hook to find their secret lair
     requires:
      - STR_GSC_CULT_INITIAL_REPORT_ORIGINS
-      
+
   - name: STR_GSC_XENO_INFECTION_TEST_RESULTS #2B
     requires:
-     - STR_GSC_DISCOVERY_INFECTION  
-   
+     - STR_GSC_DISCOVERY_INFECTION
+
   - name: STR_GSC_MEANS_OF_INFECTION #3B Fluff for Infection mechanics
     cost: 100
     points: 15
@@ -3044,12 +3044,12 @@ research:
      #- STR_ORDO_XENOS_INVESTIGATION
     dependencies:
      - STR_GSC_INTERROGATION_DEP1
-     
+
    #STR_GSC_CULT_FURTHER_LEADS #4A
    #STR_GSC_XENO_HYBRIDS #4B
    #STR_GSC_CULT_THE_TRUE_THREAT #5A
    #STR_GSX_XENO_GENESTEALER_LIFECYCLE #5B
-   
+
   - name: STR_CLOAKED_WOMAN
     cost: 25
     points: 15
@@ -3074,8 +3074,8 @@ research:
   - name: STR_GSC_ZOMBIE_CORPSE      #GENE CULT
     cost: 50
     points: 25
-    needItem: true      
-      
+    needItem: true
+
   - name: STR_GSC_CLOAKED_WOMAN
     cost: 50
     points: 15
@@ -3097,7 +3097,7 @@ research:
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_GSC_INTERROGATION_DEP1
-      
+
   - name: STR_GSC_CIVILIAN_F0
     cost: 50
     points: 15
@@ -3231,7 +3231,7 @@ research:
     needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
-  - name: STR_GSC_JUDGE_CORPSE 
+  - name: STR_GSC_JUDGE_CORPSE
     cost: 50
     points: 25
     needItem: true
@@ -3284,7 +3284,7 @@ research:
   - name: STR_GSC_ARMORED_CAR
     cost: 50
     points: 10
-    needItem: true  
+    needItem: true
   - name: STR_GSC_KRIEG_FEMALE
     cost: 50
     points: 10
@@ -3308,7 +3308,7 @@ research:
   - name: STR_GSC_TANITH_FEMALE
     cost: 50
     points: 10
-    needItem: true  
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_OGRYN
@@ -3320,7 +3320,7 @@ research:
   - name: STR_GSC_OGRYN_ORANGE
     cost: 50
     points: 10
-    needItem: true  
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_GUARD_FLAK_FEMALE
@@ -3332,7 +3332,7 @@ research:
   - name: STR_GSC_GUARD_FLAK_MALE
     cost: 50
     points: 10
-    needItem: true    
+    needItem: true
     unlocks:
      - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_GUARD_MEDIC_FEMALE
@@ -3344,7 +3344,7 @@ research:
   - name: STR_GSC_GUARD_MEDIC_MALE
     cost: 50
     points: 10
-    needItem: true    
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_GUARD_FLAK_OFFICER_FEMALE
@@ -3356,7 +3356,7 @@ research:
   - name: STR_GSC_GUARD_FLAK_OFFICER_MALE
     cost: 50
     points: 10
-    needItem: true   
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_GUARD_CARAPACE_FEMALE
@@ -3368,7 +3368,7 @@ research:
   - name: STR_GSC_GUARD_CARAPACE_MALE
     cost: 50
     points: 10
-    needItem: true   
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_GUARD_CARAPACE_MEDIC_FEMALE
@@ -3380,7 +3380,7 @@ research:
   - name: STR_GSC_GUARD_CARAPACE_MEDIC_MALE
     cost: 50
     points: 10
-    needItem: true 
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
   - name: STR_GSC_GUARD_CARAPACE_OFFICER_FEMALE
@@ -3393,7 +3393,7 @@ research:
   - name: STR_GSC_GUARD_CARAPACE_OFFICER_MALE
     cost: 50
     points: 10
-    needItem: true    
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
@@ -3407,7 +3407,7 @@ research:
   - name: STR_GSC_GUARD_SCION_MALE
     cost: 50
     points: 10
-    needItem: true  
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
@@ -3437,7 +3437,7 @@ research:
   - name: STR_GSC_COMMISSAR_MALE
     cost: 50
     points: 10
-    needItem: true     
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
@@ -3451,7 +3451,7 @@ research:
   - name: STR_GSC_COMMISSAR_CARAPACE_MALE
     cost: 50
     points: 10
-    needItem: true      
+    needItem: true
     unlocks:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
@@ -3466,7 +3466,7 @@ research:
   - name: STR_GSC_TANITH_CORPSE
     cost: 50
     points: 25
-    needItem: true  
+    needItem: true
   - name: STR_GSC_GUARD_FLAK_CORPSE
     cost: 50
     points: 25
@@ -3486,7 +3486,7 @@ research:
   - name: STR_GSC_GUARD_CARAPACE_CORPSE
     cost: 50
     points: 25
-    needItem: true   
+    needItem: true
   - name: STR_GSC_SCION_CORPSE
     cost: 50
     points: 25
@@ -3494,12 +3494,12 @@ research:
   - name: STR_GSC_PSYKER_CORPSE
     cost: 50
     points: 25
-    needItem: true    
+    needItem: true
   - name: STR_GSC_COMMISSAR_CORPSE
     cost: 50
     points: 25
-    needItem: true     
-    
+    needItem: true
+
   - name: STR_GSC_PDF_MEDIC
     cost: 100
     points: 25
@@ -3510,7 +3510,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-    
+
   - name: STR_GSC_MEDICAE
     cost: 100
     points: 25
@@ -3543,7 +3543,7 @@ research:
   - name: STR_GSC_ADEPTAS_CORPSE
     cost: 50
     points: 25
-    needItem: true   
+    needItem: true
 
   - name: STR_GENE_CULTIST   #GENE CULT
     cost: 100
@@ -3602,42 +3602,42 @@ research:
   - name: STR_LIBERATOR_AUTOSTUB_KELER
     cost: 300
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_LIBERATOR_AUTOSTUB
     cost: 250
     points: 25
-    needItem: true   
+    needItem: true
   - name: STR_AUTOSTUB_AMMO_VOLONIUM
     cost: 100
     points: 15
-    needItem: true  
+    needItem: true
   - name: STR_AUTOSTUB_AMMO
     cost: 100
     points: 15
-    needItem: true  
-    
+    needItem: true
+
   - name: STR_GSC_NEEDLER_RIFLE
     cost: 250
     points: 25
-    needItem: true 
+    needItem: true
 
   #- name: STR_GSC_AUTOINJECTOR_WEAPON #Not recovered for research
     #cost: 250
     #points: 25
-    #needItem: true 
-    
+    #needItem: true
+
   #- name: STR_GSC_MELEE #Not recovered for research
     #cost: 50
     #points: 10
     #needItem: true
-    
+
   - name: STR_GSC_HEAVY_WEBBER
     cost: 100
     points: 15
     needItem: true
     unlocks:
      - STR_IMPERIAL_WEBBER_DEP1
-  - name: STR_HEAVY_WEBBER_AMMO 
+  - name: STR_HEAVY_WEBBER_AMMO
     cost: 50
     points: 15
     needItem: true
@@ -3659,7 +3659,7 @@ research:
     cost: 50
     points: 15
     needItem: true
-    
+
 #ORK Interrogation (Needed for Ufopedia hooks)
 #  - name: STR_ORK_ARDESTBOY
 #    cost: 192
@@ -3714,8 +3714,8 @@ research:
     points: 50
     needItem: true
     unlocks:
-      - STR_ADEPTAS_ARMORS_DEP1 
-      - STR_ASS_ARMOR_DEP1 
+      - STR_ADEPTAS_ARMORS_DEP1
+      - STR_ASS_ARMOR_DEP1
       - STR_FELINID_JUMP_ARMOR_REQUISITION_DEP1
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
@@ -3786,11 +3786,11 @@ research:
       - STR_INTERROGATION_COMPLETED
       - STR_THREAT_ONE
       - STR_PSI_LAB
-  - name: STR_ORKWYRDBOY_CORPSE 
+  - name: STR_ORKWYRDBOY_CORPSE
     cost: 50
     points: 25
     needItem: true
-  - name: STR_ORK_FLASHGITZ 
+  - name: STR_ORK_FLASHGITZ
     cost: 192
     points: 50
     needItem: true
@@ -3827,16 +3827,16 @@ research:
     cost: 50
     points: 5
     needItem: true
-    
+
   - name: STR_SNEAKY_SLUGGA
     cost: 100
     points: 25
     needItem: true
-  - name: STR_AMMO_BIT10SNEAKY 
+  - name: STR_AMMO_BIT10SNEAKY
     cost: 50
     points: 25
-    needItem: true 
-    
+    needItem: true
+
   - name: STR_SNAZZ_GUN
     cost: 200
     points: 25
@@ -3867,7 +3867,7 @@ research:
     points: 25
     needItem: true
 
-  - name: STR_DEFFKOPTER_ROKKITPOD 
+  - name: STR_DEFFKOPTER_ROKKITPOD
     cost: 150
     points: 25
     needItem: true
@@ -3883,18 +3883,18 @@ research:
     cost: 250
     points: 25
     needItem: true
-    
+
   - name: STR_ORK_SNIPER_RIFLE
     cost: 150
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: STR_ORK_AUTOCANNON_CLIP
     cost: 100
     points: 25
     unlocks:
       - STR_ASSC_DEP1
-    needItem: true 
+    needItem: true
 
 #Deserters
   - name: STR_DESERTER_SCOUT_CORPSE
@@ -3995,7 +3995,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-    
+
   - name: STR_NURGLE
     points: 50
     needItem: true
@@ -4063,7 +4063,7 @@ research:
     points: 25
     needItem: true
 
-  - name: STR_IRON_GUARD_SOLDIER 
+  - name: STR_IRON_GUARD_SOLDIER
     cost: 100
     points: 50
     needItem: true
@@ -4078,60 +4078,60 @@ research:
   - name: STR_IRON_GUARD_CORPSE
     cost: 50
     points: 25
-    needItem: true      
-     
+    needItem: true
+
 #CHAOS GENERAL WEAPONS
   - name: STR_CHAOS_RIPPERGUN
     cost: 50
     points: 25
-    needItem: true 
-    
+    needItem: true
+
   - name: STR_HEAVY_STUBBER_CHAOS
     cost: 50
     points: 25
-    needItem: true 
-    
+    needItem: true
+
   - name: STR_LONGLAS_CHAOS
     cost: 150
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_LONGLAS_TZEENTCH
     cost: 150
     points: 25
-    needItem: true 
-    
+    needItem: true
+
   - name: STR_CHAOS_HELLGUN
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_CHAOS_VOLLEYGUN
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: STR_CHAOS_LASCANNON_HANDHELD
     cost: 150
     points: 25
-    needItem: true 
+    needItem: true
   - name: STR_CHAOS_LASCANNON_BIPOD
     cost: 150
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: STR_CHAOS_ROCKET_LAUNCHER
     cost: 150
     points: 25
-    needItem: true 
-   
+    needItem: true
+
   - name: STR_IW_AUTOCANNON
     cost: 150
     points: 25
-    needItem: true 
-    
+    needItem: true
+
   - name: STR_LASGUN_CLIP_HOTSHOT_CHAOS
     cost: 100
     points: 25
-    needItem: true 
+    needItem: true
 
   - name: STR_NECRON_WARRIOR_CORPSE
     cost: 50
@@ -4294,7 +4294,7 @@ research:
     cost: 50
     points: 25
     needItem: true
-  
+
 
 #---ITEMS------------------------------------------------------
 
@@ -4302,20 +4302,20 @@ research:
 
   - name: STR_MEDIUM_SCOUT_DOUBLE_TOWER
     points: 50
-    needItem: true     
+    needItem: true
   - name: STR_LARGE_SCOUT_BRIDGED_TOWERS
     points: 50
-    needItem: true    
+    needItem: true
   - name: STR_MOBILE_FORT
     points: 50
-    needItem: true  
+    needItem: true
   - name: STR_SUPPLY_SHIP_FAST
     points: 50
     needItem: true
   - name: STR_SUPPLY_SHIP_FAST2
     points: 50
     needItem: true
-  - name: STR_LARGE_SCOUT_HEAVY 
+  - name: STR_LARGE_SCOUT_HEAVY
     points: 50
     needItem: true
   - name: STR_LARGE_SCOUT_HAMMERHEAD
@@ -4330,10 +4330,10 @@ research:
   - name: STR_TERROR_SHIP_ROSIGMA
     points: 50
     needItem: true
- 
+
   - name: STR_GSC_TAUROX
     points: 50
-    needItem: true  
+    needItem: true
   - name: STR_GSC_TAUROX_CONVOY
     points: 50
     needItem: true

--- a/Ruleset/scripts/scripts_infection_items.rul
+++ b/Ruleset/scripts/scripts_infection_items.rul
@@ -3,7 +3,7 @@ extended:
     RuleItem:
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
 items:
 

--- a/Ruleset/scripts/scripts_infection_mechanics.rul
+++ b/Ruleset/scripts/scripts_infection_mechanics.rul
@@ -10,7 +10,7 @@ extended:
     RuleItem:
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     RuleArmor:
       INFECTION_RESIST: int #reduces infection damage by this as a %
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
@@ -82,7 +82,7 @@ extended:
           var int temp;
           var int infectionDamage; #percent of damage the triggering attack inflicts
           var int infectionDamageFlat; #flat amount of dmaage the triggering attack inflicts
-          var int infectionType; #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh
+          var int infectionType; #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
           var int currentInfectionType; #the victim's current infection type if any
           var int currentInfectionDamage; #the victim's current infection damage if any
           var int infectionPercentage; #what percentage of damage dealt accrues as infection
@@ -101,18 +101,75 @@ extended:
             return;
           end;
 
-          armorRule.getTag infectionResist Tag.INFECTION_RESIST; #if our infection resist is 100% we don't bother with the rest
-          if ge infectionResist 100;
+          armorRule.getTag infectionResistType Tag.INFECTION_RESIST_TYPE; #if our infection resist is 100% and applies to all infection types we're immune; abort
+          armorRule.getTag infectionResist Tag.INFECTION_RESIST;
+          if and ge infectionResist 100 le infectionResistType 0;
             return;
           end;
 
-          #we're not a 2x2, we've done damage and we're not immune to infection; it's time to set our other variables
+          #we're not a 2x2, we've done damage and we're not totally immune to infection; it's time to set our other variables
           weapon_item.getRuleItem itemRule;
           weapon_item.getAmmoItem ammoItem;
+          #debug_log "Infection Scripts; damageUnit, offset 22: Initialize, Target:" unit;
           #debug_log "Infection Scripts; damageUnit, offset 22: Initialize, Weapon:" itemRule;
           #debug_log "Infection Scripts; damageUnit, offset 22: Initialize, Ammo:" ammoItem;
-
           ammoItem.getTag infectionType Tag.INFECTION_TYPE;
+          if le infectionType 0; #if we still have no infection type, check the weapon
+            weapon_item.getTag infectionType Tag.INFECTION_TYPE;
+            if le infectionType 0; #if we *still* have no infection type, cancel out
+              #debug_log "Infection Scripts; damageUnit, offset 22: No infection type detected; aborting.";
+              return;
+            end;
+          end;
+
+          #if our infection is specific to a type, define that check if our infection resistance type applies
+          if gt infectionResistType 0;
+            set temp 0; #reset the temp var
+            if eq infectionType 1; #check Nurgle typing
+              if or eq infectionResistType 1 eq infectionResistType 3 eq infectionResistType 5 eq infectionResistType 9;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: Nurgle infection resisted:" infectionResistType;
+              else or eq infectionResistType 7 eq infectionResistType 11 eq infectionResistType 13;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: Nurgle infection resisted:" infectionResistType;
+              end;
+            else eq infectionType 2; #check GSC typing
+              if or eq infectionResistType 2 eq infectionResistType 3 eq infectionResistType 6 eq infectionResistType 10;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: GSC infection resisted:" infectionResistType;
+              else or eq infectionResistType 7 eq infectionResistType 11 eq infectionResistType 14;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: GSC infection resisted:" infectionResistType;
+              end;
+            else eq infectionType 3; #check Slaanesh typing
+              if or eq infectionResistType 4 eq infectionResistType 5 eq infectionResistType 6 eq infectionResistType 12;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: Slaanesh infection resisted:" infectionResistType;
+              else or eq infectionResistType 7 eq infectionResistType 13 eq infectionResistType 14;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: Slaanesh infection resisted:" infectionResistType;
+              end;
+            else eq infectionType 4; #check Tzeentch typing
+              if or eq infectionResistType 8 eq infectionResistType 9 eq infectionResistType 10 eq infectionResistType 12;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: Slaanesh infection resisted:" infectionResistType;
+              else or  eq infectionResistType 11 eq infectionResistType 13 eq infectionResistType 14;
+                set temp 1;
+                #debug_log "Infection Scripts; damageUnit, offset 22: Slaanesh infection resisted:" infectionResistType;
+              end;
+            end;
+            #after checking our infection resist types, zero out infection resist/reduction if temp is false; i.e. we don't resist this particular infection type
+            if neq temp 1;
+              set infectionResist 0;
+              set infectionReduction 0;
+            end;
+          end;
+
+          if ge infectionResist 100; #again, don't bother proceeding if we have 100% resistance to this infection type
+            #debug_log "Infection Scripts; damageUnit, offset 22: Immune to detected infection type; aborting.";
+            return;
+          end;
+
           ammoItem.getTag infectionDamageFlat Tag.INFECTION_DAMAGE_FLAT;
           ammoItem.getTag infectionPercentage Tag.INFECTION_DAMAGE_PERCENT;
 
@@ -123,20 +180,6 @@ extended:
           add infectionPercentage temp;
           limit_upper infectionPercentage 100; #for now, cap infection percent at 100%
 
-          if le infectionType 0; #if we still have no infection type, check the weapon
-            weapon_item.getTag infectionType Tag.INFECTION_TYPE;
-            if le infectionType 0; #if we still have no infection type, cancel out
-              #debug_log "Infection Scripts; damageUnit, offset 22: No infection type detected; aborting.";
-              return;
-            end;
-          end;
-
-          unit.getTag currentInfectionType Tag.CURRENT_INFECTION_TYPE;
-          unit.getTag currentInfectionDamage Tag.CURRENT_INFECTION_DAMAGE;
-          armorRule.getTag infectionReduction Tag.INFECTION_RESIST;
-          armorRule.getTag infectionResistType Tag.INFECTION_RESIST_TYPE;
-
-          #debug_log "Infection Scripts; damageUnit, offset 22: Initialize, Unit:" unit;
           #debug_log "Infection Scripts; damageUnit, offset 22: Initialize, infectionDamageFlat:" infectionDamageFlat;
           #debug_log "Infection Scripts; damageUnit, offset 22: Initialize, infectionPercentage:" infectionPercentage;
 
@@ -147,51 +190,24 @@ extended:
           muldiv infectionPercentage to_health 100;
           add infectionDamage infectionPercentage;
 
-          #if our infection is specific to a type, define that check if our infection resistance type applies
-          if gt infectionResistType 0;
-            set temp 0; #reset the temp var
-            #check Nurgle typing
-            if eq infectionType 1;
-              if or neq infectionResistType 1 neq infectionResistType 3 neq infectionResistType 5;
-                set temp 1; #this means we zero out infection resist and reduction at the end of this section
-                #debug_log "Infection Scripts; damageUnit, offset 22: Nurgle infection not resisted:" infectionResistType;
-              end;
-            end;
-            #check GSC typing
-            if and eq infectionType 2 neq temp 1;
-              if or neq infectionResistType 2 neq infectionResistType 3 neq infectionResistType 6;
-                set temp 1; #this means we zero out infection resist and reduction at the end of this section
-                #debug_log "Infection Scripts; damageUnit, offset 22: GSC infection not resisted:" infectionResistType;
-              end;
-            end;
-            #check Slaanesh typing
-            if and eq infectionType 3 neq temp 1;
-              if or neq infectionResistType 3 neq infectionResistType 5 neq infectionResistType 6;
-                set temp 1; #this means we zero out infection resist and reduction at the end of this section
-                #debug_log "Infection Scripts; damageUnit, offset 22: Slaanesh infection not resisted:" infectionResistType;
-              end;
-            end;
-            #after checking our infection resist types, zero out infection resist/reduction if temp is true; i.e. we don't resist this particular infection type
-            if eq temp 1;
-              set infectionResist 0;
-              set infectionReduction 0;
-            end;
-          end;
-
+          armorRule.getTag infectionReduction Tag.INFECTION_RESIST;
           if gt infectionReduction 0; #only proceed if infectionReduction isn't null; subtract our infection reduction
             sub infectionDamage infectionReduction;
             limit_lower infectionDamage 0; #cannot go lower than 0
           end;
 
           if gt infectionResist 0; #only proceed if infectionResist isn't null; apply infection resistance as a %
-            limit_lower infectionResist 100; #cannot go lower than 0
+            limit_lower infectionResist 0; #cannot go lower than 0
             limit_upper infectionResist 100; #cannot go higher than 100
             sub infectionResist 100; #invert infectionResist
             mul infectionResist -1; #invert infectionResist
             muldiv infectionDamage infectionResist 100;
           end;
 
-          #cannot have multiple infection types; the infection with higher damage takes priority
+          #cannot have multiple infection types; the infection with higher damage takes priority; set appropriate variables
+          unit.getTag currentInfectionType Tag.CURRENT_INFECTION_TYPE;
+          unit.getTag currentInfectionDamage Tag.CURRENT_INFECTION_DAMAGE;
+
           if and neq currentInfectionType 0 neq infectionType currentInfectionType;
             #debug_log "Infection Scripts; damageUnit, offset 22: InfectionType Mismatch; currentInfectionType:" currentInfectionType;
             #debug_log "Infection Scripts; damageUnit, offset 22: InfectionType Mismatch; infectionType:" infectionType;
@@ -236,51 +252,49 @@ extended:
 
           #set infection thresholds
           unit.getTag infectionType Tag.CURRENT_INFECTION_TYPE;
-          set INFECTION_LOW_THRESHOLD 10;
-          set INFECTION_MID_THRESHOLD 30;
-          set INFECTION_HIGH_THRESHOLD 60;
+          set INFECTION_LOW_THRESHOLD 20;
+          set INFECTION_MID_THRESHOLD 40;
+          set INFECTION_HIGH_THRESHOLD 80;
 
           unit.getHealth remainingHealth;
           sub remainingHealth to_health;
 
           if le remainingHealth 0; # gets killed by this attack
-            #if Nurgle
             #debug_log "Infection Scripts; damageUnit, offset 23: Fatal Damage Incurred; Remaining Health:" remainingHealth;
-            if eq infectionType 1;
-              if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
-                rules.getRuleUnit myRuleUnit "STR_NURGLE_ZOMBIE";
-              end;
-              if and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Boomer Zombie
-                rules.getRuleUnit myRuleUnit "STR_NURGLE_BOOMER";
-              end;
-              if and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Plaguebearer
-                rules.getRuleUnit myRuleUnit "STR_CELATID_TERRORIST";
-              end;
-              if gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection; spawns Midwife of Nurgle
-                rules.getRuleUnit myRuleUnit "STR_NURGLE_DAEMONETTE";
-              end;
+          if eq infectionType 1; #if Nurgle
+            if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
+              rules.getRuleUnit myRuleUnit "STR_NURGLE_ZOMBIE";
+            else and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Boomer Zombie
+              rules.getRuleUnit myRuleUnit "STR_NURGLE_BOOMER";
+            else and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Plaguebearer
+              rules.getRuleUnit myRuleUnit "STR_CELATID_TERRORIST";
+            else; #very high level infection; spawns Midwife of Nurgle
+              rules.getRuleUnit myRuleUnit "STR_NURGLE_DAEMONETTE";
             end;
+          else eq infectionType 2; #if GSC
+            rules.getRuleUnit myRuleUnit "STR_GSC_ZOMBIE"; #only basic zombies
+          else eq infectionType 3; #if Slaanesh
+            if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
+              rules.getRuleUnit myRuleUnit "STR_ZOMBIE";
+            else and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Lesser Daemonette
+              rules.getRuleUnit myRuleUnit "STR_CHRYSSALID_TERRORISTSELENE";
+            else and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Daemonette
+              rules.getRuleUnit myRuleUnit "STR_CHRYSSALID_TERRORIST";
+            else; #very high level infection; spawns Dire Daemonette
+              rules.getRuleUnit myRuleUnit "STR_DIRE_DAEMONETTE";
+            end;
+          else eq infectionType 4; #if Tzeentch
+            if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
+              rules.getRuleUnit myRuleUnit "STR_BLUE_HORROR_TERRORIST";
+            else and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection
+              rules.getRuleUnit myRuleUnit "STR_TZEENTCH_LESSER_DAEMON";
+            else and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection
+              rules.getRuleUnit myRuleUnit "STR_FLAMER_TERRORIST";
+            else; #very high level infection
+              rules.getRuleUnit myRuleUnit "STR_PINK_HORROR_TERRORIST";
+            end;
+          end;
 
-            #if GSC
-            if eq infectionType 2;
-              rules.getRuleUnit myRuleUnit "STR_GSC_ZOMBIE"; #only basic zombies
-            end;
-
-            #if Slaanesh
-            if eq infectionType 3;
-              if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
-                rules.getRuleUnit myRuleUnit "STR_ZOMBIE";
-              end;
-              if and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Lesser Daemonette
-                rules.getRuleUnit myRuleUnit "STR_CHRYSSALID_TERRORISTSELENE";
-              end;
-              if and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Daemonette
-                rules.getRuleUnit myRuleUnit "STR_CHRYSSALID_TERRORIST";
-              end;
-              if gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection; spawns Dire Daemonette
-                rules.getRuleUnit myRuleUnit "STR_DIRE_DAEMONETTE";
-              end;
-            end;
           #debug_log "Infection Scripts; damageUnit, offset 23: Spawn Unit:" myRuleUnit;
           unit.setSpawnUnit myRuleUnit;
           unit.setSpawnUnitInstantRespawn 1;
@@ -328,45 +342,43 @@ extended:
           sub remainingHealth infectionDamage;
           if le remainingHealth 0; # gets killed
 
-            set INFECTION_LOW_THRESHOLD 10;
-            set INFECTION_MID_THRESHOLD 30;
-            set INFECTION_HIGH_THRESHOLD 60;
+            set INFECTION_LOW_THRESHOLD 20;
+            set INFECTION_MID_THRESHOLD 40;
+            set INFECTION_HIGH_THRESHOLD 80;
 
             #debug_log "Infection Scripts; newTurnUnit, offset 22: Fatal Damage Incurred; Remaining Health:" remainingHealth;
             #if Nurgle
             if eq infectionType 1;
               if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
                 rules.getRuleUnit myRuleUnit "STR_NURGLE_ZOMBIE";
-              end;
-              if and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Boomer Zombie
+              else and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Boomer Zombie
                 rules.getRuleUnit myRuleUnit "STR_NURGLE_BOOMER";
-              end;
-              if and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Plaguebearer
+              else and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Plaguebearer
                 rules.getRuleUnit myRuleUnit "STR_CELATID_TERRORIST";
-              end;
-              if gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection; spawns Midwife of Nurgle
+              else gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection; spawns Midwife of Nurgle
                 rules.getRuleUnit myRuleUnit "STR_NURGLE_DAEMONETTE";
               end;
-            end;
-
-            #if GSC
-            if eq infectionType 2;
+            else eq infectionType 2; #if GSC
               rules.getRuleUnit myRuleUnit "STR_GSC_ZOMBIE"; #only basic zombies
-            end;
-
-            #if Slaanesh
-            if eq infectionType 3;
+            else eq infectionType 3; #if Slaanesh
               if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
                 rules.getRuleUnit myRuleUnit "STR_ZOMBIE";
-              end;
-              if and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Lesser Daemonette
+              else and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection; spawns Lesser Daemonette
                 rules.getRuleUnit myRuleUnit "STR_CHRYSSALID_TERRORISTSELENE";
-              end;
-              if and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Daemonette
+              else and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection; spawns Daemonette
                 rules.getRuleUnit myRuleUnit "STR_CHRYSSALID_TERRORIST";
-              end;
-              if gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection; spawns Dire Daemonette
+              else gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection; spawns Dire Daemonette
                 rules.getRuleUnit myRuleUnit "STR_DIRE_DAEMONETTE";
+              end;
+            else eq infectionType 4; #if Tzeentch
+              if le infectionDamage INFECTION_LOW_THRESHOLD; #low level infection
+                rules.getRuleUnit myRuleUnit "STR_BLUE_HORROR_TERRORIST";
+              else and gt infectionDamage INFECTION_LOW_THRESHOLD le infectionDamage INFECTION_MID_THRESHOLD; #mid level infection
+                rules.getRuleUnit myRuleUnit "STR_TZEENTCH_LESSER_DAEMON";
+              else and gt infectionDamage INFECTION_MID_THRESHOLD le infectionDamage INFECTION_HIGH_THRESHOLD; #high level infection
+                rules.getRuleUnit myRuleUnit "STR_FLAMER_TERRORIST";
+              else and gt infectionDamage INFECTION_HIGH_THRESHOLD; #very high level infection
+                rules.getRuleUnit myRuleUnit "STR_PINK_HORROR";
               end;
             end;
 
@@ -442,12 +454,12 @@ extended:
           if gt infectionDamage 0;
             if eq infectionType 1;
               set_color new_pixel COLOR_X1_GREEN0; #Nurgle infection
-            end;
-            if eq infectionType 2;
+            else eq infectionType 2;
               set_color new_pixel COLOR_X1_PURPLE0; #GSC infection
-            end;
-            if eq infectionType 3;
+            else eq infectionType 3;
               set_color new_pixel COLOR_X1_PURPLE1; #Slaanesh infection
+            else eq infectionType 4;
+              set_color new_pixel COLOR_X1_BLUE1; #Tzeentch infection
             end;
           end;
 
@@ -470,12 +482,12 @@ extended:
               if gt infectionDamage 0;
                 if eq infectionType 1;
                   set_color new_pixel COLOR_X1_GREEN0; #Nurgle infection
-                end;
-                if eq infectionType 2;
+                else eq infectionType 2;
                   set_color new_pixel COLOR_X1_PURPLE0; #GSC infection
-                end;
-                if eq infectionType 3;
+                else eq infectionType 3;
                   set_color new_pixel COLOR_X1_PURPLE1; #Slaanesh infection
+                else eq infectionType 4;
+                  set_color new_pixel COLOR_X1_BLUE1; #Tzeentch infection
                 end;
               end;
             end;

--- a/Ruleset/vars40k.rul
+++ b/Ruleset/vars40k.rul
@@ -31,18 +31,20 @@ bughuntRank: 0 # rank 0 are VIPs, meaning that it will never activate if there i
 bughuntLowMorale: 40 # default value
 bughuntTimeUnitsLeft: 60 # default value
 transparencyLUTs:
- - colors: # R, G, B, Opacity, 0-16 values
-     - [10, 9, 8, 8] # 0 smoke
-     - [16, 6, 2, 12] # 1 flames
-     - [8, 16, 0, 4] # 2 toxic green
-     - [12, 0, 14, 4] # 3 toxic purple
-     - [16, 0, 4, 1] # 4 red lazor
-     - [10, 16, 6, 1] # 5 plasma green beam
-     - [16, 12, 4, 1] # 6 pure gold beam
-     - [2, 2, 16, 1] # 7 pure blue beam
-     - [16, 4, 0, 1] # 8 gauss
-     - [0, 6, 14, 4] # 9 toxic blue
-     - [8, 8, 12, 2] # 10 underwater
-     - [8, 12, 8, 2] # 11 underwater sonic
-     - [4, 16, 0, 4] # 12 green xom
-     - [14, 14, 16, 12] # 13 silver flames
+  - colors: # R, G, B, Opacity, 0-16 values
+    - [10, 9, 8, 8] # 0 smoke
+    - [16, 6, 2, 12] # 1 flames
+    - [8, 16, 0, 4] # 2 toxic green
+    - [12, 0, 14, 4] # 3 toxic purple
+    - [16, 0, 4, 1] # 4 red lazor
+    - [10, 16, 6, 1] # 5 plasma green beam
+    - [16, 12, 4, 1] # 6 pure gold beam
+    - [2, 2, 16, 1] # 7 pure blue beam
+    - [16, 4, 0, 1] # 8 gauss
+    - [0, 6, 14, 4] # 9 toxic blue
+    - [8, 8, 12, 2] # 10 underwater
+    - [8, 12, 8, 2] # 11 underwater sonic
+    - [4, 16, 0, 4] # 12 green xom
+    - [14, 14, 16, 12] # 13 silver flames
+    - [2, 4, 16, 2] # 14 blue warpfire
+    - [16, 4, 8, 2] # 15 pink warpfire


### PR DESCRIPTION
1. Expanded and improved the infection scripts to include Tzeentch corruption. Most Tzeentch spells and daemonic melee inflicts some level of Tzeentch corruption.

2. Inferno Bolter ammo stats changed to behave closer to canon (i.e. potentially igniting targets with fire, melting armor; higher ToArmorPre).

3. Changed Tzeentch Flamer daemons to have a short range pink fire flamethrower attack and a medium ranged multi-melta style attack.

4. Changed Glimmering Daemons to resist energy/heat based attacks but resist physical ones. Gave them a rapid fire warp fire attack for close range and a scattershot warpfire attack for medium range.

5. Pink Horrors now spawn two Blue Horrors as they should with a spawner grenade that only activates on death.

6. Rubric Marines and Tzeentch Daemons made immune to infection/corruption.

7. Rubric Marines made immune to bleed and pain (they're dust in an armor shell).