### PR TITLE
Khorne Update: Added Intimidation; Expanded Rampage Mechanics

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -4666,3 +4666,6 @@ en-US:
   #orbital beacon
   STR_ORBITAL_BEACON: "Orbital Beacon"
   STR_ORBITAL_STRIKE: "Orbital Strike"
+
+  #intimidation scripts
+  STR_INTIMIDATION_WEAPON: "Intimidation"

--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -4668,4 +4668,6 @@ en-US:
   STR_ORBITAL_STRIKE: "Orbital Strike"
 
   #intimidation scripts
-  STR_INTIMIDATION_WEAPON: "Intimidation"
+  STR_INTIMIDATION_WEAPON: "Terrify"
+  SILACOID_WEAPON: "Terrify"
+  STR_INTIMIDATION_NOTICE: "Unit has been intimidated!"

--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -64,7 +64,7 @@
       strength: 118
       psiStrength: 88
       psiSkill: 0
-      melee: 88
+      melee: 78 #brutish and a little clumsy
     isLeeroyJenkins: true
     intelligence: 2
     aggression: 8
@@ -4180,7 +4180,7 @@
       health: 118
       bravery: 110
       reactions: 88 #higher reactions so they're not so easy to kill when they rush a firing line
-      firing: 74
+      firing: 78
       throwing: 88
       strength: 88
       psiStrength: 118 #khorne protects from psykers
@@ -4196,27 +4196,20 @@
     moraleLossWhenKilled: 75 #expected to die
     livingWeapon: true
     builtInWeaponSets:
-      - - STR_BOLTPISTOL_CHAOS #basic loadouts
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_INTIMIDATION_WEAPON #basic loadouts
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_BOLTPISTOL_CHAOS
         - STR_PISTOL_CLIP
         - STR_PISTOL_CLIP
-      - - STR_PLASMA_PISTOL
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_PLASMA_PISTOL
         - STR_PLASMA_PISTOL_CLIP
         - STR_PLASMA_PISTOL_CLIP
-      - - STR_BOLTPISTOL_CHAOS #grenades start here
-        - STR_PISTOL_CLIP
-        - STR_PISTOL_CLIP
-        - STR_ALIEN_GRENADE
-        - STR_PHOSPHOR_GRENADE
-      - - STR_PLASMA_PISTOL
-        - STR_PLASMA_PISTOL_CLIP
-        - STR_PLASMA_PISTOL_CLIP
-        - STR_ALIEN_GRENADE
-        - STR_PHOSPHOR_GRENADE
-      - - STR_CHB #elite loadout
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_CHB #elite loadout
         - STR_HB_CLIP
         - STR_HB_CLIP
-        - STR_ALIEN_GRENADE
-        - STR_PHOSPHOR_GRENADE
 
   - type: STR_SECTOPOD2_TERRORIST #Dread2
     race: STR_SECTOPOD2
@@ -4314,6 +4307,7 @@
         - AUX_DAEMON_FIREBALL
       - - CYBERDISC_WEAPON
         - AUX_DAEMON_FIREBALL
+
   - type: STR_SILACOID_TERRORIST #khorne Deamon; Bloodletter
     race: STR_SILACOID
     rank: STR_LIVE_TERRORIST
@@ -4344,6 +4338,7 @@
     livingWeapon: true
     builtInWeaponSets:
       - - STR_SILACOID_WEAPON
+
   - type: STR_KHORNE_DEMIBLOODLETTERIN #khorne valkyria
     race: STR_KHORNE_SISTER
     rank: STR_LIVE_TERRORIST
@@ -5030,23 +5025,21 @@
     moraleLossWhenKilled: 75 #expected to die
     livingWeapon: true
     builtInWeaponSets:
-      - - STR_BOLTPISTOL_CHAOS
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_INTIMIDATION_WEAPON #basic loadouts
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_BOLTPISTOL_CHAOS
         - STR_PISTOL_CLIP
         - STR_PISTOL_CLIP
-        - STR_PISTOL_CLIP
-        - STR_AXE
-      - - STR_BOLTPISTOL_CHAOS
-        - STR_PISTOL_CLIP
-        - STR_PISTOL_CLIP
-        - STR_PISTOL_CLIP
-        - STR_AXE
-        - STR_ALIEN_GRENADE
-      - - STR_BOLTPISTOL_CHAOS
-        - STR_PISTOL_CLIP
-        - STR_PISTOL_CLIP
-        - STR_PISTOL_CLIP
-        - STR_AXE
-        - STR_ALIEN_GRENADE
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_PLASMA_PISTOL
+        - STR_PLASMA_PISTOL_CLIP
+        - STR_PLASMA_PISTOL_CLIP
+      - - STR_KHORNE_BERSERKER_AXE
+        - STR_CHB #elite loadout
+        - STR_HB_CLIP
+        - STR_HB_CLIP
+
 
   - type: STR_IRON_TERMINATOR #IRON WARRIOR CSM HEAVY WEAPONS
     race: STR_MUTON #Terminator
@@ -7283,7 +7276,7 @@
     stats:
       tu: 128
       stamina: 108
-      health: 100
+      health: 108
       bravery: 100
       reactions: 88
       firing: 68
@@ -7291,7 +7284,7 @@
       strength: 88
       psiStrength: 88
       psiSkill: 0
-      melee: 88
+      melee: 98
     armor: STR_WARPTALON_ARMOR
     isLeeroyJenkins: true
     intelligence: 2
@@ -7304,17 +7297,17 @@
     livingWeapon: true
     builtInWeaponSets:
       - - STR_KHORNE_CHAOS_CLAWS
-        - STR_KHORNE_CHAOS_CLAWS
+        - STR_INTIMIDATION_WEAPON
       - - STR_KHORNE_CHAOS_CLAWS
-        - STR_KHORNE_CHAOS_CLAWS
+        - STR_INTIMIDATION_WEAPON
       - - STR_KHORNE_CHAOS_CLAWS
-        - STR_KHORNE_CHAOS_CLAWS
+        - STR_INTIMIDATION_WEAPON
 
   - type: STR_WARPTALON_COMMANDER                                       # RANK 1 weapons done
     race: STR_KHRONE
     rank: STR_LIVE_LEADER
     stats:
-      tu: 128
+      tu: 138
       stamina: 128
       health: 128
       bravery: 110
@@ -7322,10 +7315,11 @@
       firing: 88
       throwing: 88
       strength: 98
-      psiStrength: 88
+      psiStrength: 108
       psiSkill: 0
       melee: 108
     armor: STR_WARPTALON_ARMOR
+    isLeeroyJenkins: true
     intelligence: 3
     aggression: 8
     canPanic: false
@@ -7336,11 +7330,11 @@
     livingWeapon: true
     builtInWeaponSets:
       - - STR_KHORNE_CHAOS_CLAWS
-        - STR_KHORNE_CHAOS_CLAWS
+        - STR_INTIMIDATION_WEAPON
       - - STR_KHORNE_CHAOS_CLAWS
-        - STR_KHORNE_CHAOS_CLAWS
+        - STR_INTIMIDATION_WEAPON
       - - STR_KHORNE_CHAOS_CLAWS
-        - STR_KHORNE_CHAOS_CLAWS
+        - STR_INTIMIDATION_WEAPON
 
  #Night Lords
   - type: STR_NIGHT_LORDS_SISTER   #Fake Sister

--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -7276,25 +7276,26 @@
         - STR_PISTOL_CLIP
         - STR_AXE
         - STR_MGRENADE
+
   - type: STR_WARPTALON_SOLDIER                                         # RANK 5  weapons done                 aggroSound
     race: STR_KHRONE
     rank: STR_LIVE_SOLDIER
-    isLeeroyJenkins: true
     stats:
-      tu: 120
-      stamina: 90
+      tu: 128
+      stamina: 108
       health: 100
       bravery: 100
-      reactions: 70
-      firing: 65
-      throwing: 62
-      strength: 70
-      psiStrength: 25
+      reactions: 88
+      firing: 68
+      throwing: 68
+      strength: 88
+      psiStrength: 88
       psiSkill: 0
-      melee: 76
+      melee: 88
     armor: STR_WARPTALON_ARMOR
+    isLeeroyJenkins: true
     intelligence: 2
-    aggression: 2
+    aggression: 8
     canPanic: false
     value: 30
     canBeMindControlled: false
@@ -7302,43 +7303,44 @@
     energyRecovery: 60
     livingWeapon: true
     builtInWeaponSets:
-      - - STR_CHAOS_CLAWS2
-        - STR_CHAOS_CLAWS
-      - - STR_CHAOS_CLAWS2
-        - STR_CHAOS_CLAWS
-      - - STR_CHAOS_CLAWS2
-        - STR_CHAOS_CLAWS
+      - - STR_KHORNE_CHAOS_CLAWS
+        - STR_KHORNE_CHAOS_CLAWS
+      - - STR_KHORNE_CHAOS_CLAWS
+        - STR_KHORNE_CHAOS_CLAWS
+      - - STR_KHORNE_CHAOS_CLAWS
+        - STR_KHORNE_CHAOS_CLAWS
+
   - type: STR_WARPTALON_COMMANDER                                       # RANK 1 weapons done
     race: STR_KHRONE
     rank: STR_LIVE_LEADER
     stats:
-      tu: 120
-      stamina: 90
-      health: 120
+      tu: 128
+      stamina: 128
+      health: 128
       bravery: 110
-      reactions: 80
-      firing: 75
-      throwing: 62
-      strength: 70
-      psiStrength: 50
+      reactions: 108
+      firing: 88
+      throwing: 88
+      strength: 98
+      psiStrength: 88
       psiSkill: 0
-      melee: 85
+      melee: 108
     armor: STR_WARPTALON_ARMOR
     intelligence: 3
-    aggression: 2
+    aggression: 8
     canPanic: false
     value: 40
     canBeMindControlled: false
-    energyRecovery: 40
+    energyRecovery: 88
     berserkChance: 90
     livingWeapon: true
     builtInWeaponSets:
-      - - STR_CHAOS_CLAWS2
-        - STR_CHAOS_CLAWS
-      - - STR_CHAOS_CLAWS2
-        - STR_CHAOS_CLAWS
-      - - STR_CHAOS_CLAWS2
-        - STR_CHAOS_CLAWS
+      - - STR_KHORNE_CHAOS_CLAWS
+        - STR_KHORNE_CHAOS_CLAWS
+      - - STR_KHORNE_CHAOS_CLAWS
+        - STR_KHORNE_CHAOS_CLAWS
+      - - STR_KHORNE_CHAOS_CLAWS
+        - STR_KHORNE_CHAOS_CLAWS
 
  #Night Lords
   - type: STR_NIGHT_LORDS_SISTER   #Fake Sister
@@ -7878,17 +7880,17 @@
     race: STR_KHRONE
     rank: STR_LIVE_COMMANDER
     stats:
-      tu: 120
-      stamina: 90
+      tu: 128
+      stamina: 128
       health: 140
-      bravery: 100
-      reactions: 70
-      firing: 60
-      throwing: 62
-      strength: 80
-      psiStrength: 50
+      bravery: 110
+      reactions: 98
+      firing: 88
+      throwing: 88
+      strength: 108
+      psiStrength: 88
       psiSkill: 0
-      melee: 85
+      melee: 128
     armor: STR_KHORNECHAMP_ARMOR
     intelligence: 3
     aggression: 2
@@ -7896,7 +7898,7 @@
     value: 40
     canBeMindControlled: false
     berserkChance: 99
-    energyRecovery: 40
+    energyRecovery: 88
     livingWeapon: true
     builtInWeaponSets:
       - - STR_CPOWER_AXE

--- a/Ruleset/ADEPTAS/armors_adeptas.rul
+++ b/Ruleset/ADEPTAS/armors_adeptas.rul
@@ -6,6 +6,8 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
   - type: STR_ADEPTAS_SENTINEL_LANCE_UC #Adeptas Sentinel Thermal Lance Sariel Pattern
@@ -227,6 +229,7 @@ armors:
       - STR_ASSC_CLIP
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: STR_PENITENT_ARMOR          #DREAD ARMOR NORMAL
     visibilityAtDay: 40
@@ -309,6 +312,7 @@ armors:
     drawingRoutine: 3
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     scripts:
       selectUnitSprite:
         var int aiming;
@@ -382,6 +386,7 @@ armors:
     drawingRoutine: 3
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     scripts:
       selectUnitSprite:
         var int temp;
@@ -454,6 +459,7 @@ armors:
     drawingRoutine: 3
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: SKULL_ARMOR
     visibilityAtDay: 40
@@ -492,6 +498,7 @@ armors:
     loftempsSet: [ 3 ]
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: STR_FRATERIS_MILITIA_HEAVY #Chaff Sisters Ecclesiarchy troops.
     visibilityAtDay: 40
@@ -2720,6 +2727,7 @@ armors:
       - INV_NULL_3X1_BACKPACK
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: STR_CHAOS_ADEPTAS_KHORNE_ARMOR     #ADEPTAS ELOHIM TIER
     tags:

--- a/Ruleset/ALLFACTIONS/armors.rul
+++ b/Ruleset/ALLFACTIONS/armors.rul
@@ -1,22 +1,41 @@
+extended:
+  tags:
+    RuleArmor:
+      INFECTION_RESIST: int #reduces infection damage by this as a %
+      INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+      ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
+      ARMOR_ENERGY_SHIELD_DECAY: int
+      ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
+
 armors:
   - type: TARANTULA_ARMOR
     builtInWeapons:
       - STR_T_SEC2
       - STR_T_SEC
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage
 
   - &STR_TARANTULA_BOLTER
     type: TARANTULA_BOLTER_ARMOR
     builtInWeapons:
       - STR_T_BOLTER_WEAPON
     allowsMoving: false
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage
 
   - type: TARANTULA_BOLTER_ARMOR_I
     refNode: *STR_TARANTULA_BOLTER
     ufopediaType: TARANTULA_BOLTER_ARMOR
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage
 
   - type: TARANTULA_ARBITES_BOLTER_ARMOR
     refNode: *STR_TARANTULA_BOLTER
     ufopediaType: TARANTULA_BOLTER_ARMOR
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage
 
   - type: STR_DEV_ARMOR_ULTRA #TATICAL CIVILIAN
     visibilityAtDay: 40
@@ -135,6 +154,8 @@ armors:
     movementType: 1
     builtInWeapons:
       - "STR_ORBITAL_STRIKE"
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage
 
   - type: STR_ORBITAL_ARMOR_NOORBITALSTRIKE #Rosigma Orbital Armor; disables orbital strike for interior environments
     visibilityAtDay: 60
@@ -172,3 +193,5 @@ armors:
     drawingRoutine: 12
     constantAnimation: true
     movementType: 1
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage

--- a/Ruleset/ENEMY/GENE/armors_gene.rul
+++ b/Ruleset/ENEMY/GENE/armors_gene.rul
@@ -9,6 +9,9 @@ extended:
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
       ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
+
 
 armors:
   - type: STR_GSC_ZOMBIE_ARMOR  # GSC ZOMBIE ARMOR
@@ -1395,6 +1398,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     painImmune: true
     allowInv: false
     spriteSheet: GSC_ARMORED_CAR_BS.PCK

--- a/Ruleset/ENEMY/KHORNE/armors_khorne.rul
+++ b/Ruleset/ENEMY/KHORNE/armors_khorne.rul
@@ -1,9 +1,16 @@
 extended:
   tags:
     RuleArmor:
+      INFECTION_RESIST: int #reduces infection damage by this as a %
+      INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+      INFECTION_RESIST_TYPE: int #bitmask; type of infection the unit resists. 0 = All, 1 = Nurgle, 2 = GSC, 4 = Slaanesh; 3 = Nurgle + GSC, 5 = Nurgle + Slaanesh, 6 = GSC + Slaanesh
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+      ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
+      ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
   - type: STR_ADEPTAS_KHORNE      #ADEPTAS KHORNE ARMOR
@@ -710,6 +717,8 @@ armors:
       - 1.0 #IMPACT
       - 1.2 #MELTA
     loftempsSet: [ 4 ]
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: STR_KHORNECHAMP_ARMOR
     visibilityAtDay: 40
@@ -740,8 +749,10 @@ armors:
       - 1.0 #IMPACT
       - 1.2 #MELTA]
     loftempsSet: [ 4 ]
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
-   #Khorngor Bloodgors
+  #Khorngor Bloodgors
   - type: STR_KHORNE_UNGOR_ARMOR                                 #Khorne Gor Grunt
     visibilityAtDay: 30
     visibilityAtDark: 25

--- a/Ruleset/ENEMY/KHORNE/armors_khorne.rul
+++ b/Ruleset/ENEMY/KHORNE/armors_khorne.rul
@@ -48,7 +48,7 @@ armors:
     spriteHairColor: [144, 144, 164, 164, 245, 245, 166, 166, 245, 32, 224, 224, 224, 224] #M0 F0 M1 F1 M2 F2 M3 F3 M4 F4 M5 F5 M6 F6
     corpseBattle:
       - STR_KHORNE_SISTERASS_CORPSE
-    meleeDodge: 
+    meleeDodge:
       reactions: 0.1
     stats:
        tu: 20
@@ -183,7 +183,7 @@ armors:
     spriteSheet: KhorneRetributorSuperior.PCK
     spriteInv: ARetributorSuperiorK.SPK
     corpseBattle:
-      - STR_ADEPTA_KHORNERETRIBUTORSUPERIOR_CORPSE 
+      - STR_ADEPTA_KHORNERETRIBUTORSUPERIOR_CORPSE
     stats:
        tu: 15
        stamina: 30
@@ -230,7 +230,7 @@ armors:
     spriteSheet: KhorneRetributorSuperiorblessed.PCK
     spriteInv: ARetributorSuperiorK.SPK
     corpseBattle:
-      - STR_ADEPTA_KHORNERETRIBUTORSUPERIOR_CORPSE 
+      - STR_ADEPTA_KHORNERETRIBUTORSUPERIOR_CORPSE
     stats:
        tu: 15
        stamina: 30
@@ -275,10 +275,10 @@ armors:
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 25
-    spriteSheet: KhorneRetributor.PCK 
+    spriteSheet: KhorneRetributor.PCK
     spriteInv: ARetributorK.SPK
     corpseBattle:
-      - STR_ADEPTA_KHORNERETRIBUTOR_CORPSE 
+      - STR_ADEPTA_KHORNERETRIBUTOR_CORPSE
     stats:
        tu: 10
        stamina: 20
@@ -325,7 +325,7 @@ armors:
     spriteSheet: KhorneRetributorblessed.PCK
     spriteInv: ARetributorK.SPK
     corpseBattle:
-      - STR_ADEPTA_KHORNERETRIBUTOR_CORPSE 
+      - STR_ADEPTA_KHORNERETRIBUTOR_CORPSE
     stats:
        tu: 10
        stamina: 20
@@ -457,7 +457,7 @@ armors:
       - INV_NULL_3X3
     specialWeapon: STR_MFIST
     loftempsSet: [ 3 ]
- 
+
   - type: STR_ADEPTAS_KHORNEPARMOR_BLESSED2    #Repentia Superior Armor that transforms into a bloodletter
     tags:
       #ARMOR_ENERGY_SHIELD_CAPACITY: 20
@@ -507,7 +507,7 @@ armors:
       - INV_NULL_3X3
     specialWeapon: STR_MFIST
     loftempsSet: [ 3 ]
-  
+
   - type: STR_ADEPTAS_KHORNENOVICEARMOR    #Rookie Khorne Sister Armor Open Helmet
       #ARMOR_ENERGY_SHIELD_CAPACITY: 10
       #ARMOR_ENERGY_SHIELD_PER_TURN: 10
@@ -571,7 +571,7 @@ armors:
     spriteSheet: ADEPTASKValkia.PCK
     spriteInv: DemiValkiaInv.SPK
     corpseBattle:
-      - STR_VALKIA_CORPSE_BASIC 
+      - STR_VALKIA_CORPSE_BASIC
     frontArmor: 50
     sideArmor: 40
     rearArmor: 25
@@ -601,7 +601,7 @@ armors:
     spriteSheet: DemiBloodletterin.PCK
     spriteInv: DemiValkiaInv.SPK
     corpseBattle:
-      - STR_VALKIA_CORPSE_BASIC 
+      - STR_VALKIA_CORPSE_BASIC
     frontArmor: 50
     sideArmor: 40
     rearArmor: 25
@@ -680,7 +680,7 @@ armors:
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
 
-  - type: STR_MUTON_ARMORB #KHRONE BESERKER
+  - type: STR_MUTON_ARMORB #Khorne Berserker
     visibilityAtDay: 40
     visibilityAtDark: 20
     heatVision: 30
@@ -690,6 +690,12 @@ armors:
     rearArmor: 70
     underArmor: 70
     drawingRoutine: 0
+    painImmune: true #it's a berserker it doesn't care
+    fearImmune: true #it's a berserker it doesn't care
+    psiDefence:
+      moraleCurrent: 1.0
+      flatHundred: 1.0 #Khorne protects against pitiful psykers
+    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 0.8 #AP
@@ -714,6 +720,12 @@ armors:
     sideArmor: 105
     rearArmor: 80
     underArmor: 80
+    painImmune: true #it's a berserker it doesn't care
+    fearImmune: true #it's a berserker it doesn't care
+    psiDefence:
+      moraleCurrent: 1.0
+      flatHundred: 1.0 #Khorne protects against pitiful psykers
+    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 0.8 #AP
@@ -728,14 +740,14 @@ armors:
       - 1.0 #IMPACT
       - 1.2 #MELTA]
     loftempsSet: [ 4 ]
-      
+
    #Khorngor Bloodgors
   - type: STR_KHORNE_UNGOR_ARMOR                                 #Khorne Gor Grunt
     visibilityAtDay: 30
     visibilityAtDark: 25
     heatVision: 20
-    spriteSheet: KHORNEUNGOR.PCK 
-    spriteInv: KhorneUngorInv.SPK 
+    spriteSheet: KHORNEUNGOR.PCK
+    spriteInv: KhorneUngorInv.SPK
     allowInv: true
     corpseBattle:
       - STR_KHORNEUNGOR_CORPSE
@@ -743,7 +755,7 @@ armors:
     sideArmor: 25
     rearArmor: 20
     underArmor: 30
-    drawingRoutine: 0 
+    drawingRoutine: 0
     damageModifier: #BEASTMEN ARMOR
       - 1.0 #none
       - 0.9 #AP
@@ -762,15 +774,15 @@ armors:
     visibilityAtDark: 25
     heatVision: 25
     spriteSheet: KHORNEUNGOR.PCK #placeholder
-    spriteInv: KhorngorInv.SPK 
+    spriteInv: KhorngorInv.SPK
     allowInv: true
     corpseBattle:
-      - STR_KHORNEGOR_CORPSE  
+      - STR_KHORNEGOR_CORPSE
     frontArmor: 40
     sideArmor: 35
     rearArmor: 25
     underArmor: 30
-    drawingRoutine: 0 
+    drawingRoutine: 0
     damageModifier: #BEASTMEN ARMOR
       - 1.0 #none
       - 0.9 #AP

--- a/Ruleset/ENEMY/NECRON/units_necron.rul
+++ b/Ruleset/ENEMY/NECRON/units_necron.rul
@@ -6,6 +6,10 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
+
+
 
 units:
   - type: STR_NECRON_WARRIOR_REVIVES  #STR_NECRON_WARRIOR_ARMOR                        RANK 5 weapons done
@@ -202,6 +206,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     spriteSheet: NECRONDR1_REVIVE.PCK
     deathFrames: 6
     spriteInv: NECRON1.SPK
@@ -245,6 +250,7 @@ armors:
       ARMOR_ENERGY_SHIELD_DECAY: 12
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: 6
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     visibilityAtDay: 40
     visibilityAtDark: 40
     bleedImmune: true
@@ -296,6 +302,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     spriteSheet: NECRONDR2_REVIVE.PCK
     deathFrames: 6
     spriteInv: NECRON2.SPK
@@ -335,6 +342,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     spriteSheet: NECRONDR3_REVIVE.PCK
     deathFrames: 6
     spriteInv: NECRON3.SPK

--- a/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
+++ b/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
@@ -8,6 +8,8 @@ extended:
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
       ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
   - type: GREEN_ROBE_ARMOR
@@ -1219,6 +1221,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     painImmune: true
     recovery: #Plague Daemons regenerate health
       health:

--- a/Ruleset/ENEMY/ORK/armors_ORK.rul
+++ b/Ruleset/ENEMY/ORK/armors_ORK.rul
@@ -5,6 +5,9 @@ extended:
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
+
 armors:
   - type: ORK_TURRET_ARMOR
     visibilityAtDay: 40
@@ -32,6 +35,9 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.2 #MELTA
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
+
   - type: ORK_TURRET2_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 20
@@ -39,6 +45,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     bleedImmune: true
     fearImmune: true
     painImmune: true
@@ -103,6 +110,9 @@ armors:
       - STR_BURNA_KILLA
       - STR_SCORCHA_TANK_BUILTIN
       - STR_BURNA_TANK_BUILTIN
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
+
   - type: STR_GROTS_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 20
@@ -250,6 +260,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
+
   - type: STR_ORK_BIKE_ARMOR            #ORK WARBIKE
     visibilityAtDay: 40
     visibilityAtDark: 20
@@ -307,6 +318,9 @@ armors:
       - INV_NULL_4X2
       - INV_NULL_2X1_ORK_BIKE_RL
       - INV_NULL_2X1_ORK_BIKE_LL
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
+
   - type: STR_ORK_ARMORM
     visibilityAtDay: 40
     visibilityAtDark: 20
@@ -327,6 +341,7 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.0 #MELTA
+
   - type: STR_ORK_TANKBUSTA_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 20

--- a/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
+++ b/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
@@ -7,6 +7,8 @@ extended:
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
       ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
   - type: STR_CHAOS_HERETEK_ARMOR
@@ -363,6 +365,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #immune to intimidation
     bleedImmune: true
     fearImmune: true
     painImmune: true

--- a/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
@@ -7,7 +7,8 @@ extended:
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
       ARMOR_IS_EXPLODE_ON_DEATH: int #used for bomberman scripts
-
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
 
@@ -295,6 +296,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
+
   - type: MUTON_ARMORTZEENTCH_BLESSED                                    #TZEENTCH REGULAR
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -325,6 +327,9 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
+
   - type: MUTON_ARMORTZS                                          #TZEENTCH SORCER
     tags:
       #ARMOR_ENERGY_SHIELD_CAPACITY: 180

