### PR TITLE
Minor Balance Tweaks

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -3005,7 +3005,7 @@ en-US:
   STR_GUARD_VETERAN_REQUISITION: "Requisition Veteran"
 
   STR_HEAVY_WEAPON_TOOLS: "Heavy Weapon Toolkit"
-  STR_HEAVY_WEAPON_TOOLS_UFOPEDIA: "{NEWLINE}This heavy weapon toolkit supports any troops wielding heavy weapons with bipods. By 'attacking' the heavy weapon soldier, the toolkit finishes deploying the heavy weapon or enables the soldier to move again on the same turn."
+  STR_HEAVY_WEAPON_TOOLS_UFOPEDIA: "{NEWLINE}This toolkit supports any troops wielding heavy weapons with bipods. By 'attacking' a heavy weapon user that has deployed or undeployed such a weapon on the same turn, the toolkit finishes deploying the heavy weapon, improving the accuracy of such a weapon deployed on the same turn, or enabling an soldier undeploying on the same turn to move again."
   STR_TOOLS_MELEE: "Assist Gunner"
 
   STR_SHOT_TYPE_AIMED: "Aimed (x{0})"
@@ -4681,3 +4681,8 @@ en-US:
   STR_INTIMIDATION_WEAPON: "Terrify"
   SILACOID_WEAPON: "Terrify"
   STR_INTIMIDATION_NOTICE: "Unit has been intimidated!"
+
+  STR_OGRYN_CARAPACE_BASIC: "Ogryn Carapace"
+  STR_OGRYN_CARAPACE_BASIC_UFOPEDIA: "Basic carapace plating specifically built for an Ogryn's large abhuman frame. Low cost, sturdy and rugged, this compromises the standard issue armor for our Ogryn infantry."
+  STR_OGRYN_CARAPACE: "Ogryn Reinforced Carapace"
+  STR_OGRYN_CARAPACE_UFOPEDIA: "Custom-made carapace armor that further increases the already impressive survivability of our Ogryn combatants. This benefits from additional plating and reinforcement (and weight) versus standard issue armoring."

--- a/Ruleset/ADEPTAS/weapons_adeptas.rul
+++ b/Ruleset/ADEPTAS/weapons_adeptas.rul
@@ -1258,7 +1258,7 @@ items:
       - STR_ADEPTAS
       - STR_FAITHFUL_ARMORY
     costBuy: 1200
-    costSell: 800
+    costSell: 300
     weight: 15
     bigSprite: 2032
     floorSprite: 8 #new floor sprite
@@ -1275,7 +1275,7 @@ items:
       - STR_ADEPTAS
       - STR_FAITHFUL_ARMORY
     costBuy: 2000
-    costSell: 800
+    costSell: 500
     weight: 15
     bigSprite: 2031
     floorSprite: 8 #new floor sprite
@@ -1311,7 +1311,7 @@ items:
       - STR_ADEPTAS
       - STR_FAITHFUL_ARMORY
     costBuy: 1000
-    costSell: 400
+    costSell: 250
     weight: 10
     bigSprite: 2032
     floorSprite: 8 #new floor sprite
@@ -1369,7 +1369,7 @@ items:
       - STR_ADEPTAS
       - STR_UFO_CONSTRUCTION #was STR_ADEPTAS_HIGHTIER
     costBuy: 15000
-    costSell: 5000
+    costSell: 4000
     weight: 10
     bigSprite: 2062
     floorSprite: { mod: 40k, index: 105 }
@@ -1506,7 +1506,7 @@ items:
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 1200
-    costSell: 600
+    costSell: 300
     weight: 5
     bigSprite: 2046
     floorSprite: { mod: 40k, index: 1008 }
@@ -1525,7 +1525,7 @@ items:
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 1200
-    costSell: 600
+    costSell: 300
     weight: 5
     bigSprite: 2045
     floorSprite: { mod: 40k, index: 1008 }
@@ -1544,7 +1544,7 @@ items:
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 1200
-    costSell: 600
+    costSell: 300
     weight: 5
     bigSprite: 2047
     floorSprite: { mod: 40k, index: 1006 }
@@ -1562,7 +1562,7 @@ items:
      - STR_FAITHFUL_ARMORY
     size: 0.2
     costBuy: 4000
-    costSell: 2760
+    costSell: 1000
     weight: 5
     bigSprite: 2059
     floorSprite: 2064

--- a/Ruleset/ALLFACTIONS/facilities.rul
+++ b/Ruleset/ALLFACTIONS/facilities.rul
@@ -189,7 +189,7 @@ items:
   - type: STR_MARKET_GOODS # trading goods
     requiresBuyBaseFunc: [TRADE]
     costBuy: 1000000
