### PR TITLE
Script Tweaks

### DIFF
--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -1918,7 +1918,9 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
-
+    recovery:
+      morale:
+        flatHundred: 1
 
   - type: STR_TAUROX_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1933,6 +1935,9 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
+    recovery:
+      morale:
+        flatHundred: 1
 
   - type: STR_TAUROS_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1946,6 +1951,9 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
+    recovery:
+      morale:
+        flatHundred: 1
 
   - type: STR_TAUROS_SMALL_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1959,7 +1967,9 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
-
+    recovery:
+      morale:
+        flatHundred: 1
 
   - type: LEMONRUSS_ARMOR
     visibilityAtDay: 40
@@ -1973,6 +1983,9 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
+    recovery:
+      morale:
+        flatHundred: 1
 
   - type: LEMONRUSS_ARMORB
     visibilityAtDay: 40
@@ -1986,6 +1999,9 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
+    recovery:
+      morale:
+        flatHundred: 1
 
   - type: STR_EMPLACEMENT_ARMOR
     frontArmor: 160 # was 130
@@ -1994,6 +2010,9 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
+    recovery:
+      morale:
+        flatHundred: 1
 
   - &STR_CAS_ARMOR
     type: STR_CAS_MISSILE_POD_ARMOR

--- a/Ruleset/scripts/scripts_infection_mechanics.rul
+++ b/Ruleset/scripts/scripts_infection_mechanics.rul
@@ -206,6 +206,22 @@ extended:
             muldiv infectionDamage infectionResist 100;
           end;
 
+          if neq infectionType 2; #Devotion only protects against Chaos Corruption, not GSC infections.
+            unit.Stats.getPsiSkill temp;
+            if gt temp 50; #we only start getting the Emprah's protection from Chaos with Devotion above 50.
+              sub temp 50;
+              div temp 2;
+              limit_upper temp 100;
+              if eq temp 100; #abort if we get 100% infection resistance
+                #debug_log "Infection Scripts; damageUnit, offset 22: Aborting. Infection resistance from Devotion at 100%" temp;
+                return;
+              end;
+              sub temp -100; #invert
+              mul temp -1;
+              muldiv infectionDamage temp 100;
+            end;
+          end;
+
           #cannot have multiple infection types; the infection with higher damage takes priority; set appropriate variables
           unit.getTag currentInfectionType Tag.CURRENT_INFECTION_TYPE;
           unit.getTag currentInfectionDamage Tag.CURRENT_INFECTION_DAMAGE;

--- a/Ruleset/scripts/scripts_intimidation_ability.rul
+++ b/Ruleset/scripts/scripts_intimidation_ability.rul
@@ -83,12 +83,14 @@ extended:
             set temp temp2; #calculate Morale overflow for negative values
             mul temp -1; #change from negative to positive
             #debug_log "Intimidation Scripts; damageUnit, offset 24: Morale overflow Stun damage dealt:" temp;
+            div temp 2; #divide stun damage in half; doing the full amount is too punishing
             add to_stun temp;
             unit.getHealth temp2; #calculate stun overflow
             sub temp2 temp;
             #debug_log "Intimidation Scripts; damageUnit, offset 24: Health minus Stun:" temp2;
             if lt temp2 0; #if stun overflows, do health damage
               mul temp2 -1;
+              div temp2 2; #divide health damage in half; doing the full amount is too punishing
               unit.getHealth temp;
               limit_upper temp2 temp; #cap health damage at current health; no disintegrations
               #debug_log "Intimidation Scripts; damageUnit, offset 24: Stun overflow Health damage dealt:" temp2;


### PR DESCRIPTION
1. Devotion now affords protection from Chaos corruption/infection at a rate of 1% resistance per 2 points of Devotion above 50.

2. Halved the stun and health damage the intimidate ability can inflict.

3. Added rapid morale recovery for manned turret armors.