### PR TITLE
Fixes Bomberman Script Kamikazi/Death Bombs Being Thrown?

### DIFF
--- a/Ruleset/ENEMY/items_spawner.rul
+++ b/Ruleset/ENEMY/items_spawner.rul
@@ -1,3 +1,11 @@
+extended:
+  tags: # Remember to add tag definitions to same file as item/armor rulesets!
+    RuleItem:
+#infection system tags
+      INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
+      INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: int #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+
 items:
   - type: STR_WEBWAY_SFX #goes off on set turn
     power: 1
@@ -69,7 +77,7 @@ items:
     armor: 255
     tags:
       ITEM_PRIMED_AT_BATTLE_START: -1
-      
+
   - type: STR_CIVILIAN_HEDONITE_BLESSED_ALPHA_SACRIFICE_SPAWNER
     spawnUnit: STR_CIVILIAN_HEDONITE_BLESSED_ALPHA_SACRIFICE #cant move
     spawnUnitFaction: 2
@@ -85,7 +93,7 @@ items:
   - type: STR_SACRIFICE_DAEMONETTE_SPAWNER
     explosionHitSound: 2119 #daemonettelaughter
     hitAnimation: 1020 #X1 Pink skullsplosion
-    
+
   - type: STR_ALPHA_DAEMONETTE_RITUALIST_SPAWNER  #ritualist
     spawnUnit: STR_ALPHA_DAEMONETTE_RITUALIST
     spawnUnitFaction: 1
@@ -159,7 +167,7 @@ items:
     armor: 255
     tags:
       ITEM_PRIMED_AT_BATTLE_START: -1
-      
+
   - type: STR_SLAANESH_DEMIMONDE_SPAWNER  #ritualist
     spawnUnit: STR_SLAANESH_DEMIMONDE_RITUALIST
     spawnUnitFaction: 1
@@ -170,7 +178,7 @@ items:
     hitAnimation: {mod: 40k, index: 1992}
     armor: 255
     tags:
-      ITEM_PRIMED_AT_BATTLE_START: -1   
+      ITEM_PRIMED_AT_BATTLE_START: -1
   - type: STR_SLAANESH_DEMIMONDE_BLESSED_SPAWNER  #ritualist
     spawnUnit: STR_SLAANESH_DEMIMONDE_BLESSED_RITUALIST
     spawnUnitFaction: 1
@@ -182,7 +190,7 @@ items:
     armor: 255
     tags:
       ITEM_PRIMED_AT_BATTLE_START: -1
-      
+
   - type: STR_SLAANESH_DEMIMONDE_SACRIFICE_SPAWNER
     spawnUnit: STR_SLAANESH_DEMIMONDE_SACRIFICE
     spawnUnitFaction: 2
@@ -274,8 +282,8 @@ items:
     hitAnimation: {mod: 40k, index: 1992}
     armor: 255
     tags:
-      ITEM_PRIMED_AT_BATTLE_START: -1 
-      
+      ITEM_PRIMED_AT_BATTLE_START: -1
+
   - type: STR_TZEENTCH_CULT_WITCH_RITUALIST_SPAWNER  #ritualist
     spawnUnit: STR_TZEENTCH_CULT_WITCH_RITUALIST
     spawnUnitFaction: 1
@@ -286,8 +294,8 @@ items:
     hitAnimation: {mod: 40k, index: 1992}
     armor: 255
     tags:
-      ITEM_PRIMED_AT_BATTLE_START: -1   
-      
+      ITEM_PRIMED_AT_BATTLE_START: -1
+
   - type: STR_FLAMERSPAWNER_GRENADE            #Tzeentch Flamer spawner
     categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL]
     requires:
@@ -378,7 +386,7 @@ items:
     hitAnimation: {mod: 40k, index: 88 }
     explosionHitSound: {mod: 40k, index: 788}
     hitSound: {mod: 40k, index: 788}
-  - type: STR_TZLESSER_DAEMON_SPAWNER_GRENADE #SUMMONS MR CRABBY SNIP SNIP 
+  - type: STR_TZLESSER_DAEMON_SPAWNER_GRENADE #SUMMONS MR CRABBY SNIP SNIP
     categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL]
     requires:
       - STR_ALIENS_ONLY