-    costSell: 1050000 #sell at a profit; trade money now for more money later; each trading most can earn a maximum of 250k / MO in this way.
+    costSell: 1100000 #sell at a profit; trade money now for more money later; each trading post can earn a maximum of 500k / MO in this way (400k with garrison supplies).
     size: 100 #bulk goods
     listOrder: 19182
     battleType: 0

--- a/Ruleset/ALLFACTIONS/personal_light.rul
+++ b/Ruleset/ALLFACTIONS/personal_light.rul
@@ -878,7 +878,7 @@ armors:
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
     recovery: # sta recovery times 1.5 + psi
       energy:
-        stamina: 0.50 
+        stamina: 0.50
         psiSkill: 0.2
   - type: STR_GSC_REPENTIA_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
@@ -1247,6 +1247,8 @@ armors:
   - type: STR_OFFICER_FLAK_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_OFFICER_FLAK_ARMOR_NOAIRSTRIKE
+    refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+  - type: STR_OGRYN_CARAPACE_BASIC
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_OGRYN_CARAPACE
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA

--- a/Ruleset/ALLFACTIONS/weapons_melta.rul
+++ b/Ruleset/ALLFACTIONS/weapons_melta.rul
@@ -75,7 +75,7 @@ items:
      - STR_LASER_WEAPONS #available to most factions quickly
     requiresBuyBaseFunc: [TRADE]
     costBuy: 10000
-    costSell: 3000
+    costSell: 2500
     hitSound: {mod: 40k, index: 19}
     hitAnimation: {mod: 40k, index: 110}
     vaporColorSurface: 1
@@ -123,7 +123,7 @@ items:
     vaporDensitySurface: 2
     vaporProbabilitySurface: 85
     size: 0.1
-    costSell: 5000
+    costSell: 1000
     weight: 3
     battleType: 2
     invWidth: 1

--- a/Ruleset/ALLFACTIONS/weapons_plasma.rul
+++ b/Ruleset/ALLFACTIONS/weapons_plasma.rul
@@ -9,7 +9,7 @@ items:
     requires:
       - STR_BARRAGE_PLASMA_CLIP
     size: 0.1
-    costSell: 6000
+    costSell: 5000
     power: 120
     clipSize: 24
     weight: 25
@@ -42,7 +42,7 @@ items:
     requires:
       - STR_PLASMA_RIFLE_CLIP
     size: 0.1
-    costSell: 6000
+    costSell: 5000
     weight: 4
     bigSprite: { mod: 40k, index: 41 }
     floorSprite: { mod: 40k, index: 621 }

--- a/Ruleset/BALANCE/explosives.rul
+++ b/Ruleset/BALANCE/explosives.rul
@@ -101,7 +101,7 @@ items:
     categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR]
     size: 0.2
     costBuy: 5000
-    costSell: 2500
+    costSell: 2000
     weight: 5 #was 6
     power: 80 #was 10
     damageType: 3

--- a/Ruleset/BALANCE/las_ammo.rul
+++ b/Ruleset/BALANCE/las_ammo.rul
@@ -49,20 +49,21 @@ items:
   - type: STR_LASCAN_CLIP #LASCANON CLIP
     power: 220
     damageAlter: #DA LAS
-      RandomType: 7 #50-200
+      RandomType: 6 #gaussian
       ToArmorPre: 0.4
       ToHealth: 1.0
-      ToArmor: 0.2
+      ToArmor: 0.1
       ToStun: 0.0
+    clipSize: 5
 
   - type: STR_LASCANNON_CLIP_SMALL
     power: 220
     damageAlter: #DA LAS
-      RandomType: 7 #50-200
+      RandomType: 6 #gaussian
       ToArmorPre: 0.4
       ToHealth: 1.0
-      ToArmor: 0.2
-      ToStun: 0.0
+      ToArmor: 0.1
+      ToStun: 0.3
     clipSize: 3
 
   - type: STR_PORTABLE_MULTILASER_BATTERY #MULTILAS POWER PACK

--- a/Ruleset/BALANCE/plasma_ammo.rul
+++ b/Ruleset/BALANCE/plasma_ammo.rul
@@ -3,9 +3,10 @@ items:
     power: 140
     powerForAnimation: 5 # 5 / 5 = 1
     clipSize: 10
+    costSell: 4000
 
   - type: STR_PLASMA_RIFLE_CLIP #                   11510
-    costSell: 5000
+    costSell: 2000
     power: 100 #75 #*** PLASMA rebalance
 
   - type: STR_PLASMA_PISTOL_CLIP

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -2339,7 +2339,7 @@ items:
     size: 0.1
     requires:
       - STR_ALIENS_ONLY
