### PR TITLE
Holographic Guardsman Zombification Bug Fix + Rebalance

### DIFF
--- a/Ruleset/IG/manufacture_IG.rul
+++ b/Ruleset/IG/manufacture_IG.rul
@@ -1546,3 +1546,18 @@ manufacture:
     producedItems:
       STR_ADEPTAS_CANTUSArmor: 1
       STR_KILLPOINT_TOKEN: 1
+
+  - name: STR_HOLOGRAM_GRENADE #these are too powerful to allow for purchase
+    category: STR_AMMUNITION
+    requires:
+      - STR_HOLOGRAM_GRENADE_REQUISITION
+    space: 2
+    time: 200
+    cost: 30000 #3000 per grenade
+    requiredItems:
+      STR_ALIEN_ALLOYS: 5
+      STR_ELERIUM_115: 2
+      STR_UFO_CONSTRUCTION: 1
+      STR_KILLPOINT_TOKEN: 100 #10 per
+    producedItems:
+      STR_HOLOGRAM_GRENADE: 10

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -3573,6 +3573,7 @@ items:
     categories: [ STR_CAT_GRENADES, STR_CAT_TACTICAL]
     requiresBuy:
       - STR_HOLOGRAM_GRENADE_REQUISITION
+      - STR_GENERALLOCK #these are too powerful to be able to purchase; gated with tokens
     size: 0.1
     costBuy: 15000
     costSell: 12000

--- a/Ruleset/scripts/scripts_infection_mechanics.rul
+++ b/Ruleset/scripts/scripts_infection_mechanics.rul
@@ -577,3 +577,7 @@ armors:
   - type: RTS_ARMOR #LEFT TURRET STORMTALON ARMOR
     tags:
       INFECTION_RESIST: 100 #infection immune
+
+  - type: TARGET_GUARDSMAN #holographic guardsman zombie immunity
+    tags:
+      INFECTION_RESIST: 100 #infection immune


### PR DESCRIPTION
1. Holographic Guardsmen are now immune to zombification.

2. Hologram grenades are too powerful to be purchased; they are now gated with killpoint tokens.