### PR TITLE
Standardize Sniper Rifle Mechanics; Expand Fire Mode Power Bonus Scripts

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -3012,6 +3012,11 @@ en-US:
   STR_SNAP_POWER_BONUS: "Power Bonus for Snap"
   STR_AIMED_POWER_BONUS: "Power Bonus for Aimed"
   STR_MELEE_POWER_BONUS: "Power Bonus for Melee"
+  STR_MELEE_POWER_BONUS: "Power Bonus for Melee"
+  STR_AUTO_ACCURACY_POWER_BONUS: "Auto Mode Firing Accuracy Power Bonus"
+  STR_SNAP_ACCURACY_POWER_BONUS: "Snap Shot Firing Accuracy Power Bonus"
+  STR_AIMED_ACCURACY_POWER_BONUS: "Aimed Shot Firing Accuracy Power Bonus"
+  STR_POWER_BONUS_PERCENTILE: "Fire Mode Power Bonus is a Percentage?"
   STR_MAXIMAL_SHOT: "Maximal Shot"
   STR_PRECISION_SHOT: "Precision Shot"
 
@@ -3753,6 +3758,8 @@ en-US:
   STR_CAT_ADEPTAS: "Sisters of Battle"
   STR_CAT_NURGLE: "Nurgle"
   STR_CAT_TZEENTCH: "Tzeentch"
+  STR_CAT_NECRON: "Necron"
+
 
 #GSC
   STR_GSC_RETALIATION: "Spiral Revenge"

--- a/Ruleset/ADEPTAS/weapons_adeptas.rul
+++ b/Ruleset/ADEPTAS/weapons_adeptas.rul
@@ -2,6 +2,18 @@ extended:
   tags:
     RuleItem:
       ITEM_DOESNT_HURT_USER: int
+      ITEM_AUTO_POWER_BONUS: int
+      ITEM_SNAP_POWER_BONUS: int
+      ITEM_AIMED_POWER_BONUS: int
+      ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
+      ITEM_RECOIL: int
+      ITEM_HAS_BIPOD: int
+      ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
 
 items:
   - type: STR_SACRESANT_SHIELD
@@ -49,7 +61,7 @@ items:
     fixedWeaponShow: true
     recover: false
     defaultInventorySlot: STR_LEFT_HAND
-    
+
   - type: STR_AUTOGUN_ADEPTAS
     categories: [STR_CAT_AUTO]
     requiresBuy:
@@ -144,7 +156,7 @@ items:
     armor: 200
     experienceTrainingMode: 5
     listOrder: 10741
-      
+
   - type: STR_SENTINEL_MELTALANCE
     weight: 0
     vaporColorSurface: {mod: 40k, index: 2}
@@ -182,7 +194,7 @@ items:
     invHeight: 3
     recover: false
     clipSize: 400 # required for ROSIGMA.zip
-    
+
   - type: STR_CHOIR_GUN # Adeptas Hymn Choir Weapon Projector    11790
     categories: [STR_CAT_PLASMA]
     size: 0.3
@@ -203,7 +215,7 @@ items:
     invHeight: 3
     armor: 200
     listOrder: 11790
-    
+
   - type: STR_NEURAL_WHIP           #12600           DA POWER
     categories: [STR_CAT_MELEE]
     size: 0.1
@@ -227,7 +239,7 @@ items:
     #ammo:
      #0:
       #compatibleAmmo: [STR_LOWPOWER_WHIPSETTING]
-     #1: 
+     #1:
       #compatibleAmmo: [STR_MEDIUMPOWER_WHIPSETTING]
      #2:
       #compatibleAmmo: [STR_HIGHPOWER_WHIPSETTING]
@@ -314,7 +326,7 @@ items:
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS_ARMORS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.2
     costBuy: 5000
     costSell: 1200
@@ -341,7 +353,7 @@ items:
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS_ARMORS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.1
     costBuy: 550
     costSell: 275
@@ -364,7 +376,7 @@ items:
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS_ARMORS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.1
     costBuy: 750
     costSell: 375
@@ -444,10 +456,10 @@ items:
     size: 0.1
     requiresBuy:
      - STR_ADEPTAS
-     - STR_FAITHFUL_ARMORY  
+     - STR_FAITHFUL_ARMORY
     costBuy: 500
     costSell: 200
-    weight: 3 
+    weight: 3
     bigSprite: 2093
     floorSprite: { mod: 40k, index: 103 }
     handSprite: { mod: 40k, index: 440 }
@@ -462,7 +474,7 @@ items:
     explosionSpeed: 20
     armor: 14
     attraction: 7
-    listOrder: 10496 
+    listOrder: 10496
 
   - type: STR_LIGHT_FLAMETHROWER_CLIP # MEPHISTO FLAMER                     10520
     categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL]
@@ -493,7 +505,7 @@ items:
     categories: [STR_CAT_BOLTER]
     size: 0.3
     requiresBuy:
-      - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS 
+      - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
       - STR_BOLTER_HELLSPITE
     costBuy: 40000
     costSell: 17000
@@ -549,7 +561,7 @@ items:
     size: 0.1
     weight: 3
     requiresBuy:
-     - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS 
+     - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
      - STR_BOLTER_HELLSPITE
     costBuy: 6000
     costSell: 2500
@@ -567,7 +579,7 @@ items:
     categories: [ STR_CAT_GRENADES, STR_CAT_ADEPTAS]
     size: 0.1
     weight: 3
-    requiresBuy: 
+    requiresBuy:
      - STR_MIDTIER_PREREQ
      - STR_HEAVY_LASER
     costBuy: 7500
@@ -585,7 +597,7 @@ items:
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.3
     costBuy: 30000
     costSell: 15000
@@ -627,11 +639,12 @@ items:
     tuMelee: 12
     flatMelee:
       time: true
+
   - type: STR_SNIPER_ARCHE #Adeptas Sniper
     categories: [STR_CAT_BOLTER, STR_CAT_SNIPER]
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.3
     costBuy: 50000
     costSell: 15000
@@ -654,6 +667,14 @@ items:
     bulletSpeed: 30
     attraction: 1
     listOrder: 11919
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
+    tags:
+      ITEM_RECOIL: 40
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 25 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1
+      ITEM_IS_HEAVY_WEAPON: 1
+
   - type: STR_STORMBOLTER_DEAZ                                                                #13100 no amied
     categories: [STR_CAT_ADEPTAS, STR_CAT_BOLTER]
     size: 0.6
@@ -719,13 +740,13 @@ items:
     tuMelee: 10
     flatMelee:
       time: true
-    
+
   - type: STR_LIGHT_BOLTER_AMMO_AP #Elohim ammo
     categories: [STR_CAT_BOLTER]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.1
     costBuy: 500
     costSell: 150