--- a/Ruleset/ENEMY/armors_chaos.rul
+++ b/Ruleset/ENEMY/armors_chaos.rul
@@ -7,6 +7,9 @@ extended:
       INFECTION_RESIST: int #reduces infection damage by this as a %
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
       INFECTION_RESIST_TYPE: int #bitmask; type of infection the unit resists. 0 = All, 1 = Nurgle, 2 = GSC, 4 = Slaanesh; 3 = Nurgle + GSC, 5 = Nurgle + Slaanesh, 6 = GSC
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
+
 
 armors:
   - type: STR_IRON_WARRIOR_ARMOR
@@ -80,7 +83,6 @@ armors:
     psiDefence:
       moraleCurrent: 1.0
       flatHundred: 1.0 #Khorne protects against pitiful psykers
-    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 0.9 #AP
@@ -95,6 +97,8 @@ armors:
       - 1.0 #IMPACT
       - 1.1 #MELTA
     loftempsSet: [ 4 ]
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Intimidation immune
 
   - type: STR_IRON_TERMINATOR_ARMOR #TER IRON WARRIOR TERMINATORS
     tags:
@@ -417,6 +421,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
+
   - type: STR_WARPTALON_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 30
@@ -430,7 +435,6 @@ armors:
     psiDefence:
       moraleCurrent: 1.0
       flatHundred: 1.0 #Khorne protects against pitiful psykers
-    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 1.0 #AP
@@ -445,6 +449,9 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 3 ] #bonus due to being warpy and going in and out of it
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Intimidation immune
+
   - type: BEHEMOTH_ARMOR       #CENT  BEHEMOTH ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 30
@@ -484,12 +491,11 @@ armors:
     rearArmor: 130
     underArmor: 180
     moveSound: {mod: 40k, index: 700}
-    fearImmune: true #it's a daemon, it doesn't care
+    fearImmune: true #it's a khorne daemon, it doesn't care
     painImmune: true #it's a daemon it doesn't care
     psiDefence:
       moraleCurrent: 1.0
       flatHundred: 1.0 #Khorne protects against pitiful psykers
-    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #VEHICLE ARMOR LARGE
       - 1.0 #none
       - 0.7 #AP
@@ -503,6 +509,10 @@ armors:
       - 0.0 #SMOKE
       - 0.2 #IMPACT
       - 1.4 #MELTA
+    builtInWeapons:
+      - STR_INTIMIDATION_WEAPON
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #Intimidation immune
 
   - type: SECTOPOD_ARMOR #Chaos Dread
     visibilityAtDay: 40

--- a/Ruleset/ENEMY/armors_chaos.rul
+++ b/Ruleset/ENEMY/armors_chaos.rul
@@ -75,6 +75,12 @@ armors:
     sideArmor: 140
     rearArmor: 70
     underArmor: 100
+    painImmune: true #it's a berserker it doesn't care
+    fearImmune: true #it's a berserker it doesn't care
+    psiDefence:
+      moraleCurrent: 1.0
+      flatHundred: 1.0 #Khorne protects against pitiful psykers
+    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 0.9 #AP
@@ -419,6 +425,12 @@ armors:
     sideArmor: 105
     rearArmor: 70
     underArmor: 110
+    painImmune: true #it's a flying berserker it doesn't care
+    fearImmune: true #it's a flying berserker it doesn't care
+    psiDefence:
+      moraleCurrent: 1.0
+      flatHundred: 1.0 #Khorne protects against pitiful psykers
+    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #CHAOS ARMOR
       - 1.0 #none
       - 1.0 #AP
@@ -472,11 +484,12 @@ armors:
     rearArmor: 130
     underArmor: 180
     moveSound: {mod: 40k, index: 700}
-    psiDefence:
-      psiStrength: 1.0
-      flatHundred: 1.0 #Khorne protects against pitiful psykers
     fearImmune: true #it's a daemon, it doesn't care
     painImmune: true #it's a daemon it doesn't care
+    psiDefence:
+      moraleCurrent: 1.0
+      flatHundred: 1.0 #Khorne protects against pitiful psykers
+    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #VEHICLE ARMOR LARGE
       - 1.0 #none
       - 0.7 #AP
@@ -490,6 +503,7 @@ armors:
       - 0.0 #SMOKE
       - 0.2 #IMPACT
       - 1.4 #MELTA
+
   - type: SECTOPOD_ARMOR #Chaos Dread
     visibilityAtDay: 40
     visibilityAtDark: 25

--- a/Ruleset/ENEMY/armors_daemon.rul
+++ b/Ruleset/ENEMY/armors_daemon.rul
@@ -53,10 +53,11 @@ armors:
     tags:
       INFECTION_RESIST: 100 #infection immune
     painImmune: true #Most daemons don't care about pain
+    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #DEAMON ARMOR
       - 1.0 #none
       - 0.7 #AP; Bloodletters more resilient to physical and fire damage.
-      - 0.7 #FLAMES
+      - 0.5 #FLAMES
       - 0.7 #HE
       - 1.0 #LASCANON
       - 1.0 #PLASMA

--- a/Ruleset/ENEMY/armors_daemon.rul
+++ b/Ruleset/ENEMY/armors_daemon.rul
@@ -8,6 +8,8 @@ extended:
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
       #reinforcement TU scripts
       ARMOR_REINFORCEMENT_TU_PERCENT: int #this is the % of TUs the unit spawns with; if unspecified, defaults to 25% of max.
+      #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
   - type: CYBERDISC_ARMOR #Flying Deamon
@@ -44,16 +46,17 @@ armors:
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
     heatVision: 33
-    psiVision: 6
+    psiVision: 8
     frontArmor: 60 #decently armored; Brass armor of Khorne
     sideArmor: 60
     rearArmor: 50
     underArmor: 60
+    fearImmune: true #Bloodletters are fear immune
     zombiImmune: true #It's a daemon; can't zombify this.
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
     painImmune: true #Most daemons don't care about pain
-    specialWeapon: STR_INTIMIDATION_WEAPON
     damageModifier: #DEAMON ARMOR
       - 1.0 #none
       - 0.7 #AP; Bloodletters more resilient to physical and fire damage.
@@ -83,6 +86,7 @@ armors:
     zombiImmune: true #It's a daemon; can't zombify this.
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 50 #intimidation resistant
       ARMOR_IS_EXPLODE_ON_DEATH: 1 #can have a boomer bomb that detonates on death
     painImmune: true #Most daemons don't care about pain; especially not Plaguebearers
     recovery: #Plaguebearers regenerate health
@@ -322,6 +326,7 @@ armors:
     zombiImmune: true #It's a daemon; can't zombify this.
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 50 #intimidation resistant
     painImmune: true #Most daemons don't care about pain
     damageModifier: #DEAMON ARMOR
       - 1.0 #untyped damage is supposed to be neutral

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -32,7 +32,9 @@ extended:
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+#intimidation scripts
+      INTIMIDATION_TU_DAMAGE_MULTIPLIER: int #TU damage multiplier 100 = baseline
+      INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: int #morale damage multiplier 100 = baseline
 
 
 items:
@@ -4687,6 +4689,7 @@ items:
     invHeight: 2
     recover: false
     listOrder: 12020
+
   - type: STR_CSERVITOR_HPLASMA_CELL #HEAVY PLASMA                12010                           ToStun
     categories: [STR_CAT_PLASMA, STR_CAT_DEVASTATOR]
     size: 0.1
@@ -4754,20 +4757,42 @@ items:
     supportedInventorySections:
       - STR_LEFT_HAND
       - STR_GROUND
-    power: 90
-    damageType: 7
+    meleePower: 68
+    meleeBonus:
+      bravery: 0.3
+      healthCurrent: 0.2
+    meleeType: 7
     accuracyMelee: 110
     tuMelee: 20
     battleType: 3
-    damageAlter: #DA DAEMON OMNOM
+    meleeAlter: #DA DAEMON OMNOM
       RandomType: 0
       ToArmorPre: 0.6
       ToEnergy: 1.5
       ToWound: 0.1
+    accuracySnap: 200
+    tuSnap: 25
+    snapRange: 20
+    maxRange: 20
+    accuracyMultiplier:
+      flatHundred: 1.0
+    power: 5
+    damageBonus:
+      bravery: 0.7
+      healthCurrent: 0.3
+    damageType: 0
+    damageAlter: #DA MELTA Double
+      FixRadius: 2
+      RandomType: 1 #Swingy damage
+      ArmorEffectiveness: 0.0 #armor doesn't help against intimidation
+      ToHealth: 0.0
+      ToArmor: 0.0
+      ToStun: 0.0
+      ToWound: 0.0
+      ToTile: 0.0
+      ToMana: 1.0 #used by intimidation scripts
     twoHanded: false
     recover: false
-    skillApplied: true
-    strengthApplied: false
     isConsumable: false
     fixedWeapon: false
     invWidth: 2
@@ -4775,6 +4800,9 @@ items:
     armor: 80
     attraction: 1
     listOrder: 12999
+    tags:
+      INTIMIDATION_TU_DAMAGE_MULTIPLIER: 100
+      INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: 100
 
   - type: STR_SONIC_CANON #                        11790
     categories: [STR_CAT_PLASMA, STR_CAT_DEVASTATOR]
@@ -5060,6 +5088,10 @@ items:
 
   - type: STR_KHORNE_CHAOS_CLAWS #                        DA POWER
     weight: 0
+    bigSprite: {mod: 40k, index: 320}
+    meleeSound: {mod: 40k, index: 753} #753 Powersword miss
+    meleeHitSound: {mod: 40k, index: 754} #744 Powersword hit
+    meleeAnimation: {mod: 40k, index: 12}
     power: 58
     damageType: 7
     costSell: 0

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -5057,3 +5057,50 @@ items:
       - STR_STUB_GUN_AMMO_HP
       - STR_STUB_GUN_AMMO_AP
       - STR_STUB_GUN_AMMO_WOUND
+
+  - type: STR_KHORNE_CHAOS_CLAWS #                        DA POWER
+    weight: 0
+    power: 58
+    damageType: 7
+    costSell: 0
+    damageBonus:
+      reactions: 0.1
+      strength: 0.2
+      melee: 0.3
+    damageAlter:     #DA POWER
+      ArmorEffectiveness: 0.7
+      ToArmorPre: 0.2
+      ToHealth: 0.9
+      ToWound: 0.5 #rip and tear
+      ToEnergy: 0.4 #rip and tear
+      ToStun: 0.4 #painful
+      ToMorale: 1.0 #rip and scare
+    accuracyMelee: 80
+    costMelee:
+      time: 20
+      energy: 10
+    flatRate: true
+    twoHanded: false
+    fixedWeapon: true
+    skillApplied: true
+    strengthApplied: false
+    meleeMultiplier:
+      melee: 1.0
+      flatHundred: 0.0
+    battleType: 3
+    clipSize: -1
+    invWidth: 2
+    invHeight: 3
+    recover: false
+    tags: #Khorne weapons are vampiric, granting them power as they spill blood for Khorne
+      TAG_HP_RETURNED_ON_KILL: 88 #regains 88 HP on kill; Sacred Khorne Number
+      TAG_ENERGY_RETURNED_ON_KILL: 88 #regains 88 Energy on kill
+      TAG_TIME_RETURNED_ON_KILL: 8 #regains 8 TU on kill
+      TAG_MORALE_RETURNED_ON_KILL: 88 #regains 88 Morale on kill
+      TAG_STUN_RETURNED_ON_KILL: 88 #regains 88 Stun on kill
+      YTAG_DAMAGE_RETURNED_AS_TIME: 8 #regain 8% of damage dealt in TUs; Sacred Khorne Number
+      YTAG_DAMAGE_RETURNED_AS_HP: 8 #regain 8% of damage dealt in HP; Sacred Khorne Number
+      YTAG_DAMAGE_RETURNED_AS_ENERGY: 8
+      YTAG_DAMAGE_RETURNED_AS_MORALE: 8
+      YTAG_DAMAGE_RETURNED_AS_STUN: 8
+      YTAG_DAMAGE_RETURNED_RESIST_TYPE: 0 #untyped damage so no modifications

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -3042,19 +3042,19 @@ items:
     categories: [ STR_CAT_TACTICAL]
     weight: 1
     bulletSprite: 0
-    #bigSprite: {mod: 40k, index: 629} #placeholder
+    bigSprite: 250 #placeholder
     specialIconSprite: 3 #placeholder
-    explosionHitSound: {mod: 40k, index: 776} #776: Resources/Sound/SPELLFAIL.wav
-    hitAnimation: 1020 #X1 Pink skullsplosion
-    bulletSpeed: 100
+    explosionHitSound: 2423
+    hitAnimation: 1050
+    bulletSpeed: 200
     accuracySnap: 200
-    tuSnap: 20
+    tuSnap: 25
     battleType: 1
     twoHanded: false
     snapRange: 20
     maxRange: 20
-    invWidth: 1
-    invHeight: 1
+    invWidth: 2
+    invHeight: 3
     power: 5
     accuracyMultiplier:
       flatHundred: 1.0
@@ -3065,6 +3065,48 @@ items:
     damageAlter: #DA MELTA Double
       FixRadius: 2
       RandomType: 1 #Swingy damage
