### PR TITLE
Bomberman Script Improvements

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -1394,7 +1394,6 @@ en-US:
   STR_NURGLE_BOOMER: "Blighted Boomer"
   STR_NURGLE_BOOMER_CORPSE: "Boomer Corpse"
   STR_NURGLE_BOOMER_ARMOR: "Nurgle Boomer"
-  STR_NURGLE_BOOM_DUMMY: "Blight Boomer"
   STR_NURGLE_BOOM: "Blight Boom"
   STR_NURGLE_CULTIST_LIGHT: "Nurgle Light Cultist"
   STR_NURGLE_CULTIST: "Nurgle Cultist"

--- a/Language/ru.yml
+++ b/Language/ru.yml
@@ -1391,7 +1391,6 @@ ru:
   STR_NURGLE_BOOMER: "Оскверненный Зазывала"
   STR_NURGLE_BOOMER_CORPSE: "Труп Зазывалы"
   STR_NURGLE_BOOMER_ARMOR: "Зазывала Нургла"
-  STR_NURGLE_BOOM_DUMMY: "Скверный Зазывала"
   STR_NURGLE_BOOM: "Скверный Зазывала"
   STR_NURGLE_CULTIST_LIGHT: "Культист Нургла"
   STR_NURGLE_CULTIST: "Культист Нургла"

--- a/Ruleset/ENEMY/GENE/armors_gene.rul
+++ b/Ruleset/ENEMY/GENE/armors_gene.rul
@@ -7,6 +7,8 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
 
 armors:
   - type: STR_GSC_ZOMBIE_ARMOR  # GSC ZOMBIE ARMOR
@@ -725,10 +727,11 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 3 ]
-    specialWeapon: STR_EXPLOSIVE_COLLAR_DUMMY
     tags:
       INFECTION_RESIST: 100
       INFECTION_RESIST_TYPE: 2 #immune to GSC infection
+      ARMOR_IS_EXPLODE_ON_DEATH: 1 #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: 1 #do we kamikazi when we hit regardless of the weapon used?
 
   - type: STR_GSC_PENETANTE_ARMOR #male
     visibilityAtDay: 30
@@ -756,10 +759,11 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 3 ]
-    specialWeapon: STR_EXPLOSIVE_COLLAR_DUMMY
     tags:
       INFECTION_RESIST: 100
       INFECTION_RESIST_TYPE: 2 #immune to GSC infection
+      ARMOR_IS_EXPLODE_ON_DEATH: 1 #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: 1 #do we kamikazi when we hit regardless of the weapon used?
 
   - type: STR_GSC_ENFORCER_MEDIC_ARMOR #GSC Infector unit
     visibilityAtDay: 30

--- a/Ruleset/ENEMY/GENE/units_gene.rul
+++ b/Ruleset/ENEMY/GENE/units_gene.rul
@@ -4,7 +4,7 @@ units:
     race: STR_GENE_CULT
     rank: STR_LIVE_TERRORIST
     stats:
-      tu: 50 
+      tu: 50
       stamina: 80
       health: 60 #GSC Healthy but not super
       bravery: 110 #GSC Mind juice
@@ -27,7 +27,7 @@ units:
     isLeeroyJenkins: true
     energyRecovery: 50
     livingWeapon: true
-    
+
   - type: STR_GENE_CULTIST                                       # RANK 4 weapons done
     race: STR_GENE_CULT
     rank: STR_LIVE_SOLDIER
@@ -40,7 +40,7 @@ units:
       firing: 60
       throwing: 55
       strength: 50 #GSC gene boost
-      psiStrength: 50 
+      psiStrength: 50
       psiSkill: 0
       melee: 60
     armor: STR_GC_ARMOR
@@ -70,7 +70,7 @@ units:
       firing: 60
       throwing: 55
       strength: 50 #GSC gene boost
-      psiStrength: 50 
+      psiStrength: 50
       psiSkill: 0
       melee: 60
     armor: STR_GC2_ARMOR
@@ -98,7 +98,7 @@ units:
       firing: 65
       throwing: 55
       strength: 50 #GSC gene boost
-      psiStrength: 50 
+      psiStrength: 50
       psiSkill: 0
       melee: 50
     armor: STR_GC3_ARMOR