@@ -417,7 +425,7 @@ items:
     hitAnimation: {mod: 40k, index: 1992}
     armor: 255
     tags:
-      ITEM_PRIMED_AT_BATTLE_START: -1   
+      ITEM_PRIMED_AT_BATTLE_START: -1
   - type: STR_GREEN_MONK_RITUALIST_BLESSED_SPAWNER  #ritualist
     spawnUnit: STR_GREEN_MONK_RITUALIST_BLESSED
     spawnUnitFaction: 1
@@ -428,7 +436,7 @@ items:
     hitAnimation: {mod: 40k, index: 1992}
     armor: 255
     tags:
-      ITEM_PRIMED_AT_BATTLE_START: -1   
+      ITEM_PRIMED_AT_BATTLE_START: -1
   - type: STR_NURGLE_CULTIST_LEADER_RITUALIST_SPAWNER  #ritualist
     spawnUnit: STR_NURGLE_CULTIST_LEADER_RITUALIST
     spawnUnitFaction: 1
@@ -440,7 +448,7 @@ items:
     armor: 255
     tags:
       ITEM_PRIMED_AT_BATTLE_START: -1
-      
+
   - type: STR_PLAGUEBEARERSPAWNER_GRENADE            #Nurgle Plaguebearer spawner
     categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL]
     requires:
@@ -470,6 +478,11 @@ items:
     hitSound: {mod: 40k, index: 832 }
     explosionHitSound: {mod: 40k, index: 832 } #blight rocket SFX
     hitAnimation: 1030 #128 green from X1.pck
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50
+      INFECTION_TYPE: 1
+
+
   - type: STR_NURGLINGSPAWNER_GRENADE            #Nurgle Nurgling Spawner
     categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL]
     requires:
@@ -499,6 +512,9 @@ items:
     explosionHitSound: {mod: 40k, index: 832 } #blight rocket SFX
     hitAnimation: 1030 #128 green from X1.pck
     hitSound: {mod: 40k, index: 832 }
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50
+      INFECTION_TYPE: 1
 
   - type: STR_DEAMONETTE_SPAWNER
     spawnUnit: STR_CHRYSSALID_TERRORIST
@@ -669,7 +685,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
-    
+
   - type: STR_TZEENTCH_CULT_LEADER_SPAWNER
     spawnUnit: STR_TZEENTCH_CULT_LEADER
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -739,7 +755,7 @@ items:
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
   - type: STR_NIGHTLORDS_WARPTALON_SPAWNER
-    spawnUnit: STR_NIGHTLORDS_WARPTALON_SOLDIER 
+    spawnUnit: STR_NIGHTLORDS_WARPTALON_SOLDIER
     spawnUnitFaction: 1 # 1: Enemy faction
     invWidth: 0
     invHeight: 0
@@ -806,7 +822,7 @@ items:
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
   - type: STR_KHORNE_WARPTALON_SPAWNER
-    spawnUnit: STR_WARPTALON_SOLDIER 
+    spawnUnit: STR_WARPTALON_SOLDIER
     spawnUnitFaction: 1 # 1: Enemy faction
     invWidth: 0
     invHeight: 0
@@ -827,7 +843,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
-    
+
   - type: STR_SNAKEMAN_SENTINEL_SPAWNER
     spawnUnit: STR_SNAKEMAN_SENTINEL
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -862,7 +878,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
-    
+
   - type: STR_SNAKEMAN_SOLDIER_SPAWNER
     spawnUnit: STR_SNAKEMAN_SOLDIER
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -874,7 +890,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
-    
+
   - type: STR_TRAITORGUARD_OGRYN_REDBLACK_SPAWNER
     spawnUnit: STR_TRAITORGUARD_OGRYN_REDBLACK
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -886,7 +902,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
-    
+
   - type: STR_SNAKEMAN_ENGINEER_SPAWNER
     spawnUnit: STR_SNAKEMAN_ENGINEER
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -909,9 +925,9 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 788 }
-    
+
   - type: STR_IRON_GUARD_SOLDIER_SPAWNER