+      ArmorEffectiveness: 0.0 #armor doesn't help against intimidation
+      ToHealth: 0.0
+      ToArmor: 0.0
+      ToStun: 0.0
+      ToWound: 0.0
+      ToTile: 0.0
+      ToMana: 1.0 #used by scripts
+    clipSize: -1
+    recover: false
+    fixedWeapon: true
+    tags:
+      INTIMIDATION_TU_DAMAGE_MULTIPLIER: 100
+      INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: 100
+
+  - type: SILACOID_WEAPON #bloodletter intimidate
+    categories: [ STR_CAT_TACTICAL]
+    weight: 1
+    bulletSprite: 0
+    bigSprite: 250 #placeholder
+    specialIconSprite: 3 #placeholder
+    explosionHitSound: 2423
+    hitAnimation: 1050
+    bulletSpeed: 200
+    accuracySnap: 200
+    tuSnap: 25
+    battleType: 1
+    twoHanded: false
+    snapRange: 20
+    maxRange: 20
+    invWidth: 2
+    invHeight: 3
+    power: 5
+    accuracyMultiplier:
+      flatHundred: 1.0
+    damageBonus:
+      bravery: 0.7
+      healthCurrent: 0.3
+    damageType: 0
+    damageAlter: #DA MELTA Double
+      FixRadius: 2
+      RandomType: 1 #Swingy damage
+      ArmorEffectiveness: 0.0 #armor doesn't help against intimidation
       ToHealth: 0.0
       ToArmor: 0.0
       ToStun: 0.0

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -9,7 +9,9 @@ extended:
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+#intimidation scripts
+      INTIMIDATION_TU_DAMAGE_MULTIPLIER: int #TU damage multiplier 100 = baseline
+      INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: int #morale damage multiplier 100 = baseline
 #bomb/kamikazi scripts
       ITEM_IS_BOMB: int #does this blow up with manual activation? The bomb fuse timer is equal to this value - 1.
       ITEM_IS_BOMB_ON_DEATH: int #does this blow up on death? The bomb fuse timer is equal to this value - 1.
@@ -42,7 +44,6 @@ extended:
 #bomb/kamikazi scripts
       ARMOR_IS_EXPLODE_ON_DEATH: int #do we check this unit on death for bombs to activate?
       ARMOR_IS_KAMIKAZI: int #do we kamikazi when we hit regardless of the weapon used?
-
 
 items:
   - type: AUX_DAEMON_FIREBALL #frag                #4006
@@ -3035,3 +3036,44 @@ items:
       YTAG_DAMAGE_RETURNED_AS_MORALE: 8
       YTAG_DAMAGE_RETURNED_AS_STUN: 8
       YTAG_DAMAGE_RETURNED_RESIST_TYPE: 0 #untyped damage so no modifications
+
+
+  - type: STR_INTIMIDATION_WEAPON
+    categories: [ STR_CAT_TACTICAL]
+    weight: 1
+    bulletSprite: 0
+    #bigSprite: {mod: 40k, index: 629} #placeholder
+    specialIconSprite: 3 #placeholder
+    explosionHitSound: {mod: 40k, index: 776} #776: Resources/Sound/SPELLFAIL.wav
+    hitAnimation: 1020 #X1 Pink skullsplosion
+    bulletSpeed: 100
+    accuracySnap: 200
+    tuSnap: 20
+    battleType: 1
+    twoHanded: false
+    snapRange: 20
+    maxRange: 20
+    invWidth: 1
+    invHeight: 1
+    power: 5
+    accuracyMultiplier:
+      flatHundred: 1.0
+    damageBonus:
+      bravery: 0.7
+      healthCurrent: 0.3
+    damageType: 0
+    damageAlter: #DA MELTA Double
+      FixRadius: 2
+      RandomType: 1 #Swingy damage
+      ToHealth: 0.0
+      ToArmor: 0.0
+      ToStun: 0.0
+      ToWound: 0.0
+      ToTile: 0.0
+      ToMana: 1.0 #used by scripts
+    clipSize: -1
+    recover: false
+    fixedWeapon: true
+    tags:
+      INTIMIDATION_TU_DAMAGE_MULTIPLIER: 100
+      INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: 100

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -22,6 +22,9 @@ extended:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
+
 
 armors:
   - &STR_GUARD_ARMOR_FLAK_DAMAGE
@@ -1876,7 +1879,6 @@ armors:
     tags:
       INFECTION_RESIST: 100 #infection immune
 
-
   - type: STR_TAUROS_TURRET_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -1889,7 +1891,6 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
-
 
   - type: STR_TAUROS_SMALL_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1918,7 +1919,6 @@ armors:
     tags:
       INFECTION_RESIST: 100 #infection immune
 
-
   - type: LEMONRUSS_ARMORB
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -1932,7 +1932,6 @@ armors:
     tags:
       INFECTION_RESIST: 100 #infection immune
 
-
   - type: STR_EMPLACEMENT_ARMOR
     frontArmor: 160 # was 130
     sideArmor: 160 # was 130
@@ -1940,8 +1939,6 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
-
-
 
   - &STR_CAS_ARMOR
     type: STR_CAS_MISSILE_POD_ARMOR
@@ -1982,6 +1979,7 @@ armors:
     allowsMoving: false
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
     builtInWeapons:
       - STR_CAS_MISSILE_POD
@@ -2001,6 +1999,7 @@ armors:
       - STR_UNIT_DESTROYER_FT1
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
 
   - type: STR_VALK_CANNON_ARMOR #armor IG rul
@@ -2011,7 +2010,7 @@ armors:
       - STR_CAS_CANNON
     tags:
       INFECTION_RESIST: 100 #infection immune
-
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
   - &STR_TANITH_ARMOR
     type: STR_TANITH_CAMO_ARMOR
@@ -2245,6 +2244,9 @@ armors:
       - 1.2 #MELTA
     loftempsSet: [ 92, 89, 90, 91 ]
     drawingRoutine: 3
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
   - type: STR_CHIMERA_TWIN_HB_TURRET_ARMOR
     visibilityAtDay: 40
@@ -2264,6 +2266,7 @@ armors:
     painImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
     spriteInv: CHIMPD.SPK #doesnt show up
     corpseGeo:  STR_CHIMERA_TURRET_CORPSE
     corpseBattle:
@@ -2332,6 +2335,8 @@ armors:
     spriteSheet: DeserterGuardFem.PCK
     spriteInv: IRON_GUARD_INV.SPK #Iron Warriors traitor Guard
     fearImmune: true
+    tags:
+      INTIMIDATION_RESISTANCE: 50 #intimidation resistant
     storeItem: STR_IRON_GUARD_ARMOR_PLAYER
     customArmorPreviewIndex: 142 #needs custom
     corpseBattle:

--- a/Ruleset/SM/armors_SM.rul
+++ b/Ruleset/SM/armors_SM.rul
@@ -3,6 +3,8 @@ extended:
     RuleArmor:
       INFECTION_RESIST: int #reduces infection damage by this as a %
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 armors:
   - type: RAZORBACK_ARMOR
@@ -15,6 +17,9 @@ armors:
     sideArmor: 130
     rearArmor: 100
     underArmor: 140
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
   - type: LTS_ARMOR #LEFT TURRET STORMTALON ARMOR
     visibilityAtDay: 40
@@ -25,6 +30,9 @@ armors:
     sideArmor: 150
     rearArmor: 150
     underArmor: 150
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
   - type: RTS_ARMOR #LEFT TURRET STORMTALON ARMOR
     visibilityAtDay: 40
@@ -35,6 +43,9 @@ armors:
     sideArmor: 150
     rearArmor: 150
     underArmor: 150
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
 
   - type: STR_PERSONAL_ARMOR_CIVILIAN #TATICAL CIVILIAN
     visibilityAtDay: 40
@@ -1362,7 +1373,8 @@ armors:
     bleedImmune: true
     zombiImmune: true
     tags:
-      INFECTION_RESIST: 50 #infection resistant
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidation immune
     storeItem: MUTON_ARMORTZEENTCH_PLAYER
     customArmorPreviewIndex: 142 #needs custom
     corpseBattle:
@@ -1400,6 +1412,8 @@ armors:
     spriteSheet: MUTON2.PCK #Khorne Berzerker
     spriteInv: KMARINE_INV
     fearImmune: true
+    tags:
+      INTIMIDATION_RESISTANCE: 75 #intimidation resistant
     storeItem: STR_KHORNECHAMP_ARMOR_PLAYER
     customArmorPreviewIndex: 142 #needs custom
     spriteFaceGroup: 6

--- a/Ruleset/eldar.rul
+++ b/Ruleset/eldar.rul
@@ -6,6 +6,8 @@
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: int
+    #intimidation script tags
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
 units:
   - type: STR_ELDAR_PLAT_P     #STR_ELDAR_ARMOR2                        RANK 7
@@ -609,6 +611,9 @@ armors:
       - 0.2 #IMPACT
       - 1.2 #MELTA
     loftempsSet: [ 92, 89, 90, 91 ]
+    tags:
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
+
   - type: ELDAR_TURRET_ARMOR_P
     antiCamouflageAtDay: 5
     antiCamouflageAtDark: 5
@@ -622,6 +627,7 @@ armors:
       ARMOR_ENERGY_SHIELD_DECAY: 12
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: 6
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     zombiImmune: true
     bleedImmune: true
     fearImmune: true

--- a/Ruleset/extraSounds.rul
+++ b/Ruleset/extraSounds.rul
@@ -80,7 +80,7 @@ extraSounds:
 
       # THIRD PARTY END
 
-      
+
 #NoviceArmorSoundEffects
 #Selection
       1501: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000936SELWeareServants.wav
@@ -115,7 +115,7 @@ extraSounds:
 #StartMoving
       1526: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/NoviceCantus/5000932MCOurEmperorgivesusstrength.wav
       1527: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000958MTheBattleWillSoonBeJoined.wav
-      1528: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000909bMOVWeWillGoObediently.wav 
+      1528: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000909bMOVWeWillGoObediently.wav
       1529: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000933bMOVTheyWalkInDarkness.wav
       1530: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000910MOVWeThreadthePathofRightousness.wav
 #SelectWeapon
@@ -126,7 +126,7 @@ extraSounds:
       1535: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000904bWPStrikethemdown.wav
 #Annoyedfemale
       1536: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/NoviceCantus/5000918bANCOurfaithbolstered.wav
-      1537: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/NoviceCantus/5000948WPCWeAreUnderAttackDoNotLoseHeart.wav 
+      1537: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/NoviceCantus/5000948WPCWeAreUnderAttackDoNotLoseHeart.wav
       1538: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000922ANWeWillBeMartyrs.wav
       1539: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/NoviceCantus/5000952ANCDemonshavefaithsisters.wav
       1540: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Novice/5000954ANGuardsmenFaithless.wav
@@ -264,7 +264,7 @@ extraSounds:
 #StartMoving
       1826: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicNoviceLetsSaveSomeLives.wav
       1827: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicPushAheadWeGotthemAgainsttheRopes.wav
-      1828: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicWhereverImNeeded.wav 
+      1828: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicWhereverImNeeded.wav
       1829: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicDontWorryImonmyWay.wav
       1830: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicMoveOutStat.wav
 #SelectWeapon
@@ -275,7 +275,7 @@ extraSounds:
       1835: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicThisisOurChancetoStrike.wav
 #Annoyedfemale
       1836: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicWeHavetoRetreat.wav
-      1837: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicPullitTogetherAndLetsGetBackInThere.wav 
+      1837: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicPullitTogetherAndLetsGetBackInThere.wav
       1838: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicNoOneMesseswithmySquad.wav
       1839: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicItsGettingRough.wav
       1840: Resources/Adeptas/battlesprite/ExtraSoundsAdeptas/Medicae/MedicOverONEHUNDREDPEOPLE.wav
@@ -387,11 +387,11 @@ extraSounds:
       2139: Resources/Sound/helicopter.wav
       2140: Resources/Sound/collar_bomb.wav
       2141: Resources/Sound/slaanesh/NAUGHTY3.wav
-      2142: Resources/Sound/slaanesh/SLAANESH_SPAWN.ogg  
-      2143: Resources/Sound/slaanesh/NEEDLER_IMPACT.wav 
-      2144: Resources/Sound/slaanesh/SLAANESH_STAB.wav  
-      2145: Resources/Sound/slaanesh/SLAANESH_SPAWN_CRUNCH.wav       
-      
+      2142: Resources/Sound/slaanesh/SLAANESH_SPAWN.ogg
+      2143: Resources/Sound/slaanesh/NEEDLER_IMPACT.wav
+      2144: Resources/Sound/slaanesh/SLAANESH_STAB.wav
+      2145: Resources/Sound/slaanesh/SLAANESH_SPAWN_CRUNCH.wav
+
 #      2150: Resources/Sound/ChaosSquatDeath1.flac
 #      2151: Resources/Sound/ChaosSquatDeath2.flac
 #      2152: Resources/Sound/ChaosSquatDeath3.flac
@@ -413,46 +413,46 @@ extraSounds:
       2210: Resources/Sound/Tzeentch/TZLEADERDEATH4.wav
       2211: Resources/Sound/Tzeentch/FemADARKPOWERCALLSYOUFORTH.ogg
       2212: Resources/Sound/Tzeentch/FemGOMYSERVANTDESTROYTHEM.ogg