@@ -179,7 +179,7 @@ units:
     standHeight: 21
     kneelHeight: 16
     value: 15
-    deathSound: [2232, 2233, 2234, 2235, 2006, 2008, 2226] 
+    deathSound: [2232, 2233, 2234, 2235, 2006, 2008, 2226]
     intelligence: 4
     moraleLossWhenKilled: 40 #GSC cares little of own losses, fanatical juice
     aggression: 2
@@ -196,15 +196,15 @@ units:
       - - STR_LIBERATOR_AUTOSTUB_KELER
         - STR_AUTOSTUB_AMMO_VOLONIUM
         - STR_AUTOSTUB_AMMO_VOLONIUM
-        - STR_AUTOSTUB_AMMO_VOLONIUM 
-        
+        - STR_AUTOSTUB_AMMO_VOLONIUM
+
 #*** Infected + new GSC Civilians ***
   - type: STR_CLOAKED_WOMAN #Imperial Citizen Tan
     race: STR_CIVILIAN
     stats:
       tu: 40
       stamina: 50
-      health: 30 
+      health: 30
       bravery: 50
       reactions: 20
       firing: 25
@@ -228,7 +228,7 @@ units:
     stats:
       tu: 40
       stamina: 50
-      health: 30 
+      health: 30
       bravery: 50
       reactions: 20
       firing: 25
@@ -252,7 +252,7 @@ units:
     stats:
       tu: 40
       stamina: 50
-      health: 30 
+      health: 30
       bravery: 50
       reactions: 20
       firing: 25
@@ -365,7 +365,7 @@ units:
       - - STR_KNIF
       - - STR_KNIF
         - STR_MAKESHIFT_PIPEBOMB
-        
+
   - type: STR_GSC_CIVILIAN_F0 #Casual clothing
     race: STR_CIVILIAN
     stats:
@@ -574,7 +574,7 @@ units:
       - - STR_FLAMETHROWER_CHAOS
         - STR_FLAMETHROWER_CLIP
 
-  - type: STR_GSC_PENETANTE_FEMALE #Non explosive 
+  - type: STR_GSC_PENETANTE_FEMALE #Non explosive
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_SOLDIER
     stats:
@@ -664,7 +664,7 @@ units:
       psiStrength: 30
       psiSkill: 0
       melee: 70 #melee specialist
-    armor: STR_GSC_ENFORCER_SHIELD_ARMOR 
+    armor: STR_GSC_ENFORCER_SHIELD_ARMOR
     standHeight: 21
     kneelHeight: 15
     intelligence: 2
@@ -676,7 +676,7 @@ units:
     livingWeapon: true
     moveSound: -1
     builtInWeaponSets:
-      - - STR_STUN_ROD 
+      - - STR_STUN_ROD
         - STR_PHOTON_GRENADE
       - - STR_SMG_STUB_GUN
         - STR_STUB_GUN_AMMO_LONG
@@ -687,7 +687,7 @@ units:
         - STR_STUN_GAS_SHELLS
         - STR_PHOTON_GRENADE
 
-  - type: STR_GSC_ENFORCER_HEAVY #female 
+  - type: STR_GSC_ENFORCER_HEAVY #female
     race: STR_GSC_ARBITES_FACTION
     rank: STR_LIVE_SOLDIER
     stats:
@@ -695,14 +695,14 @@ units:
       stamina: 80 #GSC stamina
       health: 60 #GSC healthy
       bravery: 90 #+30 bravery, nearly fearless due to genestealer control
-      reactions: 50 
+      reactions: 50
       firing: 50 #slightly worse than GSC PDF
       throwing: 55
       strength: 50 #GSC gene boost
       psiStrength: 30
       psiSkill: 0
-      melee: 60 
-    armor: STR_GSC_ENFORCER_HEAVY_ARMOR 
+      melee: 60
+    armor: STR_GSC_ENFORCER_HEAVY_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 2
@@ -719,14 +719,14 @@ units:
         - STR_STUN_ROD
         - STR_PHOTON_GRENADE
       - - STR_PUMP_SHOTGUN