@@ -768,7 +789,7 @@ items:
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     size: 0.1
     costBuy: 1500
     costSell: 250
@@ -787,7 +808,7 @@ items:
     categories: [STR_CAT_BOLTER]
     requiresBuy:
       - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
       - STR_ADEPTAS_SOB_MOBILIZATION
     size: 0.3
     costBuy: 30000
@@ -1123,7 +1144,7 @@ items:
     size: 0.3
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 65000
     costSell: 7000
     weight: 35
@@ -1152,11 +1173,11 @@ items:
     size: 0.3
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 80000
     costSell: 9000
     weight: 30
-    bigSprite: 2068 
+    bigSprite: 2068
     floorSprite: 2065
     handSprite: 2100
     bulletSprite: {mod: 40k, index: 6}
@@ -1216,7 +1237,7 @@ items:
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 2000
     costSell: 800
     weight: 15
@@ -1235,7 +1256,7 @@ items:
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 1200
     costSell: 800
     weight: 15
@@ -1252,7 +1273,7 @@ items:
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 2000
     costSell: 800
     weight: 15
@@ -1270,7 +1291,7 @@ items:
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 1500
     costSell: 400
     weight: 10
@@ -1288,7 +1309,7 @@ items:
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 1000
     costSell: 400
     weight: 10
@@ -1305,7 +1326,7 @@ items:
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 1500
     costSell: 400
     weight: 10
@@ -1369,10 +1390,10 @@ items:
     size: 0.4
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     costBuy: 100000
     costSell: 15000
-    weight: 35 
+    weight: 35
     bigSprite: 2058
     floorSprite: 2063
     handSprite: 2092
@@ -1407,7 +1428,7 @@ items:
     size: 0.4
     requiresBuy:
      - STR_ADEPTAS
-     - STR_FAITHFUL_ARMORY  
+     - STR_FAITHFUL_ARMORY
     costBuy: 10000
     costSell: 3000
     weight: 15
@@ -1433,13 +1454,13 @@ items:
     size: 0.4
     requiresBuy:
      - STR_ADEPTAS
-     - STR_FAITHFUL_ARMORY  
+     - STR_FAITHFUL_ARMORY
     costBuy: 10000
     costSell: 3000
     weight: 15
     bigSprite: 2041
     floorSprite: 2054
-    handSprite: 2044 
+    handSprite: 2044
     bulletSprite: {mod: 40k, index: 5}
     battleType: 1
     hitSound: {mod: 40k, index: 12}
@@ -1456,7 +1477,7 @@ items:
   - type: STR_CHERUBIM_GRENADE_LAUNCHER #Adeptas Cherubim pattern
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     categories: [STR_CAT_ROCKETL]
     size: 0.4
     costBuy: 15000
@@ -1481,7 +1502,7 @@ items:
   - type: STR_PHOSPHOR_GRENADE_DRUM #Sisters grenade launcher drum
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 1200
@@ -1500,7 +1521,7 @@ items:
   - type: STR_PENITENCE_GRENADE_DRUM
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 1200
@@ -1519,7 +1540,7 @@ items:
   - type: STR_CHERUBIM_INCENDIARY_GRENADE_DRUM
     requiresBuy:
       - STR_ADEPTAS
-      - STR_FAITHFUL_ARMORY  
+      - STR_FAITHFUL_ARMORY
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 1200
@@ -1538,7 +1559,7 @@ items:
     categories: [ STR_CAT_ROCKETL]
     requiresBuy:
      - STR_ADEPTAS
-     - STR_FAITHFUL_ARMORY  
+     - STR_FAITHFUL_ARMORY
     size: 0.2
     costBuy: 4000
     costSell: 2760
@@ -1583,7 +1604,7 @@ items:
     categories: [STR_CAT_LASGUN]
     size: 0.2
     requiresBuy:
-      - STR_LASCANNON_CLIP_MALTHUS 
+      - STR_LASCANNON_CLIP_MALTHUS
     costBuy: 20000 #can be manufactured
     costSell: 2000
     weight: 7
@@ -1618,7 +1639,7 @@ items:
     invHeight: 3
     armor: 300
     listOrder: 11101
-    
+
   - type: STR_HARMONIC_MELTAGUN #ADEPTAS MELTAGUN                    2019
     categories: [STR_CAT_MELTA, STR_CAT_TACTICAL]
     size: 0.3
@@ -1733,7 +1754,7 @@ items:
     meleeAlter:
       RandomWound: false
     defaultInventorySlot: STR_LEFT_HAND
-    
+
   - type: STR_EVISCERATOR
     armor: 200
     power: 150 #+50 20 TU swing at 70 accuracy isn't fantastic for a 2-handed weapon.
@@ -1743,5 +1764,5 @@ items:
       ToHealth: 0.9
       RandomType: 2 #TFTD [50% - 150%]
       ToWound: 0.3
-      ToEnergy: 0.5      
+      ToEnergy: 0.5
 

--- a/Ruleset/ALLFACTIONS/weapons_turrets.rul
+++ b/Ruleset/ALLFACTIONS/weapons_turrets.rul
@@ -104,10 +104,10 @@ items:
     tuSnap: 0
     tuAimed: 0
     autoShots: 10
-  
+
   - type: STR_STORMRAVEN_WEAPON
     refNode: *STR_TURRET_DEFAULT
-  
+
   - type: STR_STORMRAVENGK_WEAPON #STORMRAven TURRET
     refNode: *STR_TURRET_DEFAULT
 
@@ -282,8 +282,9 @@ items:
       ToArmorPre: 0.2
       ToHealth: 1.0
       ToArmor: 0.0
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
   - type: STR_LEMONRUSS_WEAPON
     costAimed:
@@ -381,8 +382,9 @@ items:
       ToArmorPre: 0.3
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     compatibleAmmo: !remove
      - STR_LASCAN_CLIP
     clipSize: -1

--- a/Ruleset/BALANCE/ballistics_IG.rul
+++ b/Ruleset/BALANCE/ballistics_IG.rul
@@ -3,6 +3,8 @@
 # NOTE: ROSIGMA 1.06Beta2 values may be used in the future
 # NOTE: IG weapons in 40k had no kneelBonus
 
+
+
 items:
 
 ## Shotguns
@@ -60,7 +62,7 @@ items:
     autoRange: 0
     snapRange: 12
     aimRange: 0
-    accuracyAuto: 0    
+    accuracyAuto: 0
     accuracySnap: 60
     accuracyAimed: 0
     tuAuto: 0
@@ -202,7 +204,7 @@ items:
     snapRange: 14
     aimRange: 0
 