-    spawnUnit: STR_IRON_GUARD_SOLDIER 
+    spawnUnit: STR_IRON_GUARD_SOLDIER
     spawnUnitFaction: 1 # 1: Enemy faction
     invWidth: 0
     invHeight: 0
@@ -1066,7 +1082,7 @@ items:
     recover: false
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
-    hitSound: {mod: 40k, index: 788 }    
+    hitSound: {mod: 40k, index: 788 }
   - type: STR_SLAANESH_ANOINTED_MISSILE_SPAWNER
     spawnUnit: STR_SLAANESH_ANOINTED_MISSILE
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -1077,7 +1093,7 @@ items:
     recover: false
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
-    hitSound: {mod: 40k, index: 788 }  
+    hitSound: {mod: 40k, index: 788 }
   - type: STR_SLAANESH_CHOSEN_SPAWNER
     spawnUnit: STR_SLAANESH_CHOSEN
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -1088,7 +1104,7 @@ items:
     recover: false
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
-    hitSound: {mod: 40k, index: 788 }      
+    hitSound: {mod: 40k, index: 788 }
 
   - type: STR_CHAOS_DREAD2_SPAWNER
     spawnUnit: STR_SECTOPOD2_TERRORIST
@@ -1205,7 +1221,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 150 } #teleport VFX
     hitSound: {mod: 40k, index: 757 } #xenodieB
-    
+
   - type: STR_GENE_SAB_BASIC_SPAWNER
     spawnUnit: STR_GENE_SAB
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -1217,7 +1233,7 @@ items:
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 10 } #smoke
     hitSound: {mod: 40k, index: 757 } #xenodieB
-  
+
   - type: STR_GENESTEALER_WEAK_SPAWNER
     spawnUnit: STR_XENO_TERRORIST #weaker
     spawnUnitFaction: 1 # 1: Enemy faction
@@ -1228,7 +1244,7 @@ items:
     recover: false
     hiddenOnMinimap: true
     hitAnimation: {mod: 40k, index: 10 } #smoke
-    hitSound: {mod: 40k, index: 757 } #xenodieB  
+    hitSound: {mod: 40k, index: 757 } #xenodieB
   - type: STR_GENESTEALER_BASIC_SPAWNER
     spawnUnit: STR_XENO_SOLDIER
     spawnUnitFaction: 1 # 1: Enemy faction

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -2205,6 +2205,9 @@ items:
     clipSize: 3
     blastRadius: 4
     listOrder: 10353
+    tags:
+      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_LIGHT_BOLTER_AMMO_NURGLE
     categories: [STR_CAT_BOLTER]
@@ -4542,7 +4545,9 @@ items:
     damageType: 3
     battleType: 4 # grenade
     recover: false
-    tuPrime: 999
+    tuThrow: 999 #only to be thrown via scripts
+    tuPrime: 999 #only to be thrown via scripts
+    throwRange: 1 #not meant to be thrown
     fixedWeapon: true
     isExplodingInHands: true
     hiddenOnMinimap: true

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -2379,7 +2379,9 @@ items:
       ToTime: 0.2
     battleType: 4 # grenade
     recover: false
-    tuPrime: 999
+    tuThrow: 999 #only to be thrown via scripts
+    tuPrime: 999 #only to be thrown via scripts
+    throwRange: 1 #not meant to be thrown
     fixedWeapon: false #has to be false so kamikazi tag and scripts work properly
     isExplodingInHands: true
     hiddenOnMinimap: true
@@ -2977,8 +2979,9 @@ items:
       ArmorEffectiveness: 0.5
     battleType: 4 # grenade
     recover: false
-    tuThrow: 999
-    tuPrime: 999
+    tuThrow: 999 #only to be thrown via scripts
+    tuPrime: 999 #only to be thrown via scripts
+    throwRange: 1 #not meant to be thrown
     armor: 30
     fixedWeapon: false #has to be false so kamikazi tag and scripts work properly
     isExplodingInHands: true


### PR DESCRIPTION
1. Bomberman Script kamikazi/death bombs can no longer be thrown.

2. Added missing infection damage parameters to Nurgling and Plaguebearer spawner grenades.

3. Whitespace removal.