-        - STR_STUN_GAS_SHELLS 
-        - STR_STUN_GAS_SHELLS 
+        - STR_STUN_GAS_SHELLS
+        - STR_STUN_GAS_SHELLS
         - STR_PHOTON_GRENADE
       - - STR_GSC_HEAVY_WEBBER
         - STR_HEAVY_WEBBER_AMMO
         - STR_PHOTON_GRENADE #replace with gas grenade
 
-  - type: STR_GSC_ENFORCER_MEDIC #infector 
+  - type: STR_GSC_ENFORCER_MEDIC #infector
     race: STR_GSC_ARBITES_FACTION
     rank: STR_LIVE_MEDIC
     stats:
@@ -734,14 +734,14 @@ units:
       stamina: 80 #GSC stamina
       health: 60 #GSC healthy
       bravery: 100 #+30 bravery, nearly fearless due to genestealer control
-      reactions: 55 
+      reactions: 55
       firing: 35 #slightly worse than GSC PDF
       throwing: 55
       strength: 50 #GSC gene boost
       psiStrength: 30
       psiSkill: 0
       melee: 80
-    armor: STR_GSC_ENFORCER_MEDIC_ARMOR 
+    armor: STR_GSC_ENFORCER_MEDIC_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 2
@@ -760,7 +760,7 @@ units:
       - - STR_GSC_NEEDLER_RIFLE
         - STR_PHOTON_GRENADE #replace with gas grenade
 
-  - type: STR_GSC_JUDGE_BIKE 
+  - type: STR_GSC_JUDGE_BIKE
     race: STR_GSC_ARBITES_FACTION
     rank: STR_LIVE_TERRORIST
     stats:
@@ -783,12 +783,12 @@ units:
     spotter: 1
     moraleLossWhenKilled: 10 #No GSC cares
     energyRecovery: 40
-    #aggroSound: #Add something from the judge sound files 
+    #aggroSound: #Add something from the judge sound files
     deathSound: [{mod: 40k, index: 41}, {mod: 40k, index: 42}, {mod: 40k, index: 43}] #male
     livingWeapon: true
     moveSound: -1
 
-  - type: STR_GSC_JUDGEF #Female 
+  - type: STR_GSC_JUDGEF #Female
     race: STR_GSC_ARBITES_FACTION
     rank: STR_LIVE_NAVIGATOR
     stats:
@@ -810,7 +810,7 @@ units:
     aggression: 4
     spotter: 1
     moraleLossWhenKilled: 10 #No GSC cares
-    #aggroSound: #Add something from the judge sound files 
+    #aggroSound: #Add something from the judge sound files
     energyRecovery: 40
     deathSound: [{mod: 40k, index: 44}, {mod: 40k, index: 45}, {mod: 40k, index: 46}] #female
     livingWeapon: true
@@ -843,7 +843,7 @@ units:
       psiStrength: 50
       psiSkill: 0
       melee: 70
-    armor: STR_GSC_JUDGEM_ARMOR 
+    armor: STR_GSC_JUDGEM_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 3
@@ -851,17 +851,17 @@ units:
     spotter: 1
     moraleLossWhenKilled: 10 #No GSC cares
     energyRecovery: 40
-    #aggroSound: #Add something from the judge sound files 
+    #aggroSound: #Add something from the judge sound files
     deathSound: [{mod: 40k, index: 41}, {mod: 40k, index: 42}, {mod: 40k, index: 43}] #male
     livingWeapon: true
     moveSound: -1
     builtInWeaponSets:
       - - STR_PUMP_SHOTGUN
-        - STR_STUN_SHELLS 
+        - STR_STUN_SHELLS
         - STR_STUN_SHELLS
         - STR_PHOTON_GRENADE #replace with gas grenade
       - - STR_PUMP_SHOTGUN
-        - STR_STUN_SHELLS 
+        - STR_STUN_SHELLS
         - STR_STUN_GAS_SHELLS
         - STR_PHOTON_GRENADE #replace with gas grenade
       - - STR_GSC_HEAVY_WEBBER
@@ -883,7 +883,7 @@ units:
       psiStrength: 50
       psiSkill: 0
       melee: 75