-      2213: Resources/Sound/Tzeentch/FemIShallPluckTheLifeFromYou.wav 
-      2214: Resources/Sound/Tzeentch/FemLAUGHTER.ogg 
+      2213: Resources/Sound/Tzeentch/FemIShallPluckTheLifeFromYou.wav
+      2214: Resources/Sound/Tzeentch/FemLAUGHTER.ogg
       2215: Resources/Sound/Tzeentch/FemSEEDSEEDSEED.wav
       2216: Resources/Sound/Tzeentch/FemSERVEME.ogg
       2217: Resources/Sound/Tzeentch/FemWitchDeath1.wav
       2218: Resources/Sound/Tzeentch/FemYOUTHINKYOUCANOPPOSEME.ogg
-      2219: Resources/Sound/Tzeentch/FemYouAreHoplessBeforeMyPower.wav 
+      2219: Resources/Sound/Tzeentch/FemYouAreHoplessBeforeMyPower.wav
       2220: Resources/Sound/Tzeentch/FemYouWillServeMeWell.wav
       2221: Resources/Sound/Tzeentch/MaleBEHOLD.wav
       2222: Resources/Sound/Tzeentch/MaleFEAR.wav
-#      2223: Resources/Sound/Tzeentch/Penitent2Suffer.wav 
+#      2223: Resources/Sound/Tzeentch/Penitent2Suffer.wav
       2224: Resources/Sound/Tzeentch/WitchAPoxUponYou.wav
-      2225: Resources/Sound/Tzeentch/WitchBeholdTheHeightofSorcery.wav 
-      2226: Resources/Sound/Tzeentch/Witch_Female_Death_01.wav 
-      2227: Resources/Sound/Tzeentch/Witch_Female_Death_02.wav 
-      2228: Resources/Sound/Tzeentch/Witch_Female_Death_03.wav 
+      2225: Resources/Sound/Tzeentch/WitchBeholdTheHeightofSorcery.wav
+      2226: Resources/Sound/Tzeentch/Witch_Female_Death_01.wav
+      2227: Resources/Sound/Tzeentch/Witch_Female_Death_02.wav
+      2228: Resources/Sound/Tzeentch/Witch_Female_Death_03.wav
       2229: Resources/Sound/Tzeentch/Witch_Female_Death_04.wav
       2230: Resources/Sound/Tzeentch/Witch_Female_Death_05.wav
-      2231: Resources/Sound/Tzeentch/Witch_Female_Death_06.wav   
-      2232: Resources/Sound/Tzeentch/Zealotdeath1.wav  
-      2233: Resources/Sound/Tzeentch/Zealotdeath2.wav  
-      2234: Resources/Sound/Tzeentch/Zealotdeath3.wav 
-      2235: Resources/Sound/Tzeentch/Zealotdeath4.wav 
-      2236: Resources/Sound/Tzeentch/Possesseddeath1.wav 
-      2237: Resources/Sound/Tzeentch/Possesseddeath2.wav 
-      2238: Resources/Sound/Tzeentch/Possesseddeath3.wav  
-      2239: Resources/Sound/Tzeentch/Possesseddeath4.wav  
-      2240: Resources/Sound/Tzeentch/PossessedAggroDieDie.wav 
-      2241: Resources/Sound/Tzeentch/Summonerdeath1.wav 
-      2242: Resources/Sound/Tzeentch/Summonerdeath2.wav         
-      2243: Resources/Sound/Tzeentch/Summonerdeath3.wav        
-      2244: Resources/Sound/Tzeentch/Summonerdeath4.wav  
+      2231: Resources/Sound/Tzeentch/Witch_Female_Death_06.wav
+      2232: Resources/Sound/Tzeentch/Zealotdeath1.wav
+      2233: Resources/Sound/Tzeentch/Zealotdeath2.wav
+      2234: Resources/Sound/Tzeentch/Zealotdeath3.wav
+      2235: Resources/Sound/Tzeentch/Zealotdeath4.wav
+      2236: Resources/Sound/Tzeentch/Possesseddeath1.wav
+      2237: Resources/Sound/Tzeentch/Possesseddeath2.wav
+      2238: Resources/Sound/Tzeentch/Possesseddeath3.wav
+      2239: Resources/Sound/Tzeentch/Possesseddeath4.wav
+      2240: Resources/Sound/Tzeentch/PossessedAggroDieDie.wav
+      2241: Resources/Sound/Tzeentch/Summonerdeath1.wav
+      2242: Resources/Sound/Tzeentch/Summonerdeath2.wav
+      2243: Resources/Sound/Tzeentch/Summonerdeath3.wav
+      2244: Resources/Sound/Tzeentch/Summonerdeath4.wav
       2245: Resources/Sound/TZservitors/HMMMM.wav
       2246: Resources/Sound/TZservitors/ICANSMELLYOU.wav
       2247: Resources/Sound/TZservitors/IGOTSOMETHINGFORYOU.wav
       2248: Resources/Sound/TZservitors/ILLBLEEDYOUNOW.wav
       2249: Resources/Sound/TZservitors/ILLCUTYOUINHALF.wav
-      2250: Resources/Sound/TZservitors/ILLHURTYOU.wav 
+      2250: Resources/Sound/TZservitors/ILLHURTYOU.wav
       2251: Resources/Sound/TZservitors/ILLRIPYOUUP.wav
-      2252: Resources/Sound/TZservitors/ISOMETHINGTHERE.wav 
+      2252: Resources/Sound/TZservitors/ISOMETHINGTHERE.wav
       2253: Resources/Sound/TZservitors/SERVONOICES.WAV
       2254: Resources/Sound/TZservitors/FemServitorTargetAcquired.wav
       2255: Resources/Sound/TZservitors/FemServMOVProceed.wav
@@ -465,7 +465,7 @@ extraSounds:
       2262: Resources/Sound/TZservitors/HEREICOME.wav #2244
       2400: Resources/Sound/NURGLEZOMBIE_AGGRO.wav
       2401: Resources/Sound/NURGLEZOMBIE_DEATH1.wav
-      2402: Resources/Sound/NURGLEZOMBIE_DEATH2.wav 
+      2402: Resources/Sound/NURGLEZOMBIE_DEATH2.wav
       2403: Resources/Sound/NURGLEZOMBIE_DEATH3.wav
       2404: Resources/Sound/NURGLEZOMBIE_DEATH4.wav
       2405: Resources/Sound/NURGLEZOMBIE_DEATH5.wav
@@ -476,9 +476,9 @@ extraSounds:
       2410: Resources/Sound/NURGLEZOMBIE_DEATH11.ogg
       2411: Resources/Sound/NURGLEZOMBIE_DEATH12.ogg
       2412: Resources/Sound/NURGLEZOMBIE_DEATH13.ogg
-      2413: Resources/Sound/BOOMERATTACK.wav 
+      2413: Resources/Sound/BOOMERATTACK.wav
       2414: Resources/Sound/BOOMERATTACK2.wav
-      2415: Resources/Sound/BOOMEREXPLODE.wav 
+      2415: Resources/Sound/BOOMEREXPLODE.wav
       2416: Resources/Sound/SuicideBombWightscream.wav
       2417: Resources/Sound/magnumshot.wav
       2418: Resources/Sound/magnumshot2.wav
@@ -486,7 +486,7 @@ extraSounds:
       2420: Resources/Sound/slashhit.wav
       2421: Resources/Sound/Minigun.wav
       2422: Resources/Sound/Minigun2.wav
-
+      2423: Resources/Sound/Ddeamon2.wav
 
 #MALE Squat
 #Selection
@@ -520,7 +520,7 @@ extraSounds:
       2524: Resources/Sounds/SQUATS/GUARDSQUAT/ANOYSquatFemale1.wav
       2525: Resources/Sounds/SQUATS/GUARDSQUAT/PANSquatFemale1.wav
       2526: Resources/Sounds/SQUATS/GUARDSQUAT/PANSquatFemale2.wav
-      
+
 
 #FEMALE Squats
 #Selection
@@ -593,7 +593,7 @@ extraSounds:
       2682: Resources/Sounds/BEASTMEN/DIEBeastman3.ogg
       2683: Resources/Sounds/BEASTMEN/DIEBeastman4.ogg
       2684: Resources/Sounds/BEASTMEN/DIEBeastman5.ogg
-      
+
 #MALE Beastmen
 #Selection
       2630: Resources/Sounds/BEASTMEN/SELImaneasyrider.ogg
@@ -617,7 +617,7 @@ extraSounds:
       2646: Resources/Sounds/BEASTMEN/ATTFireintheHole.ogg
       2647: Resources/Sounds/BEASTMEN/ATTLetMeHandleIt.ogg
       2648: Resources/Sounds/BEASTMEN/ATTLetsclearthisout.ogg
-      2649: Resources/Sounds/BEASTMEN/ATTPresstheAttack.ogg 
+      2649: Resources/Sounds/BEASTMEN/ATTPresstheAttack.ogg
 #Annoyedfemale
       2650: Resources/Sounds/BEASTMEN/ANOYBehindUs.ogg
       2651: Resources/Sounds/BEASTMEN/ANOYBehindus2.ogg
@@ -668,7 +668,7 @@ extraSounds:
       2987: Resources/Sounds/FELINIDVOICE/FELINIDMALE/DEATHFELINIDMALE2.wav
       2988: Resources/Sounds/FELINIDVOICE/FELINIDMALE/DEATHFELINIDMALE3.wav
       2989: Resources/Sounds/FELINIDVOICE/FELINIDMALE/DEATHFELINIDMALE4.wav
-      
+
 #FEMALE Felinid
 #Selection
       3000: Resources/Sounds/FELINIDVOICE/FELINIDFEMALE/SELCARVEUPYOURFACE.ogg
@@ -705,9 +705,9 @@ extraSounds:
       3028: Resources/Sounds/FELINIDVOICE/FELINIDFEMALE/DEATHFELINIDF4.wav
 #PANIC Female
       3030: Resources/Sounds/FELINIDVOICE/FELINIDFEMALE/PANICCANTLOSE.wav
-      
 
-      
+
+
 #FEMALE COMMISSAR
 #SPECIAL
       2700: Resources/Sounds/FCOMMISSAR/FComMotivation.wav
@@ -734,7 +734,7 @@ extraSounds:
       2717: Resources/Sounds/FCOMMISSAR/FComAttGoodnight.wav
       2718: Resources/Sounds/FCOMMISSAR/FComAttCanYouHandleThis.wav
 #Annoyedfemale
-      2719: Resources/Sounds/FCOMMISSAR/FComAnnoyNo.wav 
+      2719: Resources/Sounds/FCOMMISSAR/FComAnnoyNo.wav
       2720: Resources/Sounds/FCOMMISSAR/FComAnnoyed.wav
       2721: Resources/Sounds/FCOMMISSAR/FComAnnoyedRetreat.wav
       2722: Resources/Sounds/FCOMMISSAR/FComAnnoyedRetreat2.wav
@@ -749,13 +749,13 @@ extraSounds:
 #SELECTION
       2730: Resources/Sounds/GUARDCARAPACEFEMALE/SELDONEWARMINGUP.wav
       2731: Resources/Sounds/GUARDCARAPACEFEMALE/SELINTELONOURTARGET.wav
-      2732: Resources/Sounds/GUARDCARAPACEFEMALE/SELISNTGOINGTOENDWELL.wav  
-      2733: Resources/Sounds/GUARDCARAPACEFEMALE/SELLEAVETHISTOAPROFESSIONAL.wav   
+      2732: Resources/Sounds/GUARDCARAPACEFEMALE/SELISNTGOINGTOENDWELL.wav
+      2733: Resources/Sounds/GUARDCARAPACEFEMALE/SELLEAVETHISTOAPROFESSIONAL.wav
       2734: Resources/Sounds/GUARDCARAPACEFEMALE/SELREADYTOENGAGE.wav
       2735: Resources/Sounds/GUARDCARAPACEFEMALE/SELSTRESSABOUTIT.wav
-      2736: Resources/Sounds/GUARDCARAPACEFEMALE/SELTEACHEACHOTHERAFEWMOVES.wav   
-      2737: Resources/Sounds/GUARDCARAPACEFEMALE/SELWHATSTHEMISSION.wav 
-#StartMoving      
+      2736: Resources/Sounds/GUARDCARAPACEFEMALE/SELTEACHEACHOTHERAFEWMOVES.wav
+      2737: Resources/Sounds/GUARDCARAPACEFEMALE/SELWHATSTHEMISSION.wav
+#StartMoving
       2740: Resources/Sounds/GUARDCARAPACEFEMALE/MOVOVERHERE.wav
       2741: Resources/Sounds/GUARDCARAPACEFEMALE/MOVPERFECT.wav
       2742: Resources/Sounds/GUARDCARAPACEFEMALE/MOVTRYTOKEEPUP.wav
@@ -769,39 +769,39 @@ extraSounds:
       2749: Resources/Sounds/GUARDCARAPACEFEMALE/ATTTARGETINSIGHT.wav
       2750: Resources/Sounds/GUARDCARAPACEFEMALE/ATTPUTOUTOFMISERY.wav
       2751: Resources/Sounds/GUARDCARAPACEFEMALE/ATTRESISTINGWORSE.wav
