### PR TITLE
Ammo Fixes/Tweaks

### DIFF
--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -3135,7 +3135,7 @@ items:
     damageType: 0
     damageAlter: #DA MELTA Double
       FixRadius: 2
-      RandomType: 6 #Swingy damage
+      RandomType: 6 #Gaussian damage
       ArmorEffectiveness: 0.0 #armor doesn't help against intimidation
       ToHealth: 0.0
       ToArmor: 0.0
@@ -3177,7 +3177,7 @@ items:
     damageType: 0
     damageAlter: #DA MELTA Double
       FixRadius: 2
-      RandomType: 6 #Swingy damage
+      RandomType: 6 #Gaussian damage
       ArmorEffectiveness: 0.0 #armor doesn't help against intimidation
       ToHealth: 0.0
       ToArmor: 0.0

--- a/Ruleset/IG/manufacture_IG.rul
+++ b/Ruleset/IG/manufacture_IG.rul
@@ -1558,6 +1558,76 @@ manufacture:
       STR_ALIEN_ALLOYS: 5
       STR_ELERIUM_115: 2
       STR_UFO_CONSTRUCTION: 1
-      STR_KILLPOINT_TOKEN: 100 #10 per
+      STR_KILLPOINT_TOKEN: 200
     producedItems:
       STR_HOLOGRAM_GRENADE: 10
+
+  - name: STR_LIGHT_BOLTER_AMMO_SHORT
+    category: STR_AMMUNITION
+    requires:
+      - STR_LIGHT_BOLTERS_LOWTIER
+    space: 2
+    time: 100
+    cost: 400
+    requiredItems:
+      STR_ALIEN_ALLOYS: 1
+    producedItems:
+      STR_LIGHT_BOLTER_AMMO_SHORT: 10
+
+  - name: STR_LIGHT_BOLTER_AMMO_SHORT_PEN
+    category: STR_AMMUNITION
+    requires:
+      - STR_LIGHT_BOLTERS_LOWTIER
+      - STR_MIDTIER_PREREQ
+    space: 2
+    time: 100
+    cost: 1000
+    requiredItems:
+      STR_ALIEN_ALLOYS: 2
+    producedItems:
+      STR_LIGHT_BOLTER_AMMO_SHORT: 10
+
+  - name: STR_RIPPER_GUN_CLIP
+    category: STR_AMMUNITION
+    requires:
+      - STR_OGRYN_REQUISITION
+    space: 2
+    time: 100
+    cost: 500
+    requiredItems:
+      STR_ALIEN_ALLOYS: 1
+    producedItems:
+      STR_RIPPER_GUN_CLIP: 5
+
+  - name: STR_RIPPER_GUN
+    category: STR_WEAPON
+    requires:
+      - STR_OGRYN_REQUISITION
+    space: 4
+    time: 200
+    cost: 500
+    requiredItems:
+      STR_ALIEN_ALLOYS: 2
+    producedItems:
+      STR_RIPPER_GUN: 1
+
+  - name: STR_LASGUN_CLIP
+    category: STR_AMMUNITION
+    space: 2
+    time: 100
+    cost: 500
+    producedItems:
+      STR_LASGUN_CLIP: 10
+
+  - name: STR_LASGUN_CLIP_HOTSHOT
+    category: STR_AMMUNITION
+    requires:
+      - STR_LASER_WEAPONS
+      - STR_IMPERIAL_GUARD_OPERATIONS
+    space: 2
+    time: 200
+    cost: 500
+    requiredItems:
+      STR_ELERIUM_115: 4
+    producedItems:
+      STR_LASGUN_CLIP_HOTSHOT: 10

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -4050,3 +4050,11 @@ items:
     invHeight: 3
     recover: false
     turretType: 1
+
+  - type: STR_RIPPER_GUN_CLIP
+    damageAlter:
+      ToArmorPre: 0.05 #slightly better armor ablation
+      ArmorEffectiveness: 0.9 #has minor armor penetration
+
+  - type: STR_LASGUN_CLIP #LASGUN CLIP                 11010
+    costSell: 40

--- a/Ruleset/SM/manufacture_SM.rul
+++ b/Ruleset/SM/manufacture_SM.rul
@@ -344,7 +344,7 @@ manufacture:
     requiredItems:
       STR_ELERIUM_115: 20
     producedItems:
-      STR_MELTA_AMMO: 5
+      STR_HEAVY_PLASMA_CLIP: 5
 
   - name: STR_PLASMA_INC_TERRAN
     category: STR_WEAPON


### PR DESCRIPTION
1. Fixed bug with Heavy Plasma Clip recipe so it makes Heavy Plasma Clips instead of Melta Clips.

2. Added recipes for Light Bolter Short ammo, Lasgun Clips, Lasgun Hotshot, and Ripper Guns and Ripper Gun Clips.

3. Ripper Guns now have minor armor penetration and slightly better  armor ablation.