-    armor: STR_GSC_ARBITOR_ARMOR 
+    armor: STR_GSC_ARBITOR_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 4
@@ -891,7 +891,7 @@ units:
     spotter: 1
     moraleLossWhenKilled: 20 #No GSC cares
     energyRecovery: 40
-    #aggroSound: #Add something from the judge sound files 
+    #aggroSound: #Add something from the judge sound files
     deathSound: [{mod: 40k, index: 44}, {mod: 40k, index: 45}, {mod: 40k, index: 46}] #female
     livingWeapon: true
     moveSound: -1
@@ -921,7 +921,7 @@ units:
       psiStrength: 75
       psiSkill: 0
       melee: 80
-    armor: STR_GSC_WARDEN_ARMOR 
+    armor: STR_GSC_WARDEN_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 3
@@ -929,7 +929,7 @@ units:
     spotter: 1
     moraleLossWhenKilled: 30 #No GSC cares
     energyRecovery: 40
-    #aggroSound: #Add something from the judge sound files 
+    #aggroSound: #Add something from the judge sound files
     deathSound: [{mod: 40k, index: 41}, {mod: 40k, index: 42}, {mod: 40k, index: 43}] #male
     livingWeapon: true
     moveSound: -1
@@ -968,8 +968,8 @@ units:
     spotter: 2
     energyRecovery: 80
     moveSound: {mod: 40k, index: 700}
-      
-  - type: STR_GSC_MEDICAE #Female 
+
+  - type: STR_GSC_MEDICAE #Female
     race: STR_GSC_MEDICAE_RACE
     rank: STR_LIVE_SOLDIER
     stats:
@@ -984,7 +984,7 @@ units:
       psiStrength: 40
       psiSkill: 0
       melee: 80 #infector trained to poke people
-    armor: STR_GSC_MEDICAE_ARMOR 
+    armor: STR_GSC_MEDICAE_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 3
@@ -1001,7 +1001,7 @@ units:
       - - STR_GSC_AUTOINJECTOR_WEAPON
       - - STR_GSC_AUTOINJECTOR_WEAPON
 
-  - type: STR_GSC_INFECTED_REPENTIA 
+  - type: STR_GSC_INFECTED_REPENTIA
     race: STR_ZOMBIEF
     stats:
       tu: 90 #GSC gene boost, to run up and poke people
@@ -1014,17 +1014,17 @@ units:
       strength: 60 #GSC gene boost + armor
       psiStrength: 40
       psiSkill: 0
-      melee: 80 
+      melee: 80
     armor: STR_GSC_REPENTIA_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 2
     aggression: 6
     moraleLossWhenKilled: 10 #No GSC cares
-    isLeeroyJenkins: true 
+    isLeeroyJenkins: true
     energyRecovery: 60
     deathSound: [{mod: 40k, index: 44}, {mod: 40k, index: 45}, {mod: 40k, index: 46}]
-    
+
   - type: STR_GSC_INFECTED_ADEPTAS
     race: STR_ZOMBIEF
     stats:
@@ -1038,7 +1038,7 @@ units:
       strength: 60 #GSC gene boost + armor
       psiStrength: 40
       psiSkill: 0
-      melee: 60 
+      melee: 60
     armor: STR_GSC_INFECTED_ADEPTAS_ARMOR
     standHeight: 20
     kneelHeight: 14
@@ -1048,7 +1048,7 @@ units:
     moraleLossWhenKilled: 10 #No GSC cares
     energyRecovery: 40
     deathSound: [{mod: 40k, index: 44}, {mod: 40k, index: 45}, {mod: 40k, index: 46}]
-  
+
   - type: STR_GSC_HB_GUNNER
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_TERRORIST
@@ -1081,7 +1081,7 @@ units:
       - - STR_MOUNTED_HEAVY_BOLTER
         - STR_AC_AP_AMMO
       - - STR_MOUNTED_HEAVY_BOLTER
-        - STR_AC_HE_AMMO  
+        - STR_AC_HE_AMMO
   - type: STR_GSC_AUTOCANNON_GUNNER
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_TERRORIST
@@ -1115,7 +1115,7 @@ units:
         - STR_AUTOCANNON_CLIP
       - - STR_AUTOCANNON_GUARD
         - STR_AUTOCANNON_CLIP