-    costSell: 1180
+    costSell: 1000
     weight: 20
     bigSprite: 2600
     floorSprite: { mod: 40k, index: 10 }
@@ -2455,7 +2455,7 @@ items:
     size: 0.2
     # costBuy: 500
     hitAnimation: 1090
-    costSell: 4000
+    costSell: 2000
     weight: 5
     power: 50
     powerRangeReduction: 13
@@ -3489,7 +3489,7 @@ items:
       - STR_ALIENS_ONLY
     size: 0.2
     costBuy: 6000
-    costSell: 2000
+    costSell: 1500
     weight: 6
     power: 100
     damageType: 3
@@ -4935,7 +4935,7 @@ items:
     requires:
       - STR_ALIENS_ONLY
     size: 0.1
-    costSell: 7500
+    costSell: 3000
     weight: 1
     bigSprite: 2327
     floorSprite: 2429

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -1310,10 +1310,12 @@ armors:
     spriteSheet: SCION_CARAPACE_MEDIC.PCK
     customArmorPreviewIndex: 521
 
-
-  - type: STR_OGRYN_UC
+  - &STR_GUARD_ARMOR_OGRYN_BASIC_DAMAGE
+    type: STR_OGRYN_UC
     visibilityAtDay: 40
     visibilityAtDark: 9
+    tags:
+      INFECTION_RESIST: 33 #infection resistant
     frontArmor: 20
     sideArmor: 15
     rearArmor: 10
@@ -1332,14 +1334,21 @@ armors:
       - 0.5 #IMPACT
       - 1.0 #MELTA
 
-  - &STR_GUARD_ARMOR_OGRYN_CARAPACE_DAMAGE
-    type: STR_OGRYN_CARAPACE
+  - type: STR_OGRYN_CARAPACE_BASIC
+    refNode: *STR_GUARD_ARMOR_OGRYN_BASIC_DAMAGE
     visibilityAtDay: 40
     visibilityAtDark: 9
+    spriteSheet: OGRYN_CARAPACE.PCK
+    #spriteInv: OGRYN_CARAPACE
+    customArmorPreviewIndex: {mod: 40k, index: 509}
+    corpseBattle:
+      - STR_OGRYN_CARAPACE_CORPSE
+    storeItem: STR_NONE
+    loftempsSet: [ 5 ]
     frontArmor: 70
     sideArmor: 50
     rearArmor: 40
-    underArmor: 30
+    underArmor: 40
     damageModifier: #OGRYN ARMOR
       - 1.0 #none
       - 1.0 #AP
@@ -1354,8 +1363,36 @@ armors:
       - 0.5 #IMPACT
       - 1.0 #MELTA
 
-  - type: STR_OGRYN_CARAPACE
     weight: 10
+    stats:
+      tu: -5
+      stamina: -10
+
+  - &STR_GUARD_ARMOR_OGRYN_CARAPACE_DAMAGE
+    type: STR_OGRYN_CARAPACE
+    visibilityAtDay: 40
+    visibilityAtDark: 9
+    frontArmor: 80
+    sideArmor: 60
+    rearArmor: 50
+    underArmor: 50
+    tags:
+      INFECTION_RESIST: 33 #infection resistant
+    damageModifier: #OGRYN ARMOR
+      - 1.0 #none
+      - 1.0 #AP
+      - 1.0 #FLAMES
+      - 1.0 #HE
+      - 0.8 #LASCANON
+      - 0.9 #PLASMA
+      - 0.6 #STUN
+      - 0.7 #MELEE
+      - 1.0 #ACID
+      - 0.0 #SMOKE
+      - 0.5 #IMPACT
+      - 1.0 #MELTA
+
+    weight: 15
     stats:
       tu: -5
       stamina: -10
@@ -1363,11 +1400,11 @@ armors:
   - &STR_GUARD_ARMOR_BULLGRYN_SLAB # DAMAGE + STATS
     type: STR_BULLGRYN_SLAB
     refNode: *STR_GUARD_ARMOR_OGRYN_CARAPACE_DAMAGE
-    frontArmor: 120
-    sideArmor: 60
-    rearArmor: 40
-    underArmor: 30
-    weight: 20
+    frontArmor: 130
+    sideArmor: 70
+    rearArmor: 50
+    underArmor: 50
+    weight: 25
     stats:
       tu: -5
       stamina: -15
@@ -1377,11 +1414,11 @@ armors:
   - &STR_GUARD_ARMOR_BULLGRYN_BUCKLER # DAMAGE + STATS
     type: STR_BULLGRYN_BUCKLER
     refNode: *STR_GUARD_ARMOR_OGRYN_CARAPACE_DAMAGE