-      2752: Resources/Sounds/GUARDCARAPACEFEMALE/ATTNOWHERETOHIDE.wav      
-      2753: Resources/Sounds/GUARDCARAPACEFEMALE/ATTIMMOBILIZINGTARGET.wav      
-      2754: Resources/Sounds/GUARDCARAPACEFEMALE/ATTLETSDANCE.wav     
+      2752: Resources/Sounds/GUARDCARAPACEFEMALE/ATTNOWHERETOHIDE.wav
+      2753: Resources/Sounds/GUARDCARAPACEFEMALE/ATTIMMOBILIZINGTARGET.wav
+      2754: Resources/Sounds/GUARDCARAPACEFEMALE/ATTLETSDANCE.wav
       2755: Resources/Sounds/GUARDCARAPACEFEMALE/ATTEASYTARGET.wav
 #Annoyed
       2756: Resources/Sounds/GUARDCARAPACEFEMALE/ANOYHANDSOFF.wav
       2757: Resources/Sounds/GUARDCARAPACEFEMALE/ANOYNOTIMPRESSED.wav
-      2758: Resources/Sounds/GUARDCARAPACEFEMALE/ANOYDONTLETYOUREYESWANDER.wav     
+      2758: Resources/Sounds/GUARDCARAPACEFEMALE/ANOYDONTLETYOUREYESWANDER.wav
       2759: Resources/Sounds/GUARDCARAPACEFEMALE/ATTGLUTTONFORPUNISHMENT.wav
 #DEATH
       2760: Resources/Sounds/GUARDCARAPACEFEMALE/DEATH1.wav
       2761: Resources/Sounds/GUARDCARAPACEFEMALE/DEATH2.wav
       2762: Resources/Sounds/GUARDCARAPACEFEMALE/DEATH3.wav
       2763: Resources/Sounds/GUARDCARAPACEFEMALE/DEATH4.wav
-      
+
 #Stormtrooper Female Voice
 #SELECTION
       2764: Resources/Sounds/INQSTORMTROOPERFEMALE/SELBRINGITON.wav
       2765: Resources/Sounds/INQSTORMTROOPERFEMALE/SELIllClearThisOut.wav
-      2766: Resources/Sounds/INQSTORMTROOPERFEMALE/SELLetsGetThisStarted.wav    
+      2766: Resources/Sounds/INQSTORMTROOPERFEMALE/SELLetsGetThisStarted.wav
       2767: Resources/Sounds/INQSTORMTROOPERFEMALE/SELLetsWrapThisUpQuickly.wav
-      2768: Resources/Sounds/INQSTORMTROOPERFEMALE/SELNOONEESCAPESME.wav 
+      2768: Resources/Sounds/INQSTORMTROOPERFEMALE/SELNOONEESCAPESME.wav
       2769: Resources/Sounds/INQSTORMTROOPERFEMALE/SELReadyforCombat.wav
       2770: Resources/Sounds/INQSTORMTROOPERFEMALE/SELTheyJustKeeponComing.wav
       2771: Resources/Sounds/INQSTORMTROOPERFEMALE/SELThisisCostingPreciousTime.wav
       2772: Resources/Sounds/INQSTORMTROOPERFEMALE/SELWEALLCLEARHERE.wav
-#StartMoving  
+#StartMoving
       2773: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVInfiltrating2.wav
       2774: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVMove.wav
       2775: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVMoveIt.wav
       2776: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVThisWontTakeLong.wav
       2777: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVWeShouldHurry.wav
-      2778: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVIsthatAll.wav   
+      2778: Resources/Sounds/INQSTORMTROOPERFEMALE/MOVIsthatAll.wav
 #SelectWeapon
       2779: Resources/Sounds/INQSTORMTROOPERFEMALE/ATTYouDontHaveAChance.wav
       2780: Resources/Sounds/INQSTORMTROOPERFEMALE/AttIllTakeYouAllOn.wav
@@ -814,7 +814,7 @@ extraSounds:
       2786: Resources/Sounds/INQSTORMTROOPERFEMALE/ANOYSuchAHassle.wav
       2787: Resources/Sounds/INQSTORMTROOPERFEMALE/ANOYSTUFFANNOYING.wav
       2788: Resources/Sounds/INQSTORMTROOPERFEMALE/ANOYMaybeIshouldfallback.wav
-#Death      
+#Death
       2789: Resources/Sounds/INQSTORMTROOPERFEMALE/DEATHMissionFailed.wav
       2790: Resources/Sounds/INQSTORMTROOPERFEMALE/Death3.wav
       2791: Resources/Sounds/INQSTORMTROOPERFEMALE/DeathAmITooLate.wav
@@ -831,7 +831,7 @@ extraSounds:
       3805: Resources/Sounds/SCIONMALEVOICE/ScionsSelect8.ogg
       3806: Resources/Sounds/SCIONMALEVOICE/ScionsSelect9.ogg
 
-#StartMoving  
+#StartMoving
       3810: Resources/Sounds/SCIONMALEVOICE/ScionsMove1.ogg
       3811: Resources/Sounds/SCIONMALEVOICE/ScionsMove2.ogg
       3812: Resources/Sounds/SCIONMALEVOICE/ScionsMove3.ogg
@@ -853,20 +853,20 @@ extraSounds:
       3832: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed3.ogg
       3833: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed4.ogg
       3834: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed6.ogg
-      3835: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed7.ogg      
-      3836: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed9.ogg   
+      3835: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed7.ogg
+      3836: Resources/Sounds/SCIONMALEVOICE/ScionsAnnoyed9.ogg
 
 #ARMOR VERSION SPECIFIC ATTACK WEAPON SELECT LINES
 #HELLGUN
       3837: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial1.ogg
       3838: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial2.ogg
       3839: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial3.ogg
-      
+
 #VOLLYEGUN
       3842: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial7.ogg
-      3843: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial8.ogg    
-      3844: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial9.ogg   
-      
+      3843: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial8.ogg
+      3844: Resources/Sounds/SCIONMALEVOICE/ScionsSpecial9.ogg
+
 #BERSERK
       3840: Resources/Sounds/SCIONMALEVOICE/ScionsBerserk1.ogg
       3841: Resources/Sounds/SCIONMALEVOICE/ScionsBerserk2.ogg
@@ -874,10 +874,10 @@ extraSounds:
 #PANIC
       3845: Resources/Sounds/SCIONMALEVOICE/ScionsPanic1.ogg
       3846: Resources/Sounds/SCIONMALEVOICE/ScionsPanic2.ogg
-      3847: Resources/Sounds/SCIONMALEVOICE/ScionsPanic4.ogg      
-      3848: Resources/Sounds/SCIONMALEVOICE/ScionsPanic5.ogg   
-#Death      
-      
+      3847: Resources/Sounds/SCIONMALEVOICE/ScionsPanic4.ogg
+      3848: Resources/Sounds/SCIONMALEVOICE/ScionsPanic5.ogg
+#Death
+
 #ELDAR FARSEER
       #SPECIAL
       2800: Resources/Sounds/Farseer/Action1.wav
@@ -960,7 +960,7 @@ extraSounds:
       3318: Resources/Sound/BERZERKER/ATTENGULFPAIN.wav
       3319: Resources/Sound/BERZERKER/ATTGETTHEMALL.wav
       3320: Resources/Sound/BERZERKER/ATTMUSTKILL.wav
-      3321: Resources/Sound/BERZERKER/ATTTHEENEMYFINALLY.wav        
+      3321: Resources/Sound/BERZERKER/ATTTHEENEMYFINALLY.wav
       #PANIC and BERSERK
       #DEATH
 #Female Marine
@@ -989,7 +989,7 @@ extraSounds:
       3358: Resources/Sound/BERZERKER/FBERZERKER/ATTNOMERCY.ogg
       3359: Resources/Sound/BERZERKER/FBERZERKER/ATTSENSEFEAR.ogg
       3360: Resources/Sound/BERZERKER/FBERZERKER/ATTSOUNDSLIKEFUN.ogg
-      3361: Resources/Sound/BERZERKER/FBERZERKER/ATTYOURTIMEISUP.ogg      
+      3361: Resources/Sound/BERZERKER/FBERZERKER/ATTYOURTIMEISUP.ogg
       #PANIC and BERSERK
       #DEATH
 
@@ -1015,7 +1015,7 @@ extraSounds:
       3414: Resources/Sound/SLAANESH/MOVOURZEALSHALLOVERCOME.wav
       3415: Resources/Sound/SLAANESH/MOVROCKSCANNOTSTOPUS.wav
       3416: Resources/Sound/SLAANESH/MOVSLAANESHISWITHUSLETUSGO.wav
-      3417: Resources/Sound/SLAANESH/MOVWEHEARANDOBEY.wav   
+      3417: Resources/Sound/SLAANESH/MOVWEHEARANDOBEY.wav
       #SELECT WEAPON ATTACK
       3418: Resources/Sound/SLAANESH/ATTRUINTHEM.wav
       3419: Resources/Sound/SLAANESH/ATTMIGHTBONEANDFLESH.wav
@@ -1024,18 +1024,18 @@ extraSounds:
       3422: Resources/Sound/SLAANESH/ATTSCREAMTOBEHEARD.wav
       3423: Resources/Sound/SLAANESH/ATTSHREDTHEIRSANITYWITHOURSONG.wav
       3424: Resources/Sound/SLAANESH/ATTSLAANESHSINGSTHROUGHUS.wav
-      3425: Resources/Sound/SLAANESH/ATTTHINGSWILLGETLOUDNOW.wav   
+      3425: Resources/Sound/SLAANESH/ATTTHINGSWILLGETLOUDNOW.wav
       #PANIC and BERSERK
       3426: Resources/Sound/SLAANESH/PANICITISDOOM.wav
-      3427: Resources/Sound/SLAANESH/PANICWEAREBEINGDROWNEDOUT.wav   
+      3427: Resources/Sound/SLAANESH/PANICWEAREBEINGDROWNEDOUT.wav
       3428: Resources/Sound/SLAANESH/PANSUCHWHELPSATTACKINGUSBEHIND.wav
-      3429: Resources/Sound/SLAANESH/PANTHEYAREBEHINDUS.wav         
+      3429: Resources/Sound/SLAANESH/PANTHEYAREBEHINDUS.wav
 #Fem Marine 3500
       #SELECT UNIT
       3500: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELCRYFORME.ogg
       3501: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELEVERYDROPOFJOY.ogg
       3502: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELEYELIDS.ogg
-      3503: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELFIRSTTIMETORTURED.ogg 
+      3503: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELFIRSTTIMETORTURED.ogg
       3504: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELLIFERUINTODAY.ogg
       3505: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELRENDTHEIRFLESH.ogg
       3506: Resources/Sound/SLAANESH/FSLAANESHMARINE/SELTINGLE.ogg
@@ -1046,11 +1046,11 @@ extraSounds:
       3510: Resources/Sound/SLAANESH/FSLAANESHMARINE/ANOYNAUGHTYNAUGHTY.ogg
       3511: Resources/Sound/SLAANESH/FSLAANESHMARINE/ANOYWHATSTHEPOINT.ogg
       #3512 Reserved
-      #MOVE  
+      #MOVE
       3513: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVCRAVINGSATED.ogg
       3514: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVDONTGOANYWHERE.ogg
       3515: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVHURTNOMORE.ogg
-      3516: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVJOYFULPEOPLETOHURT.ogg 
+      3516: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVJOYFULPEOPLETOHURT.ogg
       3517: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVKEEPTHEMLONGING.ogg
       3518: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVNOTYETHONEY.ogg
       3519: Resources/Sound/SLAANESH/FSLAANESHMARINE/MOVPLAYTIMESOVER.ogg
@@ -1076,16 +1076,16 @@ extraSounds:
       3601: Resources/Sound/NURGLE/SELPESTILENCE.wav
       3602: Resources/Sound/NURGLE/SELPLAGUEDOOM.wav
       3603: Resources/Sound/NURGLE/SELSHAREYOURWOUNDS.wav
-      3604: Resources/Sound/NURGLE/SELWEARETHEWILLOFTHEPLAGUEGOD.wav 
-      3605: Resources/Sound/NURGLE/SELWEWILLNOTFAIL.wav 
+      3604: Resources/Sound/NURGLE/SELWEARETHEWILLOFTHEPLAGUEGOD.wav
+      3605: Resources/Sound/NURGLE/SELWEWILLNOTFAIL.wav
       #ANNOYED
       3606: Resources/Sound/NURGLE/ANOYEVERYPLAGUEAWARNING.wav
       3607: Resources/Sound/NURGLE/ANOYTHEYWILLDIEALONE.wav
       3608: Resources/Sound/NURGLE/ATTWEAREUNSTOPPABLE.wav
       3609: Resources/Sound/NURGLE/SELWHATSNEXT.wav
       #MOVE
-      3610: Resources/Sound/NURGLE/MOVLEAVETHIS.wav 
-      3611: Resources/Sound/NURGLE/MOVFORWARDSBRINGDEATH.wav 
+      3610: Resources/Sound/NURGLE/MOVLEAVETHIS.wav
+      3611: Resources/Sound/NURGLE/MOVFORWARDSBRINGDEATH.wav
       3612: Resources/Sound/NURGLE/MOVANOTHEROBJECTIVE.wav
       3613: Resources/Sound/NURGLE/MOVSPREADDEATH.wav
       3614: Resources/Sound/NURGLE/MOVSPREADNURGLESGIFT.wav