-  - type: STR_GSC_PDF_SOLDIER #Female                                  
+  - type: STR_GSC_PDF_SOLDIER #Female
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_SOLDIER
     stats:
@@ -1130,7 +1130,7 @@ units:
       psiStrength: 30
       psiSkill: 0
       melee: 50
-    armor: STR_GSC_PDF_ARMOR 
+    armor: STR_GSC_PDF_ARMOR
     standHeight: 20
     kneelHeight: 14
     intelligence: 3
@@ -1169,7 +1169,7 @@ units:
       psiStrength: 30
       psiSkill: 0
       melee: 50
-    armor: STR_GSC_PDF_ARMOR1 
+    armor: STR_GSC_PDF_ARMOR1
     standHeight: 21
     kneelHeight: 15
     intelligence: 3
@@ -1193,7 +1193,7 @@ units:
         - STR_HEAVY_STUBBER_CLIP
         - STR_PHOTON_GRENADE
 
-  - type: STR_GSC_PDF_MEDIC #Female infector                                
+  - type: STR_GSC_PDF_MEDIC #Female infector
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_SOLDIER
     stats:
@@ -1208,7 +1208,7 @@ units:
       psiStrength: 40
       psiSkill: 0
       melee: 70 #infector trained to poke people
-    armor: STR_GSC_PDF_MEDIC_ARMOR 
+    armor: STR_GSC_PDF_MEDIC_ARMOR
     standHeight: 19
     kneelHeight: 14
     intelligence: 3
@@ -1266,7 +1266,7 @@ units:
       psiStrength: 50
       psiSkill: 0
       melee: 50
-    armor: STR_GSC_KRIEG_ARMOR 
+    armor: STR_GSC_KRIEG_ARMOR
     standHeight: 19
     kneelHeight: 14
     intelligence: 4
@@ -1293,7 +1293,7 @@ units:
       psiStrength: 50
       psiSkill: 0
       melee: 50
-    armor: STR_GSC_KRIEG_ARMOR 
+    armor: STR_GSC_KRIEG_ARMOR
     standHeight: 19
     kneelHeight: 14
     intelligence: 4
@@ -1305,7 +1305,7 @@ units:
     livingWeapon: true
     moveSound: -1
     value: 10
-    
+
   - type: STR_GSC_GUARD_FLAK_MALE
     race: STR_ZOMBIEM
     stats:
@@ -1648,7 +1648,7 @@ units:
         - STR_PISTOL_WEBBER_AMMO
         - STR_AUTOPISTOL_CLIP
         - STR_OFFICERS_SWORD
-        - STR_KRAK_GRENADE 
+        - STR_KRAK_GRENADE
 
   - type: STR_GSC_GUARD_FLAK_OFFICER_FEMALE
     race: STR_ZOMBIEM
@@ -1675,7 +1675,7 @@ units:
     deathSound: [{mod: 40k, index: 44}, {mod: 40k, index: 45}, {mod: 40k, index: 46}]
     livingWeapon: true
     moveSound: -1
-    value: 25 
+    value: 25
 
   - type: STR_GSC_GUARD_CARAPACE_OFFICER_MALE
     race: STR_ZOMBIEM
@@ -2068,7 +2068,7 @@ units:
     moveSound: -1
     value: 20
 
-  - type: STR_GSC_OGRYN #Infected 
+  - type: STR_GSC_OGRYN #Infected
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_SOLDIER
     stats:
@@ -2083,7 +2083,7 @@ units:
       psiStrength: 40
       psiSkill: 0
       melee: 80
-    armor: STR_GSC_OGRYN_ARMOR 
+    armor: STR_GSC_OGRYN_ARMOR
     standHeight: 21
     kneelHeight: 14
     aggression: 7
@@ -2094,8 +2094,8 @@ units:
     moveSound: -1
     livingWeapon: true
     deathSound: [{mod: 40k, index: 281}, {mod: 40k, index: 282}, {mod: 40k, index: 283}, {mod: 40k, index: 284}, {mod: 40k, index: 285}]
