### PR TITLE
Balance Changes: Orbital Beacon, Trading Post, Grenades

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -2423,7 +2423,12 @@ en-US:
   STR_MINEFIELD: "Minefield"
   STR_OUTPOST_ADEPTAS: "Adeptas Outpost"
   STR_TRAINCAMP: "Training Camp"
-  STR_MARKET: "Market"
+  STR_MARKET: "Trading Station"
+  STR_MARKET_UFOPEDIA: "{NEWLINE}A trading outpost where rare and valuable supplies and commodities across the globe are stored, sold and transacted.
+    {NEWLINE}
+    {NEWLINE}> {ALT}Summary:{ALT} Unlocks high value goods for sale. Provides room for 30 units and 500 storage space. Generates 200000 income per month."
+  STR_MARKET_GOODS: "Trade Goods"
+  STR_MARKET_GOODS_UFOPEDIA: "Spare parts, medical supplies, construction materials, machinery, food and drink, and other sundry goods and commodities, purchased and transacted in bulk; the true life blood of the Imperium. These can be acquired and resold for a tidy profit."
   STR_ADEPTAS_CONVENT: "Adeptas Convent Barracks"
   STR_ADEPTAS_CONVENT_UFOPEDIA: "{NEWLINE}Training ground, quarters and spiritual center for the Sisters of Battle, the Adeptas Convent Barracks allow for the training and recruitment of Battle Sisters."
   STR_ADEPTAS_RECRUITMENT: "Adeptas Recruitment"
@@ -3011,7 +3016,6 @@ en-US:
   STR_AUTO_POWER_BONUS: "Power Bonus for Auto"
   STR_SNAP_POWER_BONUS: "Power Bonus for Snap"
   STR_AIMED_POWER_BONUS: "Power Bonus for Aimed"
-  STR_MELEE_POWER_BONUS: "Power Bonus for Melee"
   STR_MELEE_POWER_BONUS: "Power Bonus for Melee"
   STR_AUTO_ACCURACY_POWER_BONUS: "Auto Mode Firing Accuracy Power Bonus"
   STR_SNAP_ACCURACY_POWER_BONUS: "Snap Shot Firing Accuracy Power Bonus"

--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -8966,17 +8966,18 @@ manufacture:
     requiredItems:
       STR_ALIEN_ALLOYS: 40
       STR_ELERIUM_115: 100
-  - name: STR_TANK_LASER_CANNON
+  - name: STR_TANK_LASER_CANNON #orbital strike
     category: STR_HEAVY_WEAPONS_PLATFORM
     requires:
       - STR_NAVY_COMUNICATIONS
     space: 25
     time: 1200
-    cost: 400000
+    cost: 500000
     requiresBaseFunc: [COMU]
     requiredItems:
       STR_ALIEN_ALLOYS: 5
       STR_ELERIUM_115: 100
+      STR_KILLPOINT_TOKEN: 200
 
   - name: STR_HWP_FUSION_BOMB
     category: STR_AMMUNITION

--- a/Ruleset/ALLFACTIONS/facilities.rul
+++ b/Ruleset/ALLFACTIONS/facilities.rul
@@ -176,3 +176,18 @@ facilities:
 
   - type: STR_COMUNICATIONS
     workshops: 20 # was 10
+
+  - type: STR_MARKET
+    buildCost: 1000000
+    monthlyCost: -200000
+    storage: 500
+
+items:
+  - type: STR_MARKET_GOODS # trading goods
+    requiresBuyBaseFunc: [TRADE]
+    costBuy: 1000000
+    costSell: 1050000 #sell at a profit; trade money now for more money later; each trading most can earn a maximum of 250k / MO in this way.
+    size: 100 #bulk goods
+    listOrder: 19182
+    battleType: 0
+    transferTime: 720 #takes a month to arrive

--- a/Ruleset/BALANCE/explosives.rul
+++ b/Ruleset/BALANCE/explosives.rul
@@ -5,7 +5,7 @@ items:
 ## Mounted (Chimera turrets and similar count as mounted)
 
   - &STR_GRENADE_LAUNCHER
-    type: STR_GRENADE_LAUNCHER # done 
+    type: STR_GRENADE_LAUNCHER # done
     dropoff: 4
     autoRange: 0
     snapRange: 21
@@ -115,23 +115,61 @@ items:
 ## FRAG
 
   - type: STR_GRENADE #frag                #4006
+    weight: 2 #Imperial Guard should be able to throw these a reasonable distance
     throwRange: 16
+    damageType: 7
+    damageAlter:
+      ToArmorPre: 0.05 #small ablation
+      ArmorEffectiveness: 0.9 #concussive + shrapnel everywhere
+      ToHealth: 0.6 #much damage dealt in the form of debuffs
+      ToStun: 0.4 #painful
+      ToMorale: 0.5 #painful
+      ToEnergy: 0.4 #painful
+      ToWound: 0.4 #shrapnel
+      RandomWound: false
+      ToTile: 0.25 #it's shrapnel; deals relatively little damage to the terrain.
 
   - type: STR_PENITENCE_GRENADE40 #Hellspite underslung grenade
     power: 60
     damageType: 7
     damageAlter: #DA PENITENT
-      ToArmorPre: 0.2
-      ToArmor: 0.1
-      ToWound: 0.4
-      ToHealth: 0.6
-      ToStun: 0.3
-      ToMorale: 0.3
-      ToEnergy: 0.5
+      ToArmorPre: 0.05 #small ablation
+      ArmorEffectiveness: 0.9 #concussive + shrapnel everywhere
+      ToHealth: 0.6 #much damage dealt in the form of debuffs
+      ToStun: 0.4 #painful
+      ToMorale: 0.5 #painful
+      ToEnergy: 0.4 #painful
+      ToWound: 0.4 #shrapnel
       RandomWound: false
+      ToTile: 0.25 #it's shrapnel; deals relatively little damage to the terrain.
     clipSize: 3
     blastRadius: 4
 
+  - type: STR_FRAG_GRENADE_DRUM
+    damageType: 7
+    damageAlter:
+      ToArmorPre: 0.05 #small ablation
+      ArmorEffectiveness: 0.9 #concussive + shrapnel everywhere
+      ToHealth: 0.6 #much damage dealt in the form of debuffs
+      ToStun: 0.4 #painful
+      ToMorale: 0.5 #painful
+      ToEnergy: 0.4 #painful
+      ToWound: 0.4 #shrapnel
+      RandomWound: false
+      ToTile: 0.25 #it's shrapnel; deals relatively little damage to the terrain.
+
+  - type: STR_SENTINEL_FRAG_MISSILES
+    damageType: 7
+    damageAlter:
+      ToArmorPre: 0.05 #small ablation
+      ArmorEffectiveness: 0.9 #concussive + shrapnel everywhere
+      ToHealth: 0.6 #much damage dealt in the form of debuffs
+      ToStun: 0.4 #painful
+      ToMorale: 0.5 #painful
+      ToEnergy: 0.4 #painful
+      ToWound: 0.4 #shrapnel
+      RandomWound: false
+      ToTile: 0.25 #it's shrapnel; deals relatively little damage to the terrain.
 
 ## KRAK
 
@@ -144,6 +182,7 @@ items:
     # damageType: 1 # AP instead of HE
     damageAlter:
       ResistType: 1
+      ToArmorPre: 0.2 #ablates armor
       ArmorEffectiveness: 0.80
       # RandomType: 2 # side effect of other damageType
       FixRadius: 1
@@ -153,14 +192,17 @@ items:
     damageType: 3 # inherit from HE
     damageAlter:
       ResistType: 1 # set damageType to STD
+      ToArmorPre: 0.2 #ablates armor
       ArmorEffectiveness: 0.80
-      FixRadius: 1  
+      FixRadius: 1
     powerForAnimation: 5 # 5 / 5 = 1
 
   - type: STR_KRAK_GRENADE #krak
-    damageType: 3 
+    damageType: 3
+    weight: 3 #Imperial Guard should be able to throw these a reasonable distance
     damageAlter:
       ResistType: 1
+      ToArmorPre: 0.2 #ablates armor
       ArmorEffectiveness: 0.80
       FixRadius: 1
       RandomType: 7 #50-200%
@@ -170,6 +212,7 @@ items:
   - type: STR_KRAK_GRENADE_DRUM
     damageAlter:
       ResistType: 1
+      ToArmorPre: 0.2 #ablates armor
       ArmorEffectiveness: 0.80
       # RandomType: 2 # side effect of other damageType
       FixRadius: 1
@@ -182,13 +225,13 @@ items:
     costBuy: 4000 #reduced
     costSell: 2000
     weight: 5 #was 8
-    
+
   - type: STR_SENTINEL_INC_MISSILES
     clipSize: 4
     power: 90
     damageType: 2
     damageAlter:
-      ToHealth: 2   
+      ToHealth: 2
       # IgnoreSelfDestruct: false
       IgnoreDirection: false
       FireBlastCalc: false
@@ -255,12 +298,15 @@ items:
     tuAimed: 0
     accuracyAimed: 0
     power: 50
+    weight: 2 #Imperial Guard should be able to throw these a reasonable distance
     damageAlter:
       ArmorEffectiveness: 0.5
-      ToStun: 0.4 # was 0.2
-      ToTime: 0.8
+      ToStun: 0.8 #disorienting
+      ToTime: 0.8 #disorienting
       RadiusReduction: 5.0
-    throwRange: 12
+      ToArmor: 0.0 #it's a photon grenade; it doesn't damage armor
+      RandomType: 6 #gaussian; reliable
+    throwRange: 16
 
 ## Unsorted
 

--- a/Ruleset/ufopedia40k.rul
+++ b/Ruleset/ufopedia40k.rul
@@ -5227,3 +5227,10 @@ ufopaedia:
       - STR_PSI_AMP
       - STR_ELDAR_SEER #need to have knowledge of psychic powers and need to have researched a live Eldar Seer
     listOrder: 30521
+
+#Market Goods for Trading
+  - id: STR_MARKET_GOODS
+    type_id: 10
+    section: STR_UFO_COMPONENTS
+    text: STR_MARKET_GOODS_UFOPEDIA
+    image_id: 2ARVUS.SPK


### PR DESCRIPTION
1. Orbital Beacon costs slightly more money and 200 kill point tokens.

2. Trading Posts now cost 1 million but have 500 storage space, generate 200k per month, and allow the player to purchase Trading Goods for resale at a small profit after a month long delivery time.

3. Krak, frag and photon grenades now weigh slightly less and can actually be thrown an appreciable distance by Guardsmen. Frag grenade and Krak grenade effects standardized. 

Krak grenades now inflict armor ablation.

Frag explosives do much less health and terrain damage, but more wound, energy and morale damage (because they spam shrapnel) and inflict minor armor ablation.