### PR TITLE
Grey Knights Recruitable for $$$ and Honor Tokens; Stat Tweaks

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -4119,6 +4119,7 @@ en-US:
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR: "Storm Trooper Armor"
   STR_INQ_STORMTROOPER_REQUISITION: "Requisition Inquisition Storm Troopers"
   STR_INQ_STORMTROOPER_ARMOR_UFOPAEDIA: "{NEWLINE}Inquisitor Storm Troopers undergo rigorous purity and incorruptibility tests prior to their induction, making them preferable for use in Ordo Malleus and Hereticus forces when the number of Grey Knights and Battle Sisters may be insufficient."
+  STR_GREY_KNIGHT_REQUISITION: "Requisition Grey Knight"
   STR_INQ_HELLGUN: "Inquisition Hellgun"
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_HELLGUN: "Inquisition Hellgun Armor"
   STR_INQ_HELLGUN_UFOPEDIA: "{NEWLINE}The Inquisition Hellgun is a high quality, scoped Hellgun variant with a sanctified bayonet and finely tuned settings."

--- a/Ruleset/SM/GREY KNIGHTS/manufacture_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/manufacture_GK.rul
@@ -2562,3 +2562,15 @@ manufacture:
       STR_ALIEN_ALLOYS: 500 #halved
       STR_UFO_POWER_SOURCE: 4
       STR_UFO_NAVIGATION: 2
+
+  - name: STR_GREY_KNIGHT_REQUISITION
+    #category: STR_ADVANCEMENT
+    requires:
+      - STR_GREYKNIGHTS
+    space: 0
+    time: 1000
+    cost: 1000000
+    requiredItems:
+      STR_KILLPOINT_TOKEN: 200
+      # STR_ALIEN_HABITAT: 2
+    spawnedPersonType: STR_GK_LV1

--- a/Ruleset/SM/GREY KNIGHTS/soldiers_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/soldiers_GK.rul
@@ -275,12 +275,12 @@
       tu: 55 #buffed
       stamina: 50 #buffed
       health: 50
-      bravery: 60
+      bravery: 80
       reactions: 45 #buffed
       firing: 55 #buffed
       throwing: 50
       strength: 40
-      psiStrength: 50
+      psiStrength: 60 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 20
       melee: 60 #buffed
     maxStats:
@@ -292,7 +292,7 @@
       firing: 80 #buffed
       throwing: 80
       strength: 55 #buffed
-      psiStrength: 70
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 70
       melee: 90 #buffed
     statCaps:
@@ -304,7 +304,7 @@
       firing: 130
       throwing: 120
       strength: 120
-      psiStrength: 100
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 100
       melee: 130
     trainingStatCaps:
@@ -314,7 +314,7 @@
       firing: 100
       throwing: 80
       strength: 80
-      psiStrength: 100
+      psiStrength: 110
       psiSkill: 100
       melee: 110 #buffed
   - type: STR_GK_LV2
@@ -322,12 +322,12 @@
       tu: 55 #buffed
       stamina: 50 #buffed
       health: 50
-      bravery: 60 #buffed
+      bravery: 80
       reactions: 45 #buffed
       firing: 55 #buffed
       throwing: 50
       strength: 40
-      psiStrength: 50
+      psiStrength: 60 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 20
       melee: 60 #buffed
     maxStats:
@@ -339,7 +339,7 @@
       firing: 80 #buffed
       throwing: 80
       strength: 55 #buffed
-      psiStrength: 70
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 70
       melee: 90 #buffed
     statCaps:
@@ -351,7 +351,7 @@
       firing: 130
       throwing: 120
       strength: 120
-      psiStrength: 100
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 100
       melee: 130
     trainingStatCaps:
@@ -361,7 +361,7 @@
       firing: 100
       throwing: 80
       strength: 80
-      psiStrength: 100
+      psiStrength: 110
       psiSkill: 100
       melee: 110 #buffed
   - type: STR_GK_LV3
@@ -369,12 +369,12 @@
       tu: 55 #buffed
       stamina: 50 #buffed
       health: 50
-      bravery: 60 #buffed
+      bravery: 80
       reactions: 45 #buffed
       firing: 55 #buffed
       throwing: 50
       strength: 40
-      psiStrength: 50
+      psiStrength: 60 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 20
       melee: 60 #buffed
     maxStats:
@@ -386,7 +386,7 @@
       firing: 80 #buffed
       throwing: 80
       strength: 55 #buffed
-      psiStrength: 70
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 70
       melee: 90 #buffed
     statCaps:
@@ -398,7 +398,7 @@
       firing: 130
       throwing: 120
       strength: 120
-      psiStrength: 100
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 100
       melee: 130
     trainingStatCaps:
@@ -408,7 +408,7 @@
       firing: 100
       throwing: 80
       strength: 80
-      psiStrength: 100
+      psiStrength: 110
       psiSkill: 100
       melee: 110 #buffed
   - type: STR_GK_LV4
@@ -416,12 +416,12 @@
       tu: 55 #buffed
       stamina: 50 #buffed
       health: 50
-      bravery: 60 #buffed
+      bravery: 80
       reactions: 45 #buffed
       firing: 55 #buffed
       throwing: 50
       strength: 40
-      psiStrength: 50
+      psiStrength: 60 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 20
       melee: 60 #buffed
     maxStats:
@@ -433,7 +433,7 @@
       firing: 80 #buffed
       throwing: 80
       strength: 55 #buffed
-      psiStrength: 70
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 70
       melee: 90 #buffed
     statCaps:
@@ -445,7 +445,7 @@
       firing: 130
       throwing: 120
       strength: 120
-      psiStrength: 100
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 100
       melee: 130
     trainingStatCaps:
@@ -455,7 +455,7 @@
       firing: 100
       throwing: 80
       strength: 80
-      psiStrength: 100
+      psiStrength: 110
       psiSkill: 100
       melee: 110 #buffed
   - type: STR_GK_LV5
@@ -463,12 +463,12 @@
       tu: 55 #buffed
       stamina: 50 #buffed
       health: 50
-      bravery: 60 #buffed
+      bravery: 80
       reactions: 45 #buffed
       firing: 55 #buffed
       throwing: 50
       strength: 40
-      psiStrength: 50
+      psiStrength: 60 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 20
       melee: 60 #buffed
     maxStats:
@@ -480,7 +480,7 @@
       firing: 80 #buffed
       throwing: 80
       strength: 55 #buffed
-      psiStrength: 70
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 70
       melee: 90 #buffed
     statCaps:
@@ -492,7 +492,7 @@
       firing: 130
       throwing: 120
       strength: 120
-      psiStrength: 100
+      psiStrength: 110 #they're all capable psykers with the Emprah's geneseed; they should be above average
       psiSkill: 100
       melee: 130
     trainingStatCaps:
@@ -502,6 +502,6 @@
       firing: 100
       throwing: 80
       strength: 80
-      psiStrength: 100
+      psiStrength: 110
       psiSkill: 100
       melee: 110 #buffed


### PR DESCRIPTION
1. Grey Knights can now be recruited for $1,000,000 and 200 Honor Tokens for players that have opted for the Grey Knight Chamber Militant sub-path.

2. Grey Knights min psi strength is now 60 and max is 110 as they are all capable psykers at a minimum.

3. Grey Knight min Bravery is now 80 up from 60.