-    
-  - type: STR_GSC_OGRYN_ORANGE #Stronger version. 
+
+  - type: STR_GSC_OGRYN_ORANGE #Stronger version.
     race: STR_GSC_CULT_DISGUISED_RACE
     rank: STR_LIVE_SOLDIER
     stats:

--- a/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
+++ b/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
@@ -6,6 +6,8 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
 
 armors:
   - type: GREEN_ROBE_ARMOR
@@ -270,13 +272,13 @@ armors:
       - 1.0 #IMPACT
       - 1.3 #MELTA
     loftempsSet: [ 3 ]
-    specialWeapon: STR_NURGLE_BOOM_DUMMY
     builtInWeapons: #occupies both hands
       - STR_NURGLING_CLAWS
       - STR_NURGLING_CLAWS
     tags:
       INFECTION_RESIST: 100 #infection immune
       ARMOR_IS_EXPLODE_ON_DEATH: 1 #used for bomberman scripts
+      ARMOR_IS_KAMIKAZI: 1 #used for bomberman scripts; kamikazis on hit
 
 
   - type: STR_NURGLE_DAEMONETTE_ARMOR   #DAEMONETTE NURGLE ARMOR

--- a/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
+++ b/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
@@ -5,7 +5,8 @@ extended:
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
-
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
 
 armors:
   - type: STR_CHAOS_HERETEK_ARMOR
@@ -66,7 +67,9 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 3 ]
-    specialWeapon: STR_EXPLOSIVE_COLLAR_DUMMY
+    tags:
+      ARMOR_IS_EXPLODE_ON_DEATH: 1 #used for bomberman scripts
+      ARMOR_IS_KAMIKAZI: 1 #used for bomberman scripts; kamikazis on hit
 
   - type: STR_DESERTER_SOLDIER_FEM_ARMOR
     visibilityAtDay: 30

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -3,7 +3,6 @@ extended:
   tags:
     RuleItem:
 #bomb/kamikazi scripts
-      ITEM_IS_FOR_BOMBER: int
       ITEM_IS_BOMB: int
       ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death?
       ITEM_IS_RANDOM_FUSE: int #sets the fuse to a random value between 0 and ITEM_RANDOM_FUSE values.
@@ -4532,27 +4531,6 @@ items:
     clipSize: -1
     recover: false
 
-
-  - type: STR_EXPLOSIVE_COLLAR_DUMMY
-    specialUseEmptyHand: true
-    fixedWeapon: true
-    recover: false
-    meleeSound: 2140
-    meleeHitSound: { mod: 40k, index: 0 }
-    power: 200 # for the AI to pick this
-    meleeAnimation: { mod: 40k, index: 0 }
-    damageType: 7
-    accuracyMelee: 200
-    tuMelee: 1
-    clipSize: -1
-    battleType: 3
-    meleeMultiplier:
-      melee: 0.0
-      flatHundred: 1.0
-    flatRate: true
-    tags:
-      ITEM_IS_FOR_BOMBER: 1
-
   - type: STR_EXPLOSIVE_COLLAR_CHAOS #frag                #4006
     bulletSprite: {mod: 40k, index: 22}
     fireSound: {mod: 40k, index: 491}
@@ -4571,6 +4549,7 @@ items:
     defaultInventorySlot: STR_BELT
     tags:
       ITEM_IS_BOMB: 1
+      ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death
 
 #Tzeentch
   - type: STR_CSERVITOR_HPLASMA  #Chaos servitor heavy plasma              12000

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -6,7 +6,6 @@ extended:
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
 #bomb/kamikazi scripts
-      ITEM_IS_FOR_BOMBER: int
       ITEM_IS_BOMB: int #does this blow up with manual activation? The bomb fuse timer is equal to this value - 1.
       ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death? The bomb fuse timer is equal to this value - 1.
       ITEM_IS_RANDOM_FUSE: int #sets the fuse to a random value between 0 and ITEM_RANDOM_FUSE values.
@@ -37,6 +36,8 @@ extended:
       YTAG_DAMAGE_RETURNED_RESIST_TYPE_ARMOR: int
 #bomb/kamikazi scripts
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
+
 
 items:
   - type: AUX_DAEMON_FIREBALL #frag                #4006