-    accuracyAuto: 66 
+    accuracyAuto: 66
     accuracySnap: 80
     accuracyAimed: 0
 
@@ -268,10 +270,10 @@ items:
 
   - type: STR_BOLTER_LIGHT_UMBRA #ceramite tier high ROF light bolter guard
     dropoff: 5
-    autoRange: 10 #built for autofire, late game perk 
+    autoRange: 10 #built for autofire, late game perk
     snapRange: 13
     aimRange: 0
-    
+
     accuracyAuto: 66 #Same as light bolters
     accuracySnap: 80 #Same as light bolters
     accuracyAimed: 0
@@ -279,7 +281,7 @@ items:
     tuSnap: 25
     tuAimed: 0
     confSnap:
-      shots: 2 #8 shots snap per turn   
+      shots: 2 #8 shots snap per turn
 ## Heavy Weapons
 
   - &STR_HEAVY_STUBBER_HANDHELD
@@ -328,14 +330,14 @@ items:
     autoRange: 12 #higher than handheld light bolters
     snapRange: 15 #slightly better than solo bolter, worse than DMR
     aimRange: 0
-    
+
     accuracyAuto: 66 #Same as light bolters
     accuracySnap: 80 #Same as light bolters
     accuracyAimed: 0
     tuAuto: 60 #could lower to 50 for 2x autofire bursts, total of 6 rounds
     tuSnap: 35 #Worse vs tactical light bolters, from being a deployable weapon
     tuAimed: 0
-  
+
   - type: STR_HEAVY_BOLTER_GUARD # done
     dropoff: 4
     autoRange: 17 # + 3 for tuAuto > 50 %
@@ -381,18 +383,6 @@ items:
 
 ## Snipers
 
-  - type: STR_EXITUS_BUILTIN # done
-    dropoff: 3 
-    autoRange: 0
-    snapRange: 21
-    aimRange: 32
-
-    accuracyAuto: 0
-    accuracySnap: 80
-    accuracyAimed: 160
-    tuAuto: 0
-    tuSnap: 40
-    tuAimed: 85
 
 ## Vehicles (Sentinels, etc.)
 

--- a/Ruleset/BALANCE/ballistics_ammo.rul
+++ b/Ruleset/BALANCE/ballistics_ammo.rul
@@ -373,7 +373,8 @@ items:
     power: 150
     damageAlter:
       ToTile: 0.0
-      RandomType: 7
+      ToArmorPre: 0.1 #high velocity
+      RandomType: 6
       ArmorEffectiveness: 0.8
     damageType: 1
     clipSize: 2
@@ -381,11 +382,14 @@ items:
   - type: STR_EXITUS_AMMO_HELLFIRE # attacks twice by being HE
     refNode: *STR_EXITUS_BULLETS
     damageAlter:
-#      ToArmorPre: 0.05
-      ArmorEffectiveness: 0.8
-      RandomType: 7
-#      ToArmor: 0.1
-#      ToHealth: 1.0
+      ToArmorPre: 0.4 #acid melts armor
+      ArmorEffectiveness: 0.9
+      RandomType: 6
+      ToArmor: 0.2
+      ToHealth: 0.7
+      ToStun: 0.5 #painful
+      ToWound: 0.5 #acid and armor piercing needles cause lots of mortal wounds
+      ToMorale: 2.0 #painful
 #      ToStun: 0.5
     blastRadius: 1
     damageType: 3
@@ -394,9 +398,12 @@ items:
   - type: STR_EXITUS_AMMO_TURBOPENETRATOR
     refNode: *STR_EXITUS_BULLETS
     damageAlter:
-      ToTile: 0.0
-      RandomType: 7
-      ArmorEffectiveness: 0.4
+      ToTile: 1.0 #it'll destroy about anything it hits
+      RandomType: 6
+      ToArmorPre: 0.1
+      ArmorEffectiveness: 0.4 #armor piercing
+      ToHealth: 0.7 #armor piercing
+      ToArmor: 0.5 #obliterates armor on penetration
     power: 150
 
   - type: STR_EXITUS_AMMO_SHELLBREAKER # shield piercing
@@ -404,8 +411,9 @@ items:
     power: 150
     damageAlter:
       ToTile: 0.0
-      RandomType: 7
+      RandomType: 6
       FireThreshold: 1000 # no fire
+      ToArmorPre: 0.1 #high velocity
       ArmorEffectiveness: 0.8
       FixRadius: 0
       IgnoreDirection: false

--- a/Ruleset/BALANCE/las.rul
+++ b/Ruleset/BALANCE/las.rul
@@ -5,7 +5,14 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
 
+      ITEM_RECOIL: int
+      ITEM_HAS_BIPOD: int
+      ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
 
 # Lasguns and Lascannons
 
@@ -92,7 +99,7 @@ items:
 #  - type: STR_LASER_RIFLEC
 #    refNode: *STR_LASGUN
 
-  - type: STR_LASER_RIFLEG # done 
+  - type: STR_LASER_RIFLEG # done
     dropoff: 4
     autoRange: 9
     snapRange: 16
@@ -117,7 +124,7 @@ items:
     tuAuto: 33 # 40k 34
     tuSnap: 25
     tuAimed: 0
-  
+
   - type: STR_LASGUN_ESCHER
     dropoff: 4 #slightly worse drop off than other DMR lasrifles
     autoRange: 0
@@ -129,7 +136,7 @@ items:
     tuAuto: 0
     tuSnap: 33 #2x snap shot, slightly higher TU cost
     tuAimed: 65 #slightly worse than Tanith longlas
-    
+
   - type: STR_LASCARBINE # done # Carbine # Make it different from Lasgun
     dropoff: 4
     autoRange: 0
@@ -175,7 +182,7 @@ items:
     accuracyAimed: 90 #-10 vs Longlas
     tuAuto: 33 # 40k 34
     tuSnap: 25
-    tuAimed: 60 
+    tuAimed: 60
 
   - type: STR_LASGUN_ACCATRAN # done # Carbine # more accurate # higher firing rate
     dropoff: 4
@@ -197,8 +204,8 @@ items:
   - type: STR_LASGUN_VOSTROYA # done # long barrel
     dropoff: 3 #-1
     autoRange: 13
-    snapRange: 22 
-    aimRange: 30 #make it a option vs longlas, slightly worse at the sniping role 
+    snapRange: 22
+    aimRange: 30 #make it a option vs longlas, slightly worse at the sniping role
 
     accuracyAuto: 50
     accuracySnap: 80
@@ -206,10 +213,10 @@ items:
     tuAuto: 40
     tuSnap: 30
     tuAimed: 65
-  
+
   - type: STR_LASGUN_LUCIUS # done # power shot
     dropoff: 4