@@ -1098,47 +1098,47 @@ extraSounds:
       3622: Resources/Sound/NURGLE/ATTKILLEVERYONE.wav
       3623: Resources/Sound/NURGLE/ATTMAKETHEMHURT.wav
       3624: Resources/Sound/NURGLE/ATTOPENFIRE.wav
-      3625: Resources/Sound/NURGLE/ATTTHEYWEAKEN.wav   
-      #PANIC and BERSERK 
+      3625: Resources/Sound/NURGLE/ATTTHEYWEAKEN.wav
+      #PANIC and BERSERK
       #DEATH
       3630: Resources/Sound/NURGLE/DEATHALLSHALLFALL.wav
       3631: Resources/Sound/NURGLE/DEATH2APARTINGGIFT.wav
       3632: Resources/Sound/NURGLE/DEATH3FIGHTONBROTHERS.wav
       3633: Resources/Sound/NURGLE/DEATH4URGH.wav
-      
+
 #Female Marine 3640+
       #SELECT UNIT
       3640: Resources/Sound/NURGLE/NURGLEFMARINE/SELBEREADY.wav
-      3641: Resources/Sound/NURGLE/NURGLEFMARINE/SELDEATHISINBLOOM.wav 
+      3641: Resources/Sound/NURGLE/NURGLEFMARINE/SELDEATHISINBLOOM.wav
       3642: Resources/Sound/NURGLE/NURGLEFMARINE/SELFRIENDSALLAROUND.wav
-      3643: Resources/Sound/NURGLE/NURGLEFMARINE/SELNOTALWAYSWHATTHEYSEEM.wav 
+      3643: Resources/Sound/NURGLE/NURGLEFMARINE/SELNOTALWAYSWHATTHEYSEEM.wav
       3644: Resources/Sound/NURGLE/NURGLEFMARINE/SELTHEHARVESTISUPONUS.wav
-      3645: Resources/Sound/NURGLE/NURGLEFMARINE/SELWHATLURKSBENEATHTHESOIL.wav 
+      3645: Resources/Sound/NURGLE/NURGLEFMARINE/SELWHATLURKSBENEATHTHESOIL.wav
       #ANNOYED
       3646: Resources/Sound/NURGLE/NURGLEFMARINE/ANOYBUSYWORLD.wav
-      3647: Resources/Sound/NURGLE/NURGLEFMARINE/ANOYJUSTAHARMLESSFLOWER.wav 
+      3647: Resources/Sound/NURGLE/NURGLEFMARINE/ANOYJUSTAHARMLESSFLOWER.wav
       3648: Resources/Sound/NURGLE/NURGLEFMARINE/ANOYNURGLEFEMLAUGH.wav
       3649: Resources/Sound/NURGLE/NURGLEFMARINE/ATTWAITUNTILMYSEEDSTAKEROOT.wav
       #MOVE
-      3650: Resources/Sound/NURGLE/NURGLEFMARINE/MOVVENTUREOFFBEATENPATH.wav 
+      3650: Resources/Sound/NURGLE/NURGLEFMARINE/MOVVENTUREOFFBEATENPATH.wav
       3651: Resources/Sound/NURGLE/NURGLEFMARINE/MOVJUSTWAIT.wav
-      3652: Resources/Sound/NURGLE/NURGLEFMARINE/MOVMYPREYCLEVER.wav 
+      3652: Resources/Sound/NURGLE/NURGLEFMARINE/MOVMYPREYCLEVER.wav
       3653: Resources/Sound/NURGLE/NURGLEFMARINE/MOVNONEWILLESCAPEMYGRASP.wav
-      3654: Resources/Sound/NURGLE/NURGLEFMARINE/MOVSUCHMORETOSEE.wav 
-      3655: Resources/Sound/NURGLE/NURGLEFMARINE/MOVTAKECAREFULSTEPS.wav 
+      3654: Resources/Sound/NURGLE/NURGLEFMARINE/MOVSUCHMORETOSEE.wav
+      3655: Resources/Sound/NURGLE/NURGLEFMARINE/MOVTAKECAREFULSTEPS.wav
       #SELECT WEAPON ATTACK
-      3658: Resources/Sound/NURGLE/NURGLEFMARINE/ATTBURST.wav 
-      3659: Resources/Sound/NURGLE/NURGLEFMARINE/ATTCHOKETHELIFE.wav 
-      3660: Resources/Sound/NURGLE/NURGLEFMARINE/ATTMYSPRINGYOURFALL.wav 
+      3658: Resources/Sound/NURGLE/NURGLEFMARINE/ATTBURST.wav
+      3659: Resources/Sound/NURGLE/NURGLEFMARINE/ATTCHOKETHELIFE.wav
+      3660: Resources/Sound/NURGLE/NURGLEFMARINE/ATTMYSPRINGYOURFALL.wav
       3661: Resources/Sound/NURGLE/NURGLEFMARINE/ATTPIERCE.wav
-      3662: Resources/Sound/NURGLE/NURGLEFMARINE/ATTSOON.wav 
-      3663: Resources/Sound/NURGLE/NURGLEFMARINE/ATTTHISLANDISMINE.wav 
-      3664: Resources/Sound/NURGLE/NURGLEFMARINE/ATTWAITUNTILMYSEEDSTAKEROOT.wav 
-      3665: Resources/Sound/NURGLE/NURGLEFMARINE/ATTAPROMISINGGARDEN.wav 
-      #PANIC and BERSERK 
+      3662: Resources/Sound/NURGLE/NURGLEFMARINE/ATTSOON.wav
+      3663: Resources/Sound/NURGLE/NURGLEFMARINE/ATTTHISLANDISMINE.wav
+      3664: Resources/Sound/NURGLE/NURGLEFMARINE/ATTWAITUNTILMYSEEDSTAKEROOT.wav
+      3665: Resources/Sound/NURGLE/NURGLEFMARINE/ATTAPROMISINGGARDEN.wav
+      #PANIC and BERSERK
       #DEATH
-      3670: Resources/Sound/NURGLE/NURGLEFMARINE/DEATHNURGLEFEM.wav 
-      3671: Resources/Sound/NURGLE/NURGLEFMARINE/DEATHNURGLEFEM2.wav 
+      3670: Resources/Sound/NURGLE/NURGLEFMARINE/DEATHNURGLEFEM.wav
+      3671: Resources/Sound/NURGLE/NURGLEFMARINE/DEATHNURGLEFEM2.wav
       3672: Resources/Sound/NURGLE/NURGLEFMARINE/DEATHNURGLEFEM3.wav
 
 #TZEENTCH MARINE ARMOR PLAYER
@@ -1150,57 +1150,57 @@ extraSounds:
       3703: Resources/Sound/Tzeentch/SELTHESTRANDSOFDESTINYWEAVEONLYAWEBOFDEATH.wav
       3704: Resources/Sound/Tzeentch/SELTIMEISFLEETING.wav
       #ANNOYED
-      3706: Resources/Sound/Tzeentch/ANOYIAWAIT.wav 
+      3706: Resources/Sound/Tzeentch/ANOYIAWAIT.wav
       3707: Resources/Sound/Tzeentch/ANOYKINKY.wav
       #MOVE
-      3710: Resources/Sound/Tzeentch/MOVILLSEETOIT.wav 
-      3711: Resources/Sound/Tzeentch/MOVINDUB.wav 
-      3712: Resources/Sound/Tzeentch/MOVPROCEED.wav 
-      3713: Resources/Sound/Tzeentch/MOVRAID.wav 
+      3710: Resources/Sound/Tzeentch/MOVILLSEETOIT.wav
+      3711: Resources/Sound/Tzeentch/MOVINDUB.wav
+      3712: Resources/Sound/Tzeentch/MOVPROCEED.wav
+      3713: Resources/Sound/Tzeentch/MOVRAID.wav
       3714: Resources/Sound/Tzeentch/MOVYESMASTER.wav
       #SELECT WEAPON ATTACK
-      3718: Resources/Sound/Tzeentch/ATTBEDRAINEDOFLIFE.wav 
+      3718: Resources/Sound/Tzeentch/ATTBEDRAINEDOFLIFE.wav
       3719: Resources/Sound/Tzeentch/ATTMAKEYOURCHOICE.wav
-      3720: Resources/Sound/Tzeentch/ATTOBLIVIONAWAITS.wav 
+      3720: Resources/Sound/Tzeentch/ATTOBLIVIONAWAITS.wav
       3721: Resources/Sound/Tzeentch/ATTTIMEISNOW.wav
       3722: Resources/Sound/Tzeentch/ATTYOUMAYFEELASTING.wav
-      #PANIC and BERSERK 
+      #PANIC and BERSERK
       #DEATH
-      3730: Resources/Sound/Tzeentch/RUBRICHDEATH1.wav 
+      3730: Resources/Sound/Tzeentch/RUBRICHDEATH1.wav
       3731: Resources/Sound/Tzeentch/RUBRICHDEATH2.wav
-      3732: Resources/Sound/Tzeentch/RUBRICDEATH3.wav 
+      3732: Resources/Sound/Tzeentch/RUBRICDEATH3.wav
 #Fem Marine 3740
       #SELECT UNIT
-      3740: Resources/Sound/Tzeentch/SELBEREADY.ogg 
+      3740: Resources/Sound/Tzeentch/SELBEREADY.ogg
       3741: Resources/Sound/Tzeentch/SELBRINGWORLDTOKNEES.ogg
       3742: Resources/Sound/Tzeentch/SELEVERYTHINGASPLANNED.ogg
       3743: Resources/Sound/Tzeentch/SELIRETURN.ogg
       3744: Resources/Sound/Tzeentch/SELLETTHECARNAGECOMMENCE.ogg
       3745: Resources/Sound/Tzeentch/SELPREPAREDTODOWHATNEEDS.ogg
-      3746: Resources/Sound/Tzeentch/SELVANQUISHTHEWEAK.ogg 
+      3746: Resources/Sound/Tzeentch/SELVANQUISHTHEWEAK.ogg
       3747: Resources/Sound/Tzeentch/SELWHATMORTAL.ogg
       #ANNOYED
-      3748: Resources/Sound/Tzeentch/ANOYFORNOW.ogg 
+      3748: Resources/Sound/Tzeentch/ANOYFORNOW.ogg
       3749: Resources/Sound/Tzeentch/ANOYNOTINTERFERE.ogg
       3750: Resources/Sound/Tzeentch/ANOYUNWORTHY.ogg
-      3751: Resources/Sound/Tzeentch/ANOYYOURSERIOUS.ogg 
+      3751: Resources/Sound/Tzeentch/ANOYYOURSERIOUS.ogg
       3752: Resources/Sound/Tzeentch/ANOYSTILLJUSTACHILD.ogg
-      #MOVE  
+      #MOVE
       3753: Resources/Sound/Tzeentch/MOVALWAYSTHEPLAN.ogg
       3754: Resources/Sound/Tzeentch/MOVLETSGETGOING.ogg
       3755: Resources/Sound/Tzeentch/MOVMASTERAMUSED.ogg
       3756: Resources/Sound/Tzeentch/MOVONTHEWAY.ogg
-      3757: Resources/Sound/Tzeentch/MOVWEAREINAGREEMENT.ogg 
+      3757: Resources/Sound/Tzeentch/MOVWEAREINAGREEMENT.ogg
       #SELECT WEAPON ATTACK
       3762: Resources/Sound/Tzeentch/ATTDEATHRAGES.ogg
       3763: Resources/Sound/Tzeentch/ATTDELICIOUS.ogg
       3764: Resources/Sound/Tzeentch/ATTDELUDED.ogg
       3765: Resources/Sound/Tzeentch/ATTDIE.ogg
-      3766: Resources/Sound/Tzeentch/ATTHATERESORTINGTOVIOLENCE.ogg 
-      3767: Resources/Sound/Tzeentch/ATTSCREAMFORME.ogg 
+      3766: Resources/Sound/Tzeentch/ATTHATERESORTINGTOVIOLENCE.ogg
+      3767: Resources/Sound/Tzeentch/ATTSCREAMFORME.ogg
       3768: Resources/Sound/Tzeentch/ATTSOULISMINE.ogg
       3769: Resources/Sound/Tzeentch/ATTSUCHPLANSFORYOU.ogg
       #PANIC and BERSERK
       #DEATH
- 
-      
+
+