@@ -1408,6 +1409,7 @@ items:
     blastRadius: 1
     damageAlter: #DA SPIT
       RandomType: 2 #TFTD [50% - 150%]
+      ToArmorPre: 0.3
       ToArmor: 0.3
       ToHealth: 0.3
       ToTime: 0.2
@@ -2357,28 +2359,6 @@ items:
     }
     bulletSpeed: 15
     listOrder: 6940
-
-  - type: STR_NURGLE_BOOM_DUMMY
-    specialUseEmptyHand: true
-    fixedWeapon: true
-    recover: false
-    meleeSound: 2413 #roar activation noise
-    meleeHitSound: { mod: 40k, index: 0 }
-    power: 200 # for the AI to pick this
-    meleeAnimation: { mod: 40k, index: 0 }
-    damageType: 7
-    accuracyMelee: 200
-    tuMelee: 1
-    clipSize: -1
-    battleType: 3
-    meleeMultiplier:
-      melee: 0.0
-      flatHundred: 1.0
-    flatRate: true
-    tags:
-      ITEM_IS_FOR_BOMBER: 1
-      INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
-      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_NURGLE_BOOM #blight
     bulletSprite: {mod: 40k, index: 22}

--- a/Ruleset/scripts/scripts_bomberman.rul
+++ b/Ruleset/scripts/scripts_bomberman.rul
@@ -1,39 +1,42 @@
 extended:
   tags:
     RuleItem:
-      ITEM_IS_FOR_BOMBER: int
       ITEM_IS_BOMB: int #does this blow up with manual activation? The bomb fuse timer is equal to this value - 1.
       ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death? The bomb fuse timer is equal to this value - 1.
       ITEM_IS_RANDOM_FUSE: int #sets the fuse to a random value between 0 and ITEM_RANDOM_FUSE values.
     RuleArmor:
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
 
   scripts:
     hitUnit:
       - new: ROSIGMA_hU_bomberman
-        offset: 43
+        offset: 44
         code: |
-          var ptr RuleItem ruleItem;
+          var ptr RuleArmor armorRule;
           var int temp;
+          var int fuseEnabled;
           var ptre BattleItem someItem;
           var int numInventoryItems;
           var int randomFuse;
 
-          damaging_item.getRuleItem ruleItem;
-          ruleItem.getTag temp Tag.ITEM_IS_FOR_BOMBER;
+          #if our armor doesn't have the kamikazi tag, cancel out
+          attacker.getRuleArmor armorRule;
+          armorRule.getTag temp Tag.ARMOR_IS_KAMIKAZI; #we check the armor for this tag to avoid having to cycle through items every time we damage something
 
-          if le temp 0; #if we don't have the tag, abort
-            #debug_log "Bomberman Scripts; hitUnit, offset 43: Aborted. No ITEM_IS_FOR_BOMBER Tag Detected";
+          if le temp 0;
+            #debug_log "Bomberman Scripts; hitUnit, offset 44: Aborted. No ARMOR_IS_EXPLODE_ON_DEATH Tag Detected";
             return power part side;
           end;
 
           attacker.getInventoryItem.size numInventoryItems;
-          #debug_log "numInventoryItems" numInventoryItems;
+          #debug_log "Bomberman Scripts; hitUnit, offset 44: numInventoryItems" numInventoryItems;
           loop var i numInventoryItems;
             attacker.getInventoryItem someItem i;
             someItem.getTag temp Tag.ITEM_IS_BOMB; #get the bomb timer
+            someItem.isFuseEnabled fuseEnabled; #don't bother if the fuse is already active
             # attacker.setTag Tag.UNIT_TURNED_TRAITOR 1; # doesn't recolor fast enough
-            if ge temp 1;
+            if and ge temp 1 le fuseEnabled 0;
               someItem.getTag randomFuse Tag.ITEM_IS_RANDOM_FUSE; #check if the fuse is random
               if ge randomFuse 1;
                 battle_game.randomRange temp 0 randomFuse;
@@ -41,24 +44,55 @@ extended:
               else;
                 sub temp 1;
               end;
-              attacker.setTimeUnits 0;
               someItem.setFuseTimer temp;
               someItem.setFuseEnabled 1;