-    autoRange: 0 
+    autoRange: 0
     snapRange: 16
     aimRange: 16 # Powershot
     accuracyAuto: 0 # 40k 50
@@ -225,7 +232,7 @@ items:
       shortName: STR_POWER_SHOT_COUNT
 
     tags:
-      ITEM_AIMED_POWER_BONUS: 20  
+      ITEM_AIMED_POWER_BONUS: 20
 
   - type: STR_MCLASER_RIFLE # done # MC
     dropoff: 4
@@ -251,7 +258,7 @@ items:
     accuracyAimed: 0
 
     tuAuto: 33 # 40k 34
-    tuSnap: 25 
+    tuSnap: 25
     tuAimed: 0
 
     power: 75
@@ -261,8 +268,9 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
   - type: STR_HOTSHOT_VOLLEY_GUN # done # Power Pack
     dropoff: 4
@@ -271,21 +279,22 @@ items:
     aimRange: 0
 
     accuracyAuto: 50 # 40k 60
-    accuracySnap: 60 # 40k 70 
+    accuracySnap: 60 # 40k 70
     accuracyAimed: 0
     tuAuto: 40
     tuSnap: 25
     tuAimed: 0
 
-    power: 65 # 40k 75  
+    power: 65 # 40k 75
     damageType: 1 # AP instead of LAS
     damageAlter:
       ToArmorPre: 0.3
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
     confSnap:
       shots: 3 # 40k 2
@@ -317,27 +326,28 @@ items:
     confAimed:
       shots: 1
       spendPerShot: 8 # + 2 heat
-      name: STR_POWER_SHOT_2    
+      name: STR_POWER_SHOT_2
       shortName: STR_POWER_SHOT_2_COUNT
 
     clipSize: 900 # shouldn't deplete
 
-    power: 65 
+    power: 65
     damageType: 1
     damageAlter:
       ToArmorPre: 0.3
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     tags:
-      ITEM_AUTO_POWER_BONUS: 20  
+      ITEM_AUTO_POWER_BONUS: 20
       ITEM_AIMED_POWER_BONUS: 30
 
 ## Heavy Weapons
 
-  - type: STR_LASCAN # done # Marine Lascannon 
+  - type: STR_LASCAN # done # Marine Lascannon
     dropoff: 3
     autoRange: 0
     snapRange: 22
@@ -384,7 +394,8 @@ items:
 
 ## Snipers
 
-  - type: STR_LONGLAS # done
+  - type: STR_LONGLAS # done STR_CAT_SNIPER
+    categories: [STR_CAT_LASGUN, STR_CAT_SNIPER]
     dropoff: 2
     autoRange: 0
     snapRange: 22
@@ -397,10 +408,16 @@ items:
     tuSnap: 35
     tuAimed: 65
 
-    accuracyMultiplier:
-      firing: 1
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
 
-  - type: STR_LONGLAS_TANITH # done
+    tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
+      ITEM_IS_HEAVY_WEAPON: 1
+
+  - type: STR_LONGLAS_TANITH # done STR_CAT_SNIPER
+    categories: [STR_CAT_LASGUN, STR_CAT_SNIPER]
     dropoff: 2
     autoRange: 0
     snapRange: 22
@@ -413,8 +430,13 @@ items:
     tuSnap: 35
     tuAimed: 60
 
-    accuracyMultiplier:
-      firing: 1
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
+
+    tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
+      ITEM_IS_HEAVY_WEAPON: 1
 
 ## Vehicles (Sentinels, etc.)
 
@@ -434,12 +456,13 @@ items:
     autoShots: 5
     power: 60
     damageType: 1
-    damageAlter: 
+    damageAlter:
       ToArmorPre: 0.3
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
   - type: STR_SLASCAN # done # Sentinel
     dropoff: 3
@@ -460,10 +483,11 @@ items:
       ToArmorPre: 0.3
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
-  - type: STR_SLASCANPD # done # Arbites 
+  - type: STR_SLASCANPD # done # Arbites
     dropoff: 3
     autoRange: 0
     snapRange: 25
@@ -482,8 +506,9 @@ items:
       ToArmorPre: 0.3
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
   - type: AUX_HOVERTANK_LASER # done # player Dread
     dropoff: 3
@@ -506,8 +531,9 @@ items:
       ToArmorPre: 0.3
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
   - type: STR_HOVERTANK_LASER # done # not used
     dropoff: 3
@@ -530,8 +556,9 @@ items:
       ToArmorPre: 0.3
       ToHealth: 1.0
       ToArmor: 0.1
-      ToStun: 0.0
-      ToWound: 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
 
 
 ## Mounted (Chimera turrets and similar count as mounted)

--- a/Ruleset/BALANCE/las_ammo.rul
+++ b/Ruleset/BALANCE/las_ammo.rul
@@ -3,12 +3,12 @@ items:
   - &LASGUN_DAMAGE_ALTER
     type: STR_LASPISTOL_CLIP
     damageType: 1 # AP instead of LAS
-    damageAlter: 
+    damageAlter:
       ToArmorPre: 0.2
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0 # hardly makes a difference
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
     clipSize: 30
 
   - type: STR_LASPISTOL_CLIP_HOTSHOT
@@ -36,7 +36,7 @@ items:
   - type: STR_LASCANNON_CLIP_MALTHUS #LASCANON MALTHUS POWER PACK               2018
     power: 140
     damageType: 4
-    RandomType: 2 #50-150 
+    RandomType: 2 #50-150
     damageAlter: #DA LAS MELTA
       ToArmorPre: 0.5
       ToHealth: 0.8
@@ -46,7 +46,7 @@ items:
     powerRangeThreshold: 16
     powerRangeReduction: 5 # lowers power by 5 by each tile beyond 10, at range 20 it has lost 50 power.
 
-  - type: STR_LASCAN_CLIP #LASCANON CLIP 
+  - type: STR_LASCAN_CLIP #LASCANON CLIP
     power: 220
     damageAlter: #DA LAS
       RandomType: 7 #50-200
@@ -54,7 +54,7 @@ items:
       ToHealth: 1.0
       ToArmor: 0.2
       ToStun: 0.0
-      
+
   - type: STR_LASCANNON_CLIP_SMALL
     power: 220
     damageAlter: #DA LAS
@@ -82,7 +82,7 @@ items:
     armor: 200
     hitSound: {mod: 40k, index: 19}
     hitAnimation: {mod: 40k, index: 36}
-    RandomType: 2 #50-150 
+    RandomType: 2 #50-150
     power: 60 #-5 vs Hotshot volleygun, higher ROF instead
     damageType: 1 # AP instead of LAS
     damageAlter: #Hotshot