-    frontArmor: 85
-    sideArmor: 65
+    frontArmor: 95
+    sideArmor: 75
     rearArmor: 50
-    underArmor: 30
-    weight: 15
+    underArmor: 50
+    weight: 20
     stats:
       stamina: -10
       melee: 10

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -1345,6 +1345,8 @@ armors:
       - STR_OGRYN_CARAPACE_CORPSE
     storeItem: STR_NONE
     loftempsSet: [ 5 ]
+    units:
+      - STR_OGRYN
     frontArmor: 70
     sideArmor: 50
     rearArmor: 40

--- a/Ruleset/IG/armors_layers_IG.rul
+++ b/Ruleset/IG/armors_layers_IG.rul
@@ -122,7 +122,7 @@ armors:
       M7: ["", "M7", "HAIR_M7", "", "Male", "", "HELMET_MALE_LAYER_INV", "", ""]
       M8: ["", "M8", "HAIR_M8", "", "Male", "", "HELMET_MALE_LAYER_INV", "", ""]
       M9: ["", "M9", "HAIR_M9", "", "Male", "", "HELMET_MALE_LAYER_INV", "", ""]
-      
+
   - type: STR_FELINIDGUARD_MEDIC_CARAPACE_ARMOR
     layersDefaultPrefix: FELINID
     layersSpecificPrefix:
@@ -154,7 +154,7 @@ armors:
       M7: ["", "M7", "HAIR_M7", "", "Male", "Male", "HELMET_MALE_LAYER_INV", "", ""]
       M8: ["", "M8", "HAIR_M8", "", "Male", "Male", "HELMET_MALE_LAYER_INV", "", ""]
       M9: ["", "M9", "HAIR_M9", "", "Male", "Male", "HELMET_MALE_LAYER_INV", "", ""]
-      
+
   - &GUARD_POWER_ARMOR
     type: STR_GUARD_POWER_ARMOR
     layersDefaultPrefix: GUARD_POWER_ARMOR
@@ -182,11 +182,11 @@ armors:
       F6: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F6"]
       F7: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F7"]
       F8: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F8"]
-      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9"] 
+      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9"]
 
   - type: STR_GUARD_POWER_ARMOR_MULTILAS
     refNode: *GUARD_POWER_ARMOR
-    
+
   - type: STR_KRIEG_POWER_ARMOR
     refNode: *GUARD_POWER_ARMOR
     layersDefinition:
@@ -209,7 +209,7 @@ armors:
       F6: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F6"]
       F7: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F7"]
       F8: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F8"]
-      F9: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F9"] 
+      F9: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F9"]
 
   - type: STR_KRIEG_POWER_ARMOR_MULTILAS
     refNode: *GUARD_POWER_ARMOR
@@ -234,7 +234,7 @@ armors:
       F7: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F7"]
       F8: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F8"]
       F9: ["POWER_ARMOR_KRIEG_INV", "POWER_ARMOR_KRIEG_F9"]
-      
+
   - type: STR_GUARD_POWER_ARMOR_MEDIC
     refNode: *GUARD_POWER_ARMOR
     layersDefinition:
@@ -257,7 +257,7 @@ armors:
       F6: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F6", "POWER_ARMOR_GREEN_LAYER_MEDIC_INV"]
       F7: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F7", "POWER_ARMOR_GREEN_LAYER_MEDIC_INV"]
       F8: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F8", "POWER_ARMOR_GREEN_LAYER_MEDIC_INV"]
-      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9", "POWER_ARMOR_GREEN_LAYER_MEDIC_INV"] 
+      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9", "POWER_ARMOR_GREEN_LAYER_MEDIC_INV"]
 
   - type: STR_GUARD_POWER_ARMOR_OFFICER
     refNode: *GUARD_POWER_ARMOR
@@ -281,7 +281,7 @@ armors:
       F6: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F6", "POWER_ARMOR_GREEN_LAYER_OFFICER_INV"]
       F7: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F7", "POWER_ARMOR_GREEN_LAYER_OFFICER_INV"]
       F8: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F8", "POWER_ARMOR_GREEN_LAYER_OFFICER_INV"]
-      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9", "POWER_ARMOR_GREEN_LAYER_OFFICER_INV"] 
+      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9", "POWER_ARMOR_GREEN_LAYER_OFFICER_INV"]
 
   - type: STR_GUARD_POWER_ARMOR_COMMISSAR
     refNode: *GUARD_POWER_ARMOR
@@ -305,8 +305,8 @@ armors:
       F6: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F6", "POWER_ARMOR_GREEN_LAYER_COMMISSAR_FEM_INV"]
       F7: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F7", "POWER_ARMOR_GREEN_LAYER_COMMISSAR_FEM_INV"]
       F8: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F8", "POWER_ARMOR_GREEN_LAYER_COMMISSAR_FEM_INV"]