--- a/Ruleset/scripts/scripts_intimidation_ability.rul
+++ b/Ruleset/scripts/scripts_intimidation_ability.rul
@@ -1,0 +1,63 @@
+extended:
+  tags:
+    RuleItem:
+      INTIMIDATION_TU_DAMAGE_MULTIPLIER: int #TU damage multiplier 100 = baseline
+      INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: int #morale damage multiplier 100 = baseline
+
+  scripts:
+    damageUnit:
+      - new: ROSIGMA_dU_intimidation
+        offset: 24
+        code: |
+          var int temp;
+          var int temp2;
+          var int moraleMultiplier; #percent of damage the triggering attack inflicts
+          var int damage;
+
+          set damage to_mana;
+          if le to_mana 0; # only proceed if we actually do damage
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. No damage dealt.";
+            return;
+          end;
+
+          unit.Stats.getBravery temp2;
+          if ge temp2 110; #Bravery 110+ units are immune to intimidation
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Unit is fearless; Bravery:" temp2;
+            return;
+          end;
+
+          weapon_item.getTag moraleMultiplier Tag.INTIMIDATION_MORALE_DAMAGE_MULTIPLIER; #get morale damage multiplier
+
+          if le moraleMultiplier 0; #morale damage multiplier has to be greater than 0, otherwise abort
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: No morale multiplier detected, Aborting.";
+            return;
+          end;
+
+          #debug_log "Intimidation Scripts; damageUnit, offset 24: Initialize, Weapon:" weapon_item;
+          #debug_log "Intimidation Scripts; damageUnit, offset 24: Initialize, Target:" unit;
+
+          set temp to_mana;
+          sub temp temp2; #subtract target Bravery from our power
+
+          if le temp 0; #if our net power after Bravery is subtracted is null or negative, abort.
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Null or negative morale:" temp;
+            return;
+          end;
+
+          #calculate target Morale; we bypass to_morale because high Bravery reduces damage too aggressively
+          muldiv temp moraleMultiplier 100; #calculate morale damage
+          #debug_log "Intimidation Scripts; damageUnit, offset 24: Morale damage dealt:" temp;
+          unit.getMorale temp2;
+          sub temp2 temp;
+          limit_lower temp2 0;
+          unit.setMorale temp2; #apply Morale damages
+
+          weapon_item.getTag moraleMultiplier Tag.INTIMIDATION_TU_DAMAGE_MULTIPLIER;
+          if gt moraleMultiplier 0;
+            set temp2 temp; #set our damage to TU
+            muldiv temp2 moraleMultiplier 100;
+            add to_time temp; #apply TU damages
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: TU damage dealt:" temp;
+          end;
+
+          return;

--- a/Ruleset/scripts/scripts_intimidation_ability.rul
+++ b/Ruleset/scripts/scripts_intimidation_ability.rul
@@ -1,8 +1,11 @@
 extended:
   tags:
+    #intimidation script tags
     RuleItem:
       INTIMIDATION_TU_DAMAGE_MULTIPLIER: int #TU damage multiplier 100 = baseline
       INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: int #morale damage multiplier 100 = baseline
+    RuleArmor:
+      INTIMIDATION_RESISTANCE: int #Reduces the effectiveness of Intimidate attacks by this percentage
 
   scripts:
     damageUnit:
@@ -12,17 +15,19 @@ extended:
           var int temp;
           var int temp2;
           var int moraleMultiplier; #percent of damage the triggering attack inflicts
-          var int damage;
+          var int intimidateResist;
+          var ptr RuleArmor armorRule;
 
-          set damage to_mana;
           if le to_mana 0; # only proceed if we actually do damage
             #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. No damage dealt.";
             return;
           end;
 
-          unit.Stats.getBravery temp2;
-          if ge temp2 110; #Bravery 110+ units are immune to intimidation
-            #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Unit is fearless; Bravery:" temp2;
+          unit.getRuleArmor armorRule;
+          armorRule.getTag intimidateResist Tag.INTIMIDATION_RESISTANCE; #if our infection resist is 100% and applies to all infection types we're immune; abort
+
+          if ge intimidateResist 100; #Abort if the target has immunity
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Unit is immune to intimidate:" intimidateResist;
             return;
           end;
 
@@ -35,11 +40,18 @@ extended:
 
           #debug_log "Intimidation Scripts; damageUnit, offset 24: Initialize, Weapon:" weapon_item;
           #debug_log "Intimidation Scripts; damageUnit, offset 24: Initialize, Target:" unit;
+          #debug_log "Intimidation Scripts; damageUnit, offset 24: Initialize, Initial Power:" to_mana;
 
           set temp to_mana;
+          unit.Stats.getBravery temp2;
           sub temp temp2; #subtract target Bravery from our power
 
-          if le temp 0; #if our net power after Bravery is subtracted is null or negative, abort.
+          sub intimidateResist 100; #invert intimidateResist
+          mul intimidateResist -1; #invert intimidateResist
+
+          muldiv temp intimidateResist 100; #get the percentage
+
+          if le temp 0; #if our net power is null or negative, abort.
             #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Null or negative morale:" temp;
             return;
           end;
@@ -59,5 +71,7 @@ extended:
             add to_time temp; #apply TU damages
             #debug_log "Intimidation Scripts; damageUnit, offset 24: TU damage dealt:" temp;
           end;
+
+          battle_game.flashMessage "STR_INTIMIDATION_NOTICE";
 
           return;

--- a/Ruleset/scripts/scripts_ranged_dodge.rul
+++ b/Ruleset/scripts/scripts_ranged_dodge.rul
@@ -29,7 +29,7 @@ armors:
         if eq side unitFaction; # don't reset on others' turns
           unit.setTag Tag.UNIT_COUNTER_SUCCESSFUL_DODGES 0;
         end;
-        return; 
+        return;
 
       hitUnit: |
         var int temp;
@@ -58,7 +58,7 @@ armors:
         targetArmor.getTag maxSuccessfulDodges Tag.ARMOR_MAX_SUCCESSFUL_DODGES;
 
         # assume that setting it has been forgotten
-        if eq maxSuccessfulDodges 0; 
+        if eq maxSuccessfulDodges 0;
           set maxSuccessfulDodges 1;
         end;
 
@@ -154,116 +154,116 @@ armors:
     tags:
       DODGE_CHANCE: 40
       ARMOR_MAX_SUCCESSFUL_DODGES: 4
-      
+
   - type: STR_ADEPTAS_ARMORB_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ASSASSINNEUTRAL_FEMSUIT
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ADEPTAS_ARMORR_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ADEPTAS_ARMORR_FIXED_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ADEPTAS_ARMORS_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ADEPTAS_ARMORCEL_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 30
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
 #MARINES
   - type: STR_SCOUT_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_SCOUTH_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SCOUTHW_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SCOUTHB_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SCOUTHR_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SCOUTHY_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SCOUTHG_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_FLYING_SUIT_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ASS_ARMOR_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ASS_ARMOR_HONOR_UC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_CHAOS_RAPTOR_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #GUARD
   - type: STR_ELYSIAN_JUMP_ARMOR
     refNode: *STR_DODGE_ARMOR
@@ -271,49 +271,49 @@ armors:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ELYSIAN_JUMP_MEDIC_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_FELINID_JUMP_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_FELINIDGUARD_FLAK_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       FLIGHT_DODGE_CHANCE: 0
-      ARMOR_MAX_SUCCESSFUL_DODGES: 1      
-      
+      ARMOR_MAX_SUCCESSFUL_DODGES: 1
+
   - type: STR_FELINIDGUARD_FLAK_ARMOR_MEDIC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       FLIGHT_DODGE_CHANCE: 0
-      ARMOR_MAX_SUCCESSFUL_DODGES: 1  
-      
+      ARMOR_MAX_SUCCESSFUL_DODGES: 1
+
   - type: STR_FELINIDGUARD_CARAPACE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 5
       FLIGHT_DODGE_CHANCE: 0
-      ARMOR_MAX_SUCCESSFUL_DODGES: 1     
-      
+      ARMOR_MAX_SUCCESSFUL_DODGES: 1
+
   - type: STR_FELINIDGUARD_MEDIC_CARAPACE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 5
       FLIGHT_DODGE_CHANCE: 0
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #ELDAR
 
   - type: STR_ELDAR_ARMOR
@@ -321,115 +321,115 @@ armors:
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ELDAR_ARMOR_M
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ELDAR_ARMOR_M_SHIELD
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ELDAR_ARMOR_F
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ELDAR_ARMOR_F_SHIELD
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ELDAR_ARMOR_FH
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ELDAR_ARMOR2_P #banshee
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 40
       ARMOR_MAX_SUCCESSFUL_DODGES: 4
-      
+
   - type: STR_ELDAR_ARMOR2_P_SHIELD  #banshee
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 40
       ARMOR_MAX_SUCCESSFUL_DODGES: 4
-      
+
   - type: STR_ELDAR_ARMOR3_P #seer player
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 50
       ARMOR_MAX_SUCCESSFUL_DODGES: 5
-      
+
   - type: STR_ELDAR_ARMOR3_P_SHIELD  #seer player
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 50
       ARMOR_MAX_SUCCESSFUL_DODGES: 5
-      
+
   - type: STR_ELDAR_ARMOR4_P #dire avenger
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ELDAR_ARMOR4_P_SHIELD  #dire avenger
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ELDAR_ARMOR5_P #Scorpion
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ELDAR_ARMOR5_P_SHIELD  #Scorpion
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ELDAR_ARMOR6_P #reaper
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ELDAR_ARMOR6_P_SHIELD  #reaper
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ELDAR_ARMOR2 #banshee
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 40
       ARMOR_MAX_SUCCESSFUL_DODGES: 4
-      
+
   - type: STR_ELDAR_ARMOR3  #Farseer
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 40
       ARMOR_MAX_SUCCESSFUL_DODGES: 4
-      
+
   - type: STR_ELDAR_FARSEER_ARMOR   #Player Farsser
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 40
       ARMOR_MAX_SUCCESSFUL_DODGES: 4
-      
+
 #INQUISITION/CHAMBER MILITANT
 
   - type: STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK
@@ -438,219 +438,217 @@ armors:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #Slaanesh dodge
   - type: STR_SLAAN_DEVOTED_SUIT
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ADEPTAS_SLAANASSASSINARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_SLAANCHOSEN_ASS
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_ADEPTAS_SLAANESH
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ADEPTAS_SLAANESH_BLESSED_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SLAANCELESTIAN_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_SLAANGOR_FIENDGOR_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_SLAANGOR_BULLGOR_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_SLAANGOR_GOR_ARMORMEDIUM
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_CHRYSSALID_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_CHRYSSALID_ARMOR_DIRE
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_CHRYSSALID_ARMORSELENE
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_NEVERBORN_TERRORIST_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_CHAOS_SERAPHIM
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_HERETIC_SERAPHIM_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #Khorne
   - type: STR_SILACOID_ARMORT #blood letter
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_KHORNE_REVENGEANCE_SUIT
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_ADEPTAS_ARMOR_KHORNE_REPENTIA
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_KHORNE_REPENTIA_LIGHT
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_KHORNESISTER_VALKIA_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_KHORNE_VALKIA_ARMORSUPERIOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_KHORNE_VALKIA_ARMORBASIC
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_MUTON_ARMORB
     refNode: *STR_DODGE_ARMOR
-    builtInWeapons: #built in special Khorne Berserker axe
-      - STR_KHORNE_BERSERKER_AXE
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_KHORNE_VALKIA_ARMORRETRIBUTOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_CHAOS_PENETANTE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_DESERTER_PSYKER_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #Tzeentch
   - type: STR_ADEPTAS_TZEENTCHNASSASSINARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
   - type: STR_TZEENTCH_CULT_WITCH_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_TZEENTCH_CULT_LEADER_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_TZEENTCH_CULT_LEADER_ASSASSIN_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_TZEENTCH_CULT_SUMMONER_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_FLAMER_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #Nurgle
   - type: STR_NURGLECHEM_SUIT
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_NURGLE_DAEMONETTE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 2
-      
+
 #Undivided
   - type: STR_NIGHTLORD_RAPTOR_ARMOR0
     refNode: *STR_DODGE_ARMOR #50%
@@ -658,164 +656,164 @@ armors:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_NIGHTLORD_RAPTOR_ARMOR2
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_NIGHTLORDS_WARPTALON_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_FLOATER_ARMOR0
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: FLOATER_ARMOR1
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: FLOATER_ARMOR2
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_WARPTALON_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 0
       FLIGHT_DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ALPHA_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 5
       FLIGHT_DODGE_CHANCE: 0
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ALPHA_CORVUS_ARMOR
     refNode: *STR_DODGE_ARMOR #50%
     tags:
       DODGE_CHANCE: 5
       FLIGHT_DODGE_CHANCE: 0
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #GSC
   - type: GENE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: GENE_ARMOR2
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: GENE_ARMOR3
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
-      
+
   - type: STR_GSC_PENETANTE_ARMOR_FEMALE
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GSC_PENETANTE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GSC_ENFORCER_MEDIC_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
-      ARMOR_MAX_SUCCESSFUL_DODGES: 1      
-      
+      ARMOR_MAX_SUCCESSFUL_DODGES: 1
+
   - type: STR_GSC_PDF_MEDIC_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
-      ARMOR_MAX_SUCCESSFUL_DODGES: 1      
-      
+      ARMOR_MAX_SUCCESSFUL_DODGES: 1
+
   - type: STR_GSC_GUARD_MEDIC_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GSC_MEDICAE_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GSC_PSYKER_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GSC_REPENTIA_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GSC_KELER_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_SAB_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
 #ORKS
   - type: STR_WEIRDORK_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 25
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ORK_ARMORKommando
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 20
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_ORK_TANKBUSTA_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 10
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+
   - type: STR_GROTS_ARMOR
     refNode: *STR_DODGE_ARMOR
     tags:
       DODGE_CHANCE: 15
       ARMOR_MAX_SUCCESSFUL_DODGES: 1
-      
+


### PR DESCRIPTION
1. Added Intimidate scripting/mechanics. Most Khorne units without a ranged attack (Warptalons, Bloodletters, Juggernauts etc) gain the ability to Intimidate that damages TU and Morale in a small AoE and is resisted by Bravery. Certain units (mostly FearImmune) are resistant/immune to Intimidate.

2. Various low level tweaks to Khorne units. 

3. Expanded Stat Gain On Melee Hit/Kill for Khorne weapons.