@@ -90,8 +90,8 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
     followProjectiles: false   # the camera stays still while shooting (prevents minigun seizures)
     clipSize: 200
     powerRangeThreshold: 16

--- a/Ruleset/ENEMY/GENE/weapons_gene.rul
+++ b/Ruleset/ENEMY/GENE/weapons_gene.rul
@@ -153,7 +153,7 @@ items:
     fireSound: 2419 #silentshot
     hitSound: {mod: 40k, index: 101} #stabhit
     hitAnimation: 2190 #purple juice
-    power: 50
+    power: 30
     accuracySnap: 50
     accuracyAimed: 80
     tuSnap: 45
@@ -167,7 +167,7 @@ items:
       ToWound: 0.05
       ToArmor: 0.05
       ToTime: 0.6
-      RandomType: 2 #TFTD [50% - 150%]
+      RandomType: 6 #gaussian
     battleType: 1
     twoHanded: true
     fixedWeapon: true
@@ -175,9 +175,14 @@ items:
     invWidth: 2
     invHeight: 3
     clipSize: -1
+    kneelBonus: 130
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
       INFECTION_TYPE: 2 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 100 #sniper weapon; aimed shots target vitals
+      ITEM_POWER_BONUS_PERCENTILE: 1
     specialChance: 10
     zombieUnit: STR_GSC_ZOMBIE #generic placeholder
     zombieUnitByArmorMale: { STR_JARMOR_UCM: STR_MARINE_ZOMBIE_TACTICAL_M, STR_JARMORH_UC: STR_MARINE_ZOMBIE_TACTICAL_M,

--- a/Ruleset/ENEMY/ORK/weapons_ORK.rul
+++ b/Ruleset/ENEMY/ORK/weapons_ORK.rul
@@ -5,6 +5,14 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
+      ITEM_RECOIL: int
+      ITEM_HAS_BIPOD: int
+      ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
 
 items:
 
@@ -1507,7 +1515,7 @@ items:
     recover: false
 
   - type: STR_ORK_SNIPER_RIFLE
-    categories: [STR_CAT_ORK, STR_CAT_SNIPER]
+    categories: [STR_CAT_ORK, STR_CAT_SNIPER, STR_CAT_SCOUT]
     size: 0.2
     dropoff: 3
     requires:
@@ -1519,7 +1527,7 @@ items:
     handSprite: 2250
     bulletSprite: {mod: 40k, index: 6}
     fireSound: {mod: 40k, index: 12 }
-    accuracySnap: 80
+    accuracySnap: 50
     accuracyAimed: 125
     accuracyMultiplier:
       firing: [0.5, 0.005]
@@ -1534,9 +1542,15 @@ items:
     invHeight: 3
     bulletSpeed: 50
     listOrder: 6940
+    kneelBonus: 150
+    tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 25 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
+      ITEM_RECOIL: 50 #autocannon recoil; because it's a looted autocannon
+      ITEM_IS_HEAVY_WEAPON: 1 # infantry but not mounted/vehicle heavy weapons
 
   - type: STR_ORK_AUTOCANNON_CLIP
-    categories: [STR_CAT_ORK]
+    categories: [STR_CAT_ORK, STR_CAT_SNIPER, STR_CAT_SCOUT]
     size: 0.3
     requires:
       - STR_XENO_ONLY
@@ -1547,13 +1561,14 @@ items:
     handSprite: {mod: 40k, index: 880 }
     hitSound: {mod: 40k, index: 13}
     hitAnimation: {mod: 40k, index: 26}
-    power: 110
+    power: 100
     damageType: 1
     clipSize: 3
     battleType: 2
     invWidth: 1
     invHeight: 1
     damageAlter: #DA BOLTER
+      RandomType: 6 #gaussian distribution for sniper type weapon
       ToArmorPre: 0.05
       ArmorEffectiveness: 0.9
       ToArmor: 0.1
@@ -1627,6 +1642,7 @@ items:
 
 #NECRON Items
   - type: STR_TRIPLE_GAUSS_CANNON   #              18017
+    categories: [STR_CAT_NECRON, STR_CAT_DEVASTATOR]
     damageAlter: #DA GUASS
       RandomType: 6 #Gauss has... gaussian damage. Consistent.
       ArmorEffectiveness: 1.0 #destroys armor; doesn't ignore it.
@@ -1656,6 +1672,7 @@ items:
       - STR_XENO_ONLY
 
   - type: STR_GAUSS_CANNON   #              18016
+    categories: [STR_CAT_NECRON, STR_CAT_DEVASTATOR]
     damageAlter: #DA GUASS
       RandomType: 6 #Gauss has... gaussian damage. Consistent.
       ArmorEffectiveness: 1.0 #destroys armor; doesn't ignore it.
@@ -1672,6 +1689,7 @@ items:
       - STR_XENO_ONLY
 
   - type: STR_GAUSS_FLAYER     #              18010
+    categories: [STR_CAT_NECRON, STR_CAT_TACTICAL]
     tuSnap: 33 #can manage 3 shots if you don't move
     damageAlter: #DA GUASS
       RandomType: 6 #Gauss has... gaussian damage. Consistent.
@@ -1711,9 +1729,8 @@ items:
       - STR_XENO_ONLY
 
   - type: STR_SYNAPTIC_DISINTEGRATOR #        18011
+    categories: [STR_CAT_NECRON, STR_CAT_SNIPER, STR_CAT_SCOUT]
     power: 40 #power scales with accuracy
-    damageBonus: #sniper rifle; lethality scales with accuracy
-      firing: [0.0, 0.002]
     accuracyMultiplier: #sniper rifle accuracy
       firing: [0.5, 0.005]
     damageType: 6 #stun damage type; this is mostly useless against inorganics
@@ -1728,13 +1745,15 @@ items:
       ToTime: 0.3 #disorienting
       ArmorEffectiveness: 0.4
       FixRadius: 0
+    kneelBonus: 130 #light sniper weapon; benefits twice as much from kneeling
     tags:
-      ITEM_AIMED_POWER_BONUS: 20 #Sniper rifle bonus to aimed shots; power of precision
-    kneelBonus: 130 #sniper weapon; benefits twice as much from kneeling
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 100 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
     requires:
       - STR_XENO_ONLY
 
   - type: STR_GAUSS_BLASTER    #              18015
+    categories: [STR_CAT_NECRON, STR_CAT_DEVASTATOR]
     snapRange: 20 #improved range due to heavy weapon
     tuSnap: 48 #can manage 2 shots if you don't really move
     damageAlter: #DA GUASS

--- a/Ruleset/ENEMY/TZEENTCH/weapons_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/weapons_tzeentch.rul
@@ -5,6 +5,11 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
     #Infection system vars
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
@@ -158,9 +163,12 @@ items:
     compatibleAmmo:
       - STR_LASGUN_CLIP
       - STR_LASGUN_CLIP_HOTSHOT_CHAOS
+    kneelBonus: 130
     tags:
-      ITEM_SNAP_POWER_BONUS: 10
-      ITEM_AIMED_POWER_BONUS: 20
+      ITEM_SNAP_ACCURACY_POWER_BONUS: 10
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
+
     battleType: 1
     twoHanded: true
     invWidth: 1

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -23,6 +23,17 @@ extended:
       YTAG_DAMAGE_RETURNED_AS_MORALE: int
       YTAG_DAMAGE_RETURNED_AS_STUN: int
       YTAG_DAMAGE_RETURNED_RESIST_TYPE: int
+#aim mode damage bonuses
+      ITEM_AUTO_POWER_BONUS: int
+      ITEM_SNAP_POWER_BONUS: int
+      ITEM_AIMED_POWER_BONUS: int
+      ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
+
 
 items:
   - type: STR_SCARE_GRENADE #Scare Gas Grenade, pink gas
@@ -185,8 +196,6 @@ items:
     fireSound: {mod: 40k, index: 741}
     accuracySnap: 70
     accuracyAimed: 90
-    accuracyMultiplier:
-      firing: [0.5, 0.005]
     tuSnap: 35
     tuAimed: 65
     snapRange: 33
@@ -199,6 +208,12 @@ items:
     invHeight: 3
     bulletSpeed: 50
     listOrder: 11050
+    kneelBonus: 130
+    accuracyMultiplier:
+      firing: [0.5, 0.005]
+    tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
 
   - type: STR_LASGUN_CLIP_HOTSHOT_CHAOS
     categories: [STR_CAT_LASGUN, STR_CAT_SNIPER]
@@ -3401,6 +3416,12 @@ items:
     invHeight: 3
     listOrder: 11905
     bulletSpeed: 50
+    kneelBonus: 150
+    accuracyMultiplier:
+      firing: [0.5, 0.005]
+    tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
 
   - type: STR_CHAOS_ROCKET_LAUNCHER #                 12110
     categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR, STR_CAT_CHAOS]

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -5,6 +5,11 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
 #bomb/kamikazi scripts
       ITEM_IS_BOMB: int #does this blow up with manual activation? The bomb fuse timer is equal to this value - 1.
       ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death? The bomb fuse timer is equal to this value - 1.