-      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9", "POWER_ARMOR_GREEN_LAYER_COMMISSAR_FEM_INV"] 
-      
+      F9: ["POWER_ARMOR_GREEN_LAYER_INV", "POWER_ARMOR_F9", "POWER_ARMOR_GREEN_LAYER_COMMISSAR_FEM_INV"]
+
   - &STR_ELYSIAN_ARMOR
     type: STR_ELYSIAN_JUMP_ARMOR
     layersDefaultPrefix: GUARD
@@ -572,7 +572,7 @@ armors:
 #  - type: STR_OFFICER_CARAPACE_ARMOR
 
 
-  - type: STR_PENAL_ARMOR_BROWN_UC 
+  - type: STR_PENAL_ARMOR_BROWN_UC
     layersDefaultPrefix: 20
     layersSpecificPrefix:
       20: PENAL
@@ -635,7 +635,7 @@ armors:
     refNode: *STR_STORMTROOPER_OFFICER_CARAPACE_ARMOR
 
   - type: STR_STORMTROOPER_OFFICER_CARAPACE_ARMOR_HELLPISTOL
-    refNode: *STR_STORMTROOPER_OFFICER_CARAPACE_ARMOR  
+    refNode: *STR_STORMTROOPER_OFFICER_CARAPACE_ARMOR
 
   - &STR_STORMTROOPER_CARAPACE_ARMOR
     type: STR_STORMTROOPER_CARAPACE_ARMOR
@@ -1011,3 +1011,16 @@ armors:
 
   - type: STR_GUARD_ARMORS_TAUROS_HEAVY_FLAMER
     refNode: *STR_ARMOR_TAUROS
+  - type: STR_OGRYN_CARAPACE_BASIC
+    layersDefaultPrefix: OGRYN
+    layersSpecificPrefix:
+      4: OGRYN_CARAPACE
+    layersDefinition:
+      M0: ["", "M0", "", "", "Armor", "", "", "", ""]
+      M1: ["", "M1", "", "", "Armor", "", "", "", ""]
+      M2: ["", "M2", "", "", "Armor", "", "", "", ""]
+      M3: ["", "M3", "", "", "Armor", "", "", "", ""]
+      F0: ["", "M0", "", "", "Armor", "", "", "", ""]
+      F1: ["", "M1", "", "", "Armor", "", "", "", ""]
+      F2: ["", "M2", "", "", "Armor", "", "", "", ""]
+      F3: ["", "M3", "", "", "Armor", "", "", "", ""]

--- a/Ruleset/IG/ufopaedia_IG.rul
+++ b/Ruleset/IG/ufopaedia_IG.rul
@@ -1,22 +1,22 @@
 ufopaedia:
   - id: STR_LASGUN_ACCATRAN
     text: STR_LASGUN_ACCATRAN_CODEX
-    
+
   - id: STR_LASGUN_VOSS
     text: STR_LASGUN_VOSS_CODEX
 
   - id: STR_LASGUN_VOSTROYA
     text: STR_LASGUN_VOSTROYA_CODEX
-    
-  - id: STR_LASGUN_LUCIUS  
+
+  - id: STR_LASGUN_LUCIUS
     text: STR_LASGUN_LUCIUS_CODEX
-    
+
   - id: STR_LASGUN_TANITH
-    text: STR_LASGUN_TANITH_CODEX   
-    
-  - id: STR_LONGLAS_TANITH   
+    text: STR_LASGUN_TANITH_CODEX
+
+  - id: STR_LONGLAS_TANITH
     text: STR_LONGLAS_TANITH_CODEX
-    
+
   - id: STR_PENAL_ARMOR_BROWN_UC              #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -63,20 +63,20 @@ ufopaedia:
     section: STR_NOT_AVAILABLE
   - id: STR_MORTAR_AMMO_KRAK
     type_id: 14
-    section: STR_NOT_AVAILABLE    
+    section: STR_NOT_AVAILABLE
   - id: STR_MORTAR_AMMO_PHOSPHOR
     type_id: 14
-    section: STR_NOT_AVAILABLE    
+    section: STR_NOT_AVAILABLE
   - id: STR_MORTAR_AMMO_SMOKE
     type_id: 14
     section: STR_NOT_AVAILABLE
   - id: STR_MORTAR_AMMO_ILLUMINATION
     type_id: 14
-    section: STR_NOT_AVAILABLE    
+    section: STR_NOT_AVAILABLE
   - id: STR_MORTAR_AMMO_PHOTON
     type_id: 14
-    section: STR_NOT_AVAILABLE   
-    
+    section: STR_NOT_AVAILABLE
+
   - id: STR_GUARD_ARMORP_UC
     requires:
         - STR_IMPERIAL_GUARD_OPERATIONS
@@ -97,7 +97,7 @@ ufopaedia:
     text: STR_ELYSIAN_JUMP_MEDIC_ARMOR_UFOPAEDIA
     requires:
         - STR_ELYSIAN_JUMP_ARMOR_REQUISITION
-    listOrder: 6711    
+    listOrder: 6711
 
   - id: STR_GUARD_IMPERIAL_ASSASSIN_UC              #6800   #ARMOR
     type_id: 15
@@ -140,7 +140,7 @@ ufopaedia:
     requires:
         - STR_IMPERIAL_GUARD_OPERATIONS
         - STR_TANITH_REQUISITIONS
- 
+
 
   - id: STR_MEDIC_CARAPACE_ARMOR                #6700   #ARMOR
     type_id: 15
@@ -225,7 +225,7 @@ ufopaedia:
     type_id: 14
     section: STR_NOT_AVAILABLE
 
-  - id: STR_VULTURE_IG    
+  - id: STR_VULTURE_IG
     type_id: 11
     requires:
       - STR_VULTURE_IG_REQUISITION
@@ -322,15 +322,15 @@ ufopaedia:
   - id: STR_HEAVY_ROCKET_HE #frag
     type_id: 14
     section: STR_NOT_AVAILABLE
-      
+
   - id: STR_HEAVY_ROCKET_KRAK #krak
     type_id: 14
     section: STR_NOT_AVAILABLE
-    
+
   - id: STR_HEAVY_ROCKET #Melta Rocket
     type_id: 14
     section: STR_NOT_AVAILABLE
-    
+
   - id: STR_ACCATRAN_ROCKET_LAUNCHER
     requires:
       - STR_GUARD_AND_ARBITES
@@ -339,7 +339,7 @@ ufopaedia:
     image_id: ROCKET_ACCATRAN_CODEX.SPK
     text: STR_ACCATRAN_ROCKET_LAUNCHER_CODEX
     listOrder: 12105
-    
+
   - id: STR_FLECHETTE_PISTOL
     requires:
       - STR_UFO_CONSTRUCTION
@@ -349,7 +349,7 @@ ufopaedia:
     image_id: FLECHETTE_PISTOL_CODEX.SPK
     text: STR_FLECHETTE_PISTOL_CODEX
     listOrder: 10725
-    
+
   - id: STR_SHOTGUN_PISTOL
     requires:
       - STR_MIDTIER_PREREQ
@@ -359,7 +359,7 @@ ufopaedia:
     image_id: SHOTPISTOL_CODEX.SPK
     text: STR_SHOTGUN_PISTOL_CODEX
     listOrder: 10605
-    
+
   - id: STR_AUTOPISTOL_HIGHGRADE
     requires:
       - STR_BALLISTIC_WEAPONS_HIGHGRADE
@@ -368,7 +368,7 @@ ufopaedia:
     image_id: AUTOPISTOL_HIGH_GRADE_CODEX.SPK
     text: STR_AUTOPISTOL_HIGHGRADE_CODEX
     listOrder: 10740
-    
+
   - id: STR_AUTOGUN_HIGHGRADE
     requires:
       - STR_BALLISTIC_WEAPONS_HIGHGRADE
@@ -377,7 +377,7 @@ ufopaedia:
     image_id: AUTOGUN_HIGH_GRADE_CODEX.SPK
     text: STR_AUTOGUN_HIGHGRADE_CODEX
     listOrder: 10741
-    
+
   - id: STR_AUTOGUN_HIGHGRADE_UNDERSLUNG
     requires:
       - STR_BALLISTIC_WEAPONS_HIGHGRADE
@@ -396,7 +396,7 @@ ufopaedia:
   - id: STR_KRAK_GRENADE40
     type_id: 14
     section: STR_NOT_AVAILABLE
-    
+
   - id: STR_HEAVY_SNIPER_RIFLEG
     requires:
       - STR_UFO_CONSTRUCTION #ceramite tier
@@ -406,14 +406,14 @@ ufopaedia:
     image_id: orksnipercodex.SPK
     text: STR_HEAVY_SNIPER_RIFLEG_CODEX
     listOrder: 10776
-    
+
   - id: STR_HEAVY_SNIPER_RIFLEG_AMMO
     type_id: 14
     section: STR_NOT_AVAILABLE
   - id: STR_HEAVY_SNIPER_RIFLEG_AMMO_PENETRATOR
     type_id: 14
     section: STR_NOT_AVAILABLE
-    
+
   - id: STR_SMOKE_GRENADE_DRUM
     type_id: 14
     section: STR_NOT_AVAILABLE
@@ -458,7 +458,7 @@ ufopaedia:
     image_id: UMBRA_UNDERSLUNG_CODEX.SPK
     text: STR_BOLTER_LIGHT_UMBRA_UNDERSLUNG_CODEX
     listOrder: 10771
-    
+
   - id: STR_BOLTER_LIGHT_SOLO
     requires:
       - STR_IMPERIAL_GUARD_OPERATIONS
@@ -501,7 +501,7 @@ ufopaedia:
     image_id: BOLTER_SOLO_COMBIMELTA.SPK
     text: STR_BOLTER_LIGHT_SOLO_COMBIMELTA_CODEX
     listOrder: 10773
-    
+
   - id: STR_BOLTER_LIGHT_LMG #Accatran light bolter bipod
     requires:
       - STR_IMPERIAL_GUARD_OPERATIONS
@@ -518,7 +518,7 @@ ufopaedia:
     image_id: LASGUNHIGHGRADE_CODEX.SPK
     text: STR_LASER_RIFLE_G_HIGH_GRADE_CODEX
     listOrder: 10911
-    
+
 
 # allows stats for nerds entry to be viewed
   - id: STR_HEAVY_STUBBER_CLIP_MC
@@ -531,7 +531,7 @@ ufopaedia:
   - id: STR_LIGHT_BOLTER_AMMO_BELT_PEN
     type_id: 14
     section: STR_NOT_AVAILABLE
-    
+
   - id: STR_HELLPISTOL_BUILTIN
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
@@ -550,10 +550,10 @@ ufopaedia:
     type_id: 14
     section: STR_NOT_AVAILABLE
 
-  - id: STR_LIGHT_BOLTER_AMMO_SHORT_PEN 
+  - id: STR_LIGHT_BOLTER_AMMO_SHORT_PEN
     type_id: 14
     section: STR_NOT_AVAILABLE
-    
+
   - id: STR_LIGHT_BOLTER_AMMO_PEN
     type_id: 14
     section: STR_NOT_AVAILABLE
@@ -672,7 +672,7 @@ ufopaedia:
 
 
   - id: STR_LASER_RIFLE # IG can loot them
-    requires: 
+    requires:
       - STR_LASER_WEAPONS
 
   - id: STR_PSYKER_ARMOR
@@ -684,7 +684,7 @@ ufopaedia:
     requires:
      - STR_GUARD_AND_ARBITES
 #     - STR_IMPERIAL_GUARD_OPERATIONS
-     - STR_HEAVY_WEAPONS_IG 
+     - STR_HEAVY_WEAPONS_IG
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: 1ML.SPK
     text: STR_DISPOSABLE_LAUNCHER_KRAK_UFOPEDIA
@@ -751,7 +751,7 @@ ufopaedia:
         text: STR_HEAVY_LASGUN_LUCIUS_XIV_UFOPEDIA
       - title: STR_HEAVY_LASGUN_LUCIUS_XIV
         text: STR_HEAVY_LASGUN_LUCIUS_XIV_SPECIAL_UFOPEDIA
-    
+
   - id: STR_SQUAT_FLAK_ARMOR           #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -769,7 +769,7 @@ ufopaedia:
     requires:
         - STR_SQUAT_GUARDSMEN
     listOrder: 6810 #change
-    
+
   - id: STR_BEASTGUARD_FLAK_ARMOR           #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -788,7 +788,7 @@ ufopaedia:
         - STR_BEASTMEN_GUARDSMEN
         - STR_MIDTIER_PREREQ
     listOrder: 6800 #change
-    
+
   - id: STR_BEASTGUARD_CARAPACE_ARMOR          #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -819,7 +819,7 @@ ufopaedia:
         - STR_CARAPACE_ARMOR_IG
         - STR_UFO_CONSTRUCTION #ceramite
     listOrder: 6816 #change
-    
+
   - id: STR_FELINIDGUARD_FLAK_ARMOR          #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -846,11 +846,11 @@ ufopaedia:
     requires:
         - STR_FELINID_JUMP_ARMOR_REQUISITION
     listOrder: 6825 #change
-    
+
   - id: STR_FELINIDGUARD_CARAPACE_ARMOR         #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
-    image_id: FELINID_CARAPACE_ARMOR_CODEX.SPK 
+    image_id: FELINID_CARAPACE_ARMOR_CODEX.SPK
     text: STR_FELINIDGUARD_CARAPACE_ARMOR_CODEX
     requires:
       - STR_GUARD_SUPORT
@@ -872,7 +872,7 @@ ufopaedia:
   - id: STR_SHOTLAS
     requires:
       - STR_MIDTIER_PREREQ
-      - STR_IMPERIAL_GUARD_OPERATIONS 
+      - STR_IMPERIAL_GUARD_OPERATIONS
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: SHOTLAS_CODEX.SPK
@@ -880,11 +880,11 @@ ufopaedia:
     pages:
       - title: STR_SHOTLAS
         text: STR_HOTLAS_CODEX
-        
+
   - id: STR_LONG_RIFLE_GUARD
     requires:
       - STR_MIDTIER_PREREQ
-      - STR_IMPERIAL_GUARD_OPERATIONS 
+      - STR_IMPERIAL_GUARD_OPERATIONS
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: LONGRIFLE_CODEX.SPK
@@ -892,7 +892,7 @@ ufopaedia:
     pages:
       - title: STR_LONG_RIFLE_GUARD
         text: STR_LONGRIFLE_CODEX
-        
+
   - id: STR_ROTOR_CANNON
     requires:
       - STR_ROTOR_CANNON_RESEARCH
@@ -975,7 +975,7 @@ ufopaedia:
     pages:
       - title: STR_HAND_MULTILASER
         text: STR_HAND_MULTILASER_UFOPEDIA
-        
+
   - id: STR_GUARD_POWER_ARMOR          #6800   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
@@ -990,7 +990,7 @@ ufopaedia:
         text: STR_GUARD_POWER_ARMOR_CODEX_PAGE2
       - title: STR_GUARD_POWER_ARMOR_TITLE
         text: STR_GUARD_POWER_ARMOR_CODEX_PAGE3
-        
+
   - id: STR_BIOMANCER
     requires:
       - STR_BIOMANCER
@@ -1011,7 +1011,7 @@ ufopaedia:
   - id: STR_GUARD_ARMORH_UC                #6700   #ARMOR
     type_id: 15
     section: STR_ARMORPEDIA
-    image_id: CarapaceArmor.SPK   
+    image_id: CarapaceArmor.SPK
     text: STR_GUARD_ARMORH_UC_UFOPEDIA
     requires:
         - STR_CARAPACE_ARMOR_IG
@@ -1082,3 +1082,13 @@ ufopaedia:
 #        - STR_KRIEG_GUARDSMEN
     listOrder: 7860
 
+
+
+  - id: STR_OGRYN_CARAPACE_BASIC
+    requires:
+      - STR_OGRYN_REQUISITION
+    type_id: 15
+    section: STR_ARMORPEDIA
+    image_id: OGRYN_CARAPACE.SPK
+    text: STR_OGRYN_CARAPACE_BASIC_UFOPEDIA
+    listOrder: 7600

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -520,7 +520,7 @@ items:
     requiresBuy:
       - STR_BALLISTIC_WEAPONS_HIGHGRADE
     costBuy: 1000
-    costSell: 105
+    costSell: 100
     weight: 5
     bigSprite: 270
     floorSprite: {mod: 40k, index: 1011} #needs new
@@ -699,7 +699,7 @@ items:
     requiresBuy:
       - STR_MIDTIER_PREREQ
     costBuy: 2500
-    costSell: 1000
+    costSell: 600
     bigSprite: 269
     floorSprite: 2062 #change
     handSprite: { mod: 40k, index: 352 } #Needs new
@@ -1403,7 +1403,7 @@ items:
     requiresBuy:
       - STR_BASIC_SENTINEL_MISSILE
     costBuy: 3600
-    costSell: 2840
+    costSell: 900
     size: 0.5
     weight: 20
     invWidth: 2
@@ -2370,7 +2370,7 @@ items:
     categories: [STR_CAT_ROCKETL]
     size: 0.1
     costBuy: 7500
-    costSell: 6000
+    costSell: 2000
     weight: 5
     floorSprite: {mod: 40k, index: 1008}
     handSprite: {mod: 40k, index: 1048}

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -343,7 +343,7 @@ items:
   - type: STR_HWP_FUSION_BOMB    #DREAD missele System         6635
     categories: [STR_CAT_AUXILIARY]
     size: 0.6
-    costSell: 31500
+    costSell: 30000
     transferTime: 48
     weight: 20
     power: 120


### PR DESCRIPTION
1. Trading Outpost's trade goods now yield 10% profit rather than 5%.

2. Ammo sale prices across the board reduced; squashed unintended prices that allowed for the highly profitable sale of melta munitions.

3. Ogryns now have a basic default carapace armor that doesn't require manufacture. Manufactured Carapace rebranded as 'Reinforced'; most manufactured Ogryn armor given slightly better protection at the cost of more weight.

4. Ogryns given 33% infection resistance.

5. Lascannons now do gaussian damage rather than 50-200%.

6. Large lascannon charge reduced to 5 shots down from 10.