-              #debug_log "Bomberman Scripts; hitUnit, offset 43: Successful. Bomb Triggered. Bomb Item:" someItem;
-              #debug_log "Bomberman Scripts; hitUnit, offset 43: Successful. Bomb Fuse. Fuse Timer:" temp;
-              return 0 part side;
+              #debug_log "Bomberman Scripts; hitUnit, offset 44: Successful. Bomb Triggered. Bomb Item:" someItem;
+              #debug_log "Bomberman Scripts; hitUnit, offset 44: Successful. Bomb Fuse. Fuse Timer:" temp;
+              return power part side;
             end;
           end;
 
           return power part side;
 
+      - new: ROSIGMA_hU_bomberman_2
+        offset: 43
+        code: |
+          var ptr RuleItem ruleItem;
+          var ptr RuleArmor armorRule;
+          var int temp;
+
+          #if our armor weapon isn't a bomb, cancel out
+          weapon_item.getRuleItem ruleItem;
+          ruleItem.getTag temp Tag.ITEM_IS_BOMB; #we check the armor for this tag to avoid having to cycle through items every time we damage something
+          #debug_log "Bomberman Scripts; hitUnit, offset 43: Attacker:" attacker;
+          #debug_log "Bomberman Scripts; hitUnit, offset 43: Attacker Weapon:" temp;
+
+          if le temp 0;
+            #debug_log "Bomberman Scripts; hitUnit, offset 43: Aborted. No ITEM_IS_BOMB Tag Detected";
+            return power part side;
+          end;
+
+          #if our armor doesn't have the kamikazi tag, cancel out
+          attacker.getRuleArmor armorRule;
+          armorRule.getTag temp Tag.ARMOR_IS_KAMIKAZI; #we check the armor for this tag to avoid having to cycle through items every time we damage something
+
+          if le temp 0;
+            #debug_log "Bomberman Scripts; hitUnit, offset 43: Aborted. No ARMOR_IS_KAMIKAZI Tag Detected";
+            return power part side;
+          end;
+
+          attacker.setHealth 0; #kill our kamikazi unit
+          return power part side;
+
+
     #blow up our bomb if we're killed
     damageUnit:
-      - new: ROSIGMA_dU_bomberman_kamikazi
+      - new: ROSIGMA_dU_bomberman
         offset: 24
         code: |
           var ptr RuleItem ruleItem;
           var int temp;
+          var int fuseEnabled;
           var ptre BattleItem someItem;
           var int numInventoryItems;
           var int remainingHealth;
@@ -87,8 +121,9 @@ extended:
           loop var i numInventoryItems;
             unit.getInventoryItem someItem i;
             someItem.getTag temp Tag.ITEM_IS_BOMB_ON_DEATH; #get the bomb timer
+            someItem.isFuseEnabled fuseEnabled; #don't bother if the fuse is already active
             # unit.setTag Tag.UNIT_TURNED_TRAITOR 1; # doesn't recolor fast enough
-            if ge temp 1;
+            if and ge temp 1 le fuseEnabled 0;
               someItem.getTag randomFuse Tag.ITEM_IS_RANDOM_FUSE; #check if the fuse is random
               if ge randomFuse 1;
                 battle_game.randomRange temp 0 randomFuse;
@@ -96,7 +131,6 @@ extended:
               else;
                 sub temp 1;
               end;
-              unit.setTimeUnits 0;
               someItem.setFuseTimer temp;
               someItem.setFuseEnabled 1;
               #debug_log "Bomberman Scripts; damageUnit, offset 24: Successful. Bomb Triggered. Bomb Item:" someItem;


### PR DESCRIPTION
1. Bomberman Scripts now activate the fuse on grenades tagged with ITEM_IS_BOMB when the triggering unit attacks if that unit's armor also has the ARMOR_IS_KAMIKAZI  tag.

2. Bomberman Scripts will now auto kill a unit with armor that has the ARMOR_IS_KAMIKAZI tag when their ITEM_IS_BOMB flagged grenade hits a unit.

3. Removed bomberman script dummy trigger items as they're no longer necessary.

4. Corrected Nurgling spit lacking PreArmorDamage it should have (fix of opportunity).