@@ -2029,8 +2034,6 @@ items:
       ToHealth: 0.7
       ToTime: 0.5 #higher than normal TU depletion
       RandomType: 6 #gaussian
-    accuracyMultiplier: #sniper rifle accuracy
-      firing: [0.5, 0.005]
     damageBonus: #sniper weapon; power scales with accuracy
       firing: 0.3
     battleType: 1
@@ -2040,10 +2043,14 @@ items:
     invWidth: 2
     invHeight: 3
     clipSize: -1
+    kneelBonus: 130
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
     tags:
       INFECTION_DAMAGE_PERCENT: 100 #inflicts % of damage dealt as infection damage
       INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
-      ITEM_AIMED_POWER_BONUS: 30 #sniper weapon; aimed shots target vitals
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 100 #sniper weapon; aimed shots target vitals
+      ITEM_POWER_BONUS_PERCENTILE: 1
     specialChance: 10 #low chance of zombifying
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
     #Armors go left side of the colon, units go right side of the colon
@@ -2886,7 +2893,7 @@ items:
       ToStun: 0.5 #Tzeentch attacks assail the mind and are stunning
       ToTime: 0.4 #Tzeentch attacks assail the mind and are stunning
       ToTile: 6.0
-      ToWound: 0.00
+      ToWound: 0.05 #melta level wounds
       RandomWound: false
       TileDamageMethod: 2
     shotgunBehavior: 1

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -14,7 +14,16 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
       ITEM_IS_TOOL: int
+
+      ITEM_RECOIL: int
+      ITEM_HAS_BIPOD: int
+      ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
 
 items:
   - type: STR_LASGUN_ESCHER
@@ -553,7 +562,6 @@ items:
       - STR_HC_AP_AMMO
       - STR_HC_HE_AMMO
       - STR_HC_I_AMMO
-    kneelBonus: 150
     battleType: 1
     twoHanded: true
     blockBothHands: true
@@ -572,8 +580,14 @@ items:
     tuAimed: 80 #-10 vs Marine
     autoShots: 1
     listOrder: 11900
+    kneelBonus: 130
+    accuracyMultiplier:
+      firing: [0.5, 0.005]
     tags:
       ITEM_RECOIL: 20
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 25
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
+
 
   - type: STR_HEAVY_SNIPER_RIFLEG # GUARD autocannon based sniper rifle
     categories: [STR_CAT_SNIPER]
@@ -593,7 +607,6 @@ items:
     compatibleAmmo:
       - STR_HEAVY_SNIPER_RIFLEG_AMMO
       - STR_HEAVY_SNIPER_RIFLEG_AMMO_PENETRATOR
-    kneelBonus: 150
     battleType: 1
     twoHanded: true
     blockBothHands: true
@@ -602,19 +615,24 @@ items:
     armor: 200
     bulletSpeed: 50
     autoRange: 0
-    snapRange: 0
+    snapRange: 20
     aimRange: 33
     accuracySnap: 0
     accuracyAuto: 0
     accuracyAimed: 90
     tuAuto: 0
-    tuSnap: 0
+    tuSnap: 45
     tuAimed: 60
     autoShots: 1
     listOrder: 10775
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
+    kneelBonus: 150
     tags:
       ITEM_RECOIL: 50
-
+      ITEM_IS_HEAVY_WEAPON: 1
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 25
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
 
   - type: STR_HEAVY_SNIPER_RIFLEG_AMMO
     categories: [STR_CAT_SNIPER]
@@ -635,7 +653,7 @@ items:
     invHeight: 2
     damageAlter:
       ToTile: 0.0
-      RandomType: 7
+      RandomType: 6
       ArmorEffectiveness: 0.8
     damageType: 1
     clipSize: 3
@@ -665,8 +683,10 @@ items:
     clipSize: 3
     damageAlter:
       ToTile: 0.0
-      RandomType: 7
-      ArmorEffectiveness: 0.6
+      RandomType: 6
+      ArmorEffectiveness: 0.5 #armor piercing
+      ToHealth: 0.7 #armor piercing
+      ToArmor: 0.05 #armor piercing
     power: 130
     listOrder: 10778
     tags:
@@ -745,8 +765,9 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     followProjectiles: false   # the camera stays still while shooting (prevents minigun seizures)
     sprayWaypoints: 2
     recover: true
