### PR TITLE
Remove redundant handsprite; Juggernaut now up to new Khorne standard

### DIFF
--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -54,18 +54,21 @@
     race: STR_REAPER
     rank: STR_LIVE_TERRORIST
     stats:
-      tu: 85
-      stamina: 110
-      health: 250
+      tu: 128 #these things are Khornate steeds; they move fast asf boy
+      stamina: 258 #tireless daemonic steeds
+      health: 258
       bravery: 110
-      reactions: 64
+      reactions: 68
       firing: 0
       throwing: 0
-      strength: 90
-      psiStrength: 80
+      strength: 118
+      psiStrength: 88
       psiSkill: 0
-      melee: 80
+      melee: 88
     isLeeroyJenkins: true
+    intelligence: 2
+    aggression: 8
+    energyRecovery: 88 #tireless daemonic steeds
 
   - type: STR_TRAITOR_CHIMERA_TURRET
     stats:

--- a/Ruleset/ALLFACTIONS/items.rul
+++ b/Ruleset/ALLFACTIONS/items.rul
@@ -313,7 +313,6 @@ items:
     weight: 1
     floorSprite: 0
     bigSprite: {mod: 40k, index: 23}
-    handSprite: {mod: 40k, index: 504}
     twoHanded: false
     invWidth: 1
     invHeight: 2

--- a/Ruleset/ENEMY/armors_chaos.rul
+++ b/Ruleset/ENEMY/armors_chaos.rul
@@ -461,16 +461,22 @@ armors:
        stamina: 20
        health: 40
 
-  - type: STR_REAPER_ARMOR #Chaos Jugger
+  - type: STR_REAPER_ARMOR #Chaos Juggernaut
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 30
+    psiVision: 15 #bloodhunter
     spriteInv: JUGINV.SPK
     frontArmor: 150
     sideArmor: 130
     rearArmor: 130
     underArmor: 180
     moveSound: {mod: 40k, index: 700}
+    psiDefence:
+      psiStrength: 1.0
+      flatHundred: 1.0 #Khorne protects against pitiful psykers
+    fearImmune: true #it's a daemon, it doesn't care
+    painImmune: true #it's a daemon it doesn't care
     damageModifier: #VEHICLE ARMOR LARGE
       - 1.0 #none
       - 0.7 #AP

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -3000,3 +3000,38 @@ items:
       ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death
       INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
       INFECTION_TYPE: 4 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
+
+  - type: REAPER_WEAPON #Juggernaut Bite/Reaper Terrorist Bite
+    power: 0
+    weight: 0
+    damageType: 7
+    accuracyMelee: 100
+    tuMelee: 15
+    clipSize: -1
+    battleType: 3
+    fixedWeapon: true
+    invWidth: 2
+    invHeight: 3
+    recover: false
+    flatRate: true
+    damageBonus:
+      strength: 1.0 #brute strength
+    damageAlter: #Crushing, rending jaws
+      ToArmorPre: 0.1
+      ToArmor: 0.2
+      ToMorale: 2.0 #getting maimed by a juggernaut is harrowing
+      ToWound: 0.5 #rending jaws
+      ToEnergy: 0.4
+      ArmorEffectiveness: 0.9
+    tags: #Rampage mechanics; granting them power as they spill blood for Khorne
+      TAG_HP_RETURNED_ON_KILL: 88 #regains 88 HP on kill; Sacred Khorne Number
+      TAG_ENERGY_RETURNED_ON_KILL: 88 #regains 88 Energy on kill
+      TAG_TIME_RETURNED_ON_KILL: 8 #regains 8 TU on kill
+      TAG_MORALE_RETURNED_ON_KILL: 88 #regains 88 Morale on kill
+      TAG_STUN_RETURNED_ON_KILL: 88 #regains 88 Stun on kill
+      YTAG_DAMAGE_RETURNED_AS_TIME: 8 #regain 8% of damage dealt in TUs; Sacred Khorne Number
+      YTAG_DAMAGE_RETURNED_AS_HP: 8 #regain 8% of damage dealt in HP; Sacred Khorne Number
+      YTAG_DAMAGE_RETURNED_AS_ENERGY: 8
+      YTAG_DAMAGE_RETURNED_AS_MORALE: 8
+      YTAG_DAMAGE_RETURNED_AS_STUN: 8
+      YTAG_DAMAGE_RETURNED_RESIST_TYPE: 0 #untyped damage so no modifications


### PR DESCRIPTION
1. Juggernauts now have the Khorne rampage mechanics, heightened aggression and Psi Vision to aid them with their hunt. They now have heightened TUs, stamina and stamina recovery to match their distinction as a Khorne steed.

2. Removed redundant orbital strike handsprite.