@@ -796,8 +817,9 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     followProjectiles: false   # the camera stays still while shooting (prevents minigun seizures)
     sprayWaypoints: 2
     recover: false #armor attached specialWeapon
@@ -847,8 +869,9 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     followProjectiles: false   # the camera stays still while shooting (prevents minigun seizures)
     sprayWaypoints: 2
     recover: false #armor attached specialWeapon
@@ -2026,6 +2049,7 @@ items:
       time: true
 
   - type: STR_EXITUS_BUILTIN
+    categories: [STR_CAT_SNIPER]
     size: 0.3
 #    costBuy: 18400
 #    costSell: 4800
@@ -2050,9 +2074,24 @@ items:
     recover: false
     fixedWeapon: true
     fixedWeaponShow: true
+    dropoff: 3
+    autoRange: 0
+    snapRange: 21
+    aimRange: 32
+    accuracyAuto: 0
+    accuracySnap: 80
+    accuracyAimed: 160
+    tuAuto: 0
+    tuSnap: 40
+    tuAimed: 85
+    kneelBonus: 150
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
     tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
       ITEM_COLOR_CHANGES_WITH_AMMO_NON_GRAY: 6
-
+      ITEM_IS_HEAVY_WEAPON: 1
 
 
   - &STR_EXITUS_BULLETS

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -6,6 +6,11 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
       ITEM_RECOIL: int
       ITEM_HAS_BIPOD: int
       ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
@@ -42,7 +47,6 @@ items:
       - STR_HEAVY_ROCKET_HE
       - STR_HEAVY_ROCKET_KRAK
       - STR_HEAVY_ROCKET
-
 
   - type: STR_PISTOL  #BOLTER PISTOL  10100
     armor: 200
@@ -109,6 +113,13 @@ items:
     armor: 200
     requiresBuy:
       - STR_MARINES_AND_INQUISITION
+    accuracyMultiplier: #sniper rifle accuracy
+      firing: [0.5, 0.005]
+    tags:
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
+      ITEM_RECOIL: 25
+      ITEM_IS_HEAVY_WEAPON: 1 # infantry but not mounted/vehicle heavy weapons
 
   - type: STR_SHOTGUN
     weight: 10 #+3 from 7 vanilla, makes the low weight carbines more attractive.
@@ -130,12 +141,36 @@ items:
   - type: STR_HC_AP_AMMO #SNIPER AP                   11910
     costBuy: 4000 #far better than hotshot cells or AP Stub Rifle rounds, but half the clipsize so2x the cost
     costSell: 1000
+    damageAlter:
+      RandomType: 6
+      ArmorEffectiveness: 0.5 #Armor piercing; reduced health damage in exchange for armor piercing
+      ToHealth: 0.6 #Armor piercing; reduced health damage in exchange for armor piercing
+      ToArmor: 0.05 #minor armor damage on penetration
+      ToTile: 0.0
+
   - type: STR_HC_HE_AMMO #SNIPER HE                   11920
-    costBuy: 2000
-    costSell: 500
+    costBuy: 4000
+    costSell: 1000
+    damageAlter: #effectively a high powered bolter round
+      ToArmorPre: 0.1 # was 0.05
+      ArmorEffectiveness: 0.8 # was 0.9
+      ToArmor: 0.1
+      ToHealth: 1.15
+      ToStun: 0.5
+      FixRadius: 1
+      RandomType: 6
+
   - type: STR_HC_I_AMMO #SNIPER I                     11930
-    costBuy: 1000
-    costSell: 200
+    costBuy: 4000
+    costSell: 1000
+    damageAlter:
+      RandomType: 6
+      ToArmorPre: 0.05 #minor ablation
+      ArmorEffectiveness: 0.9 #minor pentration
+      FireThreshold: 0
+      IgnoreDirection: false
+      FireBlastCalc: false
+      FixRadius: 0
 
   - type: STR_STUN_SHELLS
     categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT]
@@ -407,9 +442,6 @@ items:
       FixRadius: 0
       ArmorEffectiveness: 1
       ToArmor: 0.1
-
-  - type: STR_HC_I_AMMO #SNIPER I
-    refNode: *STR_INC_AMMO
 
   - type: STR_INCENDIARY_ROCKET
     refNode: *STR_INC_AMMO
@@ -727,8 +759,9 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     vaporColor: 2
     vaporDensity: 8
     meleeHitSound: {mod: 40k, index: 101}
@@ -843,8 +876,9 @@ items:
       ArmorEffectiveness: 0.75
       ToHealth: 1.0
       ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.0
-      ToWound: 0.0 # added this
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
     vaporColor: 2
     vaporDensity: 8
     invWidth: 2
@@ -857,7 +891,8 @@ items:
     blockBothHands: true
     listOrder: 10764
     tags:
-      ITEM_AIMED_POWER_BONUS: 50 #Precision Shot Bonus
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 100 #Precision Shot Bonus
+      ITEM_POWER_BONUS_PERCENTILE: 1 #use %
       ITEM_IS_HEAVY_WEAPON: 1 #Sniper platform
 
 

--- a/Ruleset/scripts/scripts_TU_accuracy_penalty.rul
+++ b/Ruleset/scripts/scripts_TU_accuracy_penalty.rul
@@ -25,22 +25,6 @@ items:
 #    tags:
 #      ITEM_IS_HEAVY_WEAPON: 1
 
-  - type: STR_HEAVY_CANNON # Sniper
-    tags:
-      ITEM_IS_HEAVY_WEAPON: 1
-
-  - type: STR_EXITUS_BUILTIN # Sniper
-    tags:
-      ITEM_IS_HEAVY_WEAPON: 1
-
-  - type: STR_LONGLAS # Sniper # Las
-    tags:
-      ITEM_IS_HEAVY_WEAPON: 1
-
-  - type: STR_LONGLAS_TANITH # Sniper # Las
-    tags:
-      ITEM_IS_HEAVY_WEAPON: 1
-
   - type: STR_HEAVY_STUBBER # HW Bipod
     tags:
       ITEM_IS_HEAVY_WEAPON: 1
@@ -129,10 +113,6 @@ items:
       ITEM_IS_HEAVY_WEAPON: 1
 
   - type: STR_LASCAN_MALTHUS #light lascannon
-    tags:
-      ITEM_IS_HEAVY_WEAPON: 1
-
-  - type: STR_SNIPER_ARCHE #battle rifle sniper
     tags:
       ITEM_IS_HEAVY_WEAPON: 1
 

--- a/Ruleset/scripts/scripts_highpower_shot.rul
+++ b/Ruleset/scripts/scripts_highpower_shot.rul
@@ -1,4 +1,4 @@
-#items: 
+#items:
 #  - type: STR_LASGUN_LUCIUS
 #    confAuto:
 #      shots: 1
@@ -7,15 +7,20 @@
 #    compatibleAmmo:
 #      - STR_LASGUN_CLIP
 #    tags:
-#      ITEM_AUTO_POWER_BONUS: 20      
+#      ITEM_AUTO_POWER_BONUS: 20
 
 extended:
   tags:
     RuleItem:
-      ITEM_AUTO_POWER_BONUS: int
+      ITEM_AUTO_POWER_BONUS: int #percent bonus to damage equal to this amount for this fire mode
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
   scripts:
     hitUnit: # increase power if bonus exists for fire mode
       - new: ROSIGMA_hU_highpower_shot
@@ -23,6 +28,8 @@ extended:
         code: |
           var int weaponPower;
           var int powerBonus;
+          var int accuracyBonus;
+          var int temp;
           var ptr RuleItem rItem;
           var ptr BattleItem ammoItem;
 
@@ -30,35 +37,55 @@ extended:
 
           if eq battle_action battle_action_snapshot;
             rItem.getTag powerBonus Tag.ITEM_SNAP_POWER_BONUS;
+            rItem.getTag accuracyBonus Tag.ITEM_SNAP_ACCURACY_POWER_BONUS;
           end;
 
           if eq battle_action battle_action_autoshoot;
             rItem.getTag powerBonus Tag.ITEM_AUTO_POWER_BONUS;
+            rItem.getTag accuracyBonus Tag.ITEM_AUTO_ACCURACY_POWER_BONUS;
           end;
 
           if eq battle_action battle_action_aimshoot;
             rItem.getTag powerBonus Tag.ITEM_AIMED_POWER_BONUS;
+            rItem.getTag accuracyBonus Tag.ITEM_AIMED_ACCURACY_POWER_BONUS;
           end;
 
           if eq battle_action battle_action_hit;
             rItem.getTag powerBonus Tag.ITEM_MELEE_POWER_BONUS;
           end;
 
-          if eq powerBonus 0;
+          if gt accuracyBonus 0; #if we're scaling the bonus with firing accuracy, we define the bonus here
+            attacker.Stats.getFiring powerBonus; #get attacker's firing accuracy
+            #debug_log "ROSIGMA_hU_highpower_shot: Attacker's accuracy bonus." powerBonus;
+            muldiv accuracyBonus powerBonus 100;
+            set powerBonus accuracyBonus;
+          end;
+
+          if eq powerBonus 0; #cancel out if our powerBonus is undefined
+            #debug_log "ROSIGMA_hU_highpower_shot: No power bonus detected; aborting.";
             return power part side;
           end;
 
-          weapon_item.getAmmoItem ammoItem;
-          ammoItem.getRuleItem rItem;
-          rItem.getPower weaponPower;
 
-          # debug_log "Old Power" power;
+          rItem.getTag temp Tag.ITEM_POWER_BONUS_PERCENTILE; #check whether we're using a percentile or flat bonus
+
+          if eq temp 0;
+            weapon_item.getAmmoItem ammoItem;
+            ammoItem.getRuleItem rItem;
+            rItem.getPower weaponPower; #this will be a defacto flat bonus to damage
+            #debug_log "ROSIGMA_hU_highpower_shot: Flat damage bonus.";
+          else;
+            set weaponPower 100; #this will be a percentile bonus to damage
+            #debug_log "ROSIGMA_hU_highpower_shot: Percentile damage bonus.";
+          end;
+
+          #debug_log "ROSIGMA_hU_highpower_shot: Old Power" power;
 
           muldiv powerBonus power weaponPower;
           add power powerBonus;
 
 
-          # debug_log "Bonus Power" powerBonus;
-          # debug_log "New Power" power;
+          #debug_log "ROSIGMA_hU_highpower_shot: Bonus Power" powerBonus;
+          #debug_log "ROSIGMA_hU_highpower_shot: New Power" power;
 
           return power part side;

--- a/Ruleset/scripts/scripts_plasma_heat.rul
+++ b/Ruleset/scripts/scripts_plasma_heat.rul
@@ -10,6 +10,11 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
     BattleItem:
       ITEM_HEAT_CURRENT_LEVEL: int
       ITEM_HEAT_PREVIOUS_AMMO_COUNT: int

--- a/Ruleset/scripts/scripts_statsforNerds.rul
+++ b/Ruleset/scripts/scripts_statsforNerds.rul
@@ -51,6 +51,11 @@ extended:
       ITEM_SNAP_POWER_BONUS: int
       ITEM_AIMED_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
+      ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
+      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+
       ITEM_HEAT_AMMO_SPENT_FOR_INCREASE: int
       GravPercentage: int
     RuleArmor:
@@ -138,6 +143,22 @@ extended:
           rule.getTag temp Tag.ITEM_MELEE_POWER_BONUS;
           if gt temp 0;
             stats_state.addIntRow "STR_MELEE_POWER_BONUS" temp;
+          end;
+          rule.getTag temp Tag.ITEM_AIMED_ACCURACY_POWER_BONUS;
+          if gt temp 0;
+            stats_state.addIntRow "STR_AIMED_ACCURACY_POWER_BONUS" temp;
+          end;
+          rule.getTag temp Tag.ITEM_SNAP_ACCURACY_POWER_BONUS;
+          if gt temp 0;
+            stats_state.addIntRow "STR_SNAP_ACCURACY_POWER_BONUS" temp;
+          end;
+          rule.getTag temp Tag.ITEM_AUTO_ACCURACY_POWER_BONUS;
+          if gt temp 0;
+            stats_state.addIntRow "STR_AUTO_ACCURACY_POWER_BONUS" temp;
+          end;
+          rule.getTag temp Tag.ITEM_POWER_BONUS_PERCENTILE;
+          if gt temp 0;
+            stats_state.addIntRow "STR_POWER_BONUS_PERCENTILE" "STR_YES";
           end;
           rule.getTag temp Tag.ITEM_HEAT_MAX_LEVEL;
           if gt temp 0;


### PR DESCRIPTION
1. Standardized most sniper rifles in the game to use gaussian damage randomization, improved kneel bonuses, and heavy weapon classifications/recoil where appropriate.

2. Rebalanced some types of sniper ammunition to either be closer to canon representations (Exitus) or existing mechanical conventions with regards to things like typical armor piercing properties and so on (standard sniper rounds).

3. Fire Mode Power Bonus Scripts can now either scale with a % of the user's Firing Accuracy or a flat amount. This bonus can now also be either a flat amount added to weapon power, or a percentage of the weapon's power.