### PR TITLE
Corruption/Infection Ufopedia Addition

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -2919,7 +2919,7 @@ en-US:
   STR_PROMOTE_BY_COMMENDATION_UFOPEDIA_2: "{NEWLINE}Firstborn Space Marine -> Terminator{NEWLINE}for \"Crux Terminatus\"{NEWLINE}
     {NEWLINE}Available Promotions depend on faction and strategy choice."
 
-  STR_EXTINGUISHING_MEDIKIT: "Medikits extinguish Fires"
+  STR_EXTINGUISHING_MEDIKIT: "Medikits Extinguish Fires"
   STR_EXTINGUISHING_MEDIKIT_UFOPEDIA: "{NEWLINE} When soldiers are on fire each medikit contains necessary foam agents and ointments. Using the heal button a medkit will turn out the fire instead of healing a fatal wound. Only then fatal woulds will be treated as usual."
 
   STR_OVERHEATING_WEAPONS: "Weapons and Overheat"
@@ -2927,11 +2927,15 @@ en-US:
     {NEWLINE}{NEWLINE}These weapons also run into the risk that they will blow up when their maximum heat level has surpassed. Once the heat indicators start flashing the weapon will explode over the next turns.
     {NEWLINE}{NEWLINE}Soldiers are smart enough to not reaction fire once the weapon has reached the maximum heat level."
 
-  STR_GRAV_DAMAGE_BONUS: "Gravition Damage increases with Size"
+  STR_GRAV_DAMAGE_BONUS: "Gravition Damage Scales With Armor"
   STR_GRAV_DAMAGE_BONUS_UFOPEDIA: "{NEWLINE}Graviton Weapons use the weight of the enemies to hurt them. This type of weapon gets an additional damage bonus which increases with the total armor (sum of front, left, right, rear and under) of the target."
 
-  STR_JETPACK_MECHANIC: "Jetpacks are limited"
-  STR_JETPACK_MECHANIC_UFOPEDIA: "Jetpacks need to be enabled before a unit can fly. Depending on the armor the jetpack will shutdown at the beginning of the new turn and can only be restarted once the cooldown has passed."
+  STR_JETPACK_MECHANIC: "Limited Flight Jetpacks"
+  STR_JETPACK_MECHANIC_UFOPEDIA: "{NEWLINE}Jetpacks need to be enabled before a unit can fly. Depending on the armor the jetpack will shutdown at the beginning of the new turn and can only be restarted once the cooldown has passed."
+
+  STR_CORRUPTION_MECHANICS: "Corruption and Infection"
+  STR_CORRUPTION_MECHANICS_UFOPEDIA: "{NEWLINE}Not content to merely take our lives, our foe seeks also to claim and subsume our very souls. Certain profaned weapons and sorcery can inflict corruption and infection, damning their victims to a fate worse than death. Without aid, they will weaken and eventually turn away from the Emperor's light to embrace our hated enemy, transformed into horrid abominations.
+    {NEWLINE}{NEWLINE}Fortunately our blessed Medicae is capable of purging these blights via the Heal function."
 
 
   STR_GUARDSM_KRIEG: "Guardsman (Krieg)"
@@ -4451,7 +4455,8 @@ en-US:
     {NEWLINE}{NEWLINE}- TheodorTemplar
     {NEWLINE}{NEWLINE}- noblebright
     {NEWLINE}{NEWLINE}- StarSquid
-    {NEWLINE}{NEWLINE}- ErraticDeviant, Voice Acting Scions"
+    {NEWLINE}{NEWLINE}- ErraticDeviant, Voice Acting Scions
+    {NEWLINE}{NEWLINE}- Surrealistik"
   STR_ROSIGMA_CONTRIBUTORS_UFOPAEDIA_3: "{NEWLINE}ROSIGMA Testers
     {NEWLINE}(in no particular order)
     {NEWLINE}{NEWLINE}- Chupey
@@ -4686,10 +4691,10 @@ en-US:
   STR_INTIMIDATION_NOTICE: "Unit has been intimidated!"
 
   STR_OGRYN_CARAPACE_BASIC: "Ogryn Carapace"
-  STR_OGRYN_CARAPACE_BASIC_UFOPAEDIA: "Basic carapace plating specifically built for an Ogryn's large abhuman frame. Low cost, sturdy and rugged, this compromises the standard issue armor for our Ogryn infantry."
+  STR_OGRYN_CARAPACE_BASIC_UFOPAEDIA: "{NEWLINE}Basic carapace plating specifically built for an Ogryn's large abhuman frame. Low cost, sturdy and rugged, this compromises the standard issue armor for our Ogryn infantry."
   STR_OGRYN_CARAPACE: "Ogryn Reinforced Carapace"
-  STR_OGRYN_CARAPACE_UFOPAEDIA: "Custom-made carapace armor that further increases the already impressive survivability of our Ogryn combatants. This benefits from additional plating and reinforcement (and weight) versus standard issue armoring."
+  STR_OGRYN_CARAPACE_UFOPAEDIA: "{NEWLINE}Custom-made carapace armor that further increases the already impressive survivability of our Ogryn combatants. This benefits from additional plating and reinforcement (and weight) versus standard issue armoring."
   STR_RIPPER_GUN_CLIP: "Ripper Gun Buckshot Drum"
-  STR_RIPPER_GUN_CLIP_UFOPAEDIA: "Standard high impact buckshot for the Ripper Gun. Brutally effective against light to medium armor with incredible stopping power."
+  STR_RIPPER_GUN_CLIP_UFOPAEDIA: "{NEWLINE}Standard high impact buckshot for the Ripper Gun. Brutally effective against light to medium armor with incredible stopping power."
   STR_RIPPER_GUN_CLIP_AP: "Ripper Gun Flechette Drum"
-  STR_RIPPER_GUN_CLIP_AP_UFOPAEDIA: "Specialized armor piercing flechettes for the Ogryn Ripper Gun. Intended to puncture and defeat heavy armor and ceramite, these costly rounds trade the legendary stopping power of Ripper Gun buckshot for better shot grouping and greatly improved armor penetration."
+  STR_RIPPER_GUN_CLIP_AP_UFOPAEDIA: "{NEWLINE}Specialized armor piercing flechettes for the Ogryn Ripper Gun. Intended to puncture and defeat heavy armor and ceramite, these costly rounds trade the legendary stopping power of Ripper Gun buckshot for better shot grouping and greatly improved armor penetration."

--- a/Ruleset/ALLFACTIONS/armors.rul
+++ b/Ruleset/ALLFACTIONS/armors.rul
@@ -195,3 +195,10 @@ armors:
     movementType: 1
     tags:
       INTIMIDATION_RESISTANCE: 100 #Reduces the effectiveness of Intimidate attacks by this percentage
+
+  - type: SERVITOR_ARMOR_UC #DR4
+    builtInWeapons:
+      - AUX_SERVITOR_KIT
+    tags:
+      INTIMIDATION_RESISTANCE: 50 #Reduces the effectiveness of Intimidate attacks by this percentage
+      INFECTION_RESIST: 50 #reduces infection damage by this as a %

--- a/Ruleset/ALLFACTIONS/items.rul
+++ b/Ruleset/ALLFACTIONS/items.rul
@@ -336,3 +336,46 @@ items:
       IgnoreOverKill: false #leave no trace; this is the end of days
     clipSize: 1
     defaultInventorySlot: STR_RIGHT_HAND
+
+  - type: AUX_SERVITOR_KIT      #AUX FOR SERVITOR UNIT MEDI KIT
+    #*** Melee
+    tags:
+      ITEM_REPAIRS_ARMOR: 1
+    confMelee:
+      name: STR_REPAIR
+    meleeSound: { mod: 40k, index: 698 }
+    meleeHitSound: { mod: 40k, index: 699 }
+    meleeAnimation: { mod: 40k, index: 32 }
+    meleeType: 0
+    meleePower: 60
+    accuracyMelee: 100
+    damageType: 0
+    meleeAlter: #REPAIR
+      RandomType: 3
+      ToHealth: 0.0
+      ToStun: 0.0
+      ToArmor: -1.0
+      ToWound: 0.0
+      RandomWound: false
+      RandomStun: false
+      ArmorEffectiveness: 0.0
+    costMelee:
+      time: 20
+      energy: 20
+
+  - type: STR_SERVITOR #UNIT                                    2100
+    bigSprite: { mod: 40k, index: 326 }
+    meleeHitSound: { mod: 40k, index: 100 }
+    meleeAnimation: { mod: 40k, index: 0 }
+    customItemPreviewIndex: { mod: 40k, index: 0 }
+    power: 60
+    damageType: 7
+    accuracyMelee: 80
+    battleType: 3
+    damageAlter:
+      RandomType: 1
+      ArmorEffectiveness: 0.9
+    flatRate: true
+    costMelee:
+      time: 15
+      energy: 1

--- a/Ruleset/ALLFACTIONS/ufopaedia_assistance.rul
+++ b/Ruleset/ALLFACTIONS/ufopaedia_assistance.rul
@@ -2,7 +2,7 @@ ufopaedia:
   - id: STR_PROMOTE_TO_SUPERIOR
     type_id: 10
     section: STR_HELP_ROSIGMA
-    image_id: SuperiorPromotion.SPK 
+    image_id: SuperiorPromotion.SPK
     text: STR_PROMOTE_TO_SUPERIOR_UFOPEDIA
     listOrder: 51200
     requires:
@@ -108,14 +108,14 @@ ufopaedia:
     image_id: 0ENFM.SPK
     text: STR_EXTINGUISHING_MEDIKIT_UFOPEDIA
     listOrder: 52918
-    
+
   - id: STR_HELP_ARMOR_ABILITIES
     type_id: 10
     section: STR_HELP_ROSIGMA
     image_id: 0ENFM.SPK #should use something else
     text: STR_ARMOR_ABILITIES
     listOrder: 52919
-    
+
   - id: STR_OVERHEATING_WEAPONS
     type_id: 10
     section: STR_HELP_ROSIGMA
@@ -136,3 +136,10 @@ ufopaedia:
     image_id: ELYSIAN.SPK
     text: STR_JETPACK_MECHANIC_UFOPEDIA
     listOrder: 52922
+
+  - id: STR_CORRUPTION_MECHANICS
+    type_id: 10
+    section: STR_HELP_ROSIGMA
+    image_id: NURGLEZOMBIE_CODEX_ORIGINS.SPK
+    text: STR_CORRUPTION_MECHANICS_UFOPEDIA
+    listOrder: 52923

--- a/Ruleset/ALLFACTIONS/units_turrets.rul
+++ b/Ruleset/ALLFACTIONS/units_turrets.rul
@@ -157,6 +157,7 @@ units:
       - - AUX_BOLTERPD
     specab: 1
 
+
   - type: STR_CHIMEDON_TURRET #Chimera Battlecannon variant
     refNode: *STR_TURRET_DEFAULT
     race: STR_CHIMEDON_TURRET #Add

--- a/Ruleset/ARBITES/armors_arbites.rul
+++ b/Ruleset/ARBITES/armors_arbites.rul
@@ -174,10 +174,10 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
 
-  - type: STR_ARBITOR_ARMOR_UC 
+  - type: STR_ARBITOR_ARMOR_UC
     refNode: *STR_ARMOR_JUDGE
 
-  - type: STR_MARSHAL_ARMOR_UC 
+  - type: STR_MARSHAL_ARMOR_UC
     refNode: *STR_ARMOR_JUDGE
     frontArmor: 90 # was 70
     sideArmor: 80 # was 60
@@ -227,6 +227,10 @@ armors:
     sideArmor: 160 # was 130
     rearArmor: 160 # was 130
     underArmor: 150
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
 
   - type: STR_CHIMERA_PDH_ARMOR # Manitcore
     visibilityAtDay: 40
@@ -238,6 +242,10 @@ armors:
     sideArmor: 160 # was 130
     rearArmor: 160 # was 130
     underArmor: 150
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
 
   - type: WHIRLWINDPD_ARMOR
     visibilityAtDay: 40
@@ -249,6 +257,10 @@ armors:
     sideArmor: 115 # was 85
     rearArmor: 100 # was 70
     underArmor: 100
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
 
   - type: DAMOCLESPD_ARMOR # Mobile Precint Artillery Turret
     visibilityAtDay: 40
@@ -260,6 +272,10 @@ armors:
     sideArmor: 115 # was 85
     rearArmor: 100 # was 70
     underArmor: 100
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
 
   - type: TAUROXPD_ARMOR # now same level as STR_TAUROX_TURRET_ARMOR
     visibilityAtDay: 40
@@ -271,6 +287,10 @@ armors:
     sideArmor: 130
     rearArmor: 130
     underArmor: 120
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
 
   - type: STR_GUARDPD_ARMOR_UC
     specialWeapon: STR_BAYONET

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -1924,9 +1924,10 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - type: STR_TAUROX_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1941,9 +1942,10 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - type: STR_TAUROS_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1957,9 +1959,10 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - type: STR_TAUROS_SMALL_TURRET_ARMOR
     visibilityAtDay: 40
@@ -1973,9 +1976,10 @@ armors:
     underArmor: 120
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - type: LEMONRUSS_ARMOR
     visibilityAtDay: 40
@@ -1989,9 +1993,10 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - type: LEMONRUSS_ARMORB
     visibilityAtDay: 40
@@ -2005,9 +2010,10 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - type: STR_EMPLACEMENT_ARMOR
     frontArmor: 160 # was 130
@@ -2016,9 +2022,10 @@ armors:
     underArmor: 150
     tags:
       INFECTION_RESIST: 100 #infection immune
-    recovery:
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
       morale:
-        flatHundred: 1
+        flatHundred: 0.5
 
   - &STR_CAS_ARMOR
     type: STR_CAS_MISSILE_POD_ARMOR
@@ -2373,6 +2380,7 @@ armors:
     allowsKneeling: false
     allowsRunning: false
     allowsMoving: false
+
     scripts:
       selectUnitSprite:
         var int temp;


### PR DESCRIPTION
1. Added information about Corruption/Infection mechanics to the Codex/Ufopedia under Rosigma help.

2. Manned turrets lose fear immunity in exchange for rapid Morale recovery.

3. Servitor kit tweaked; the repair functionality has been rolled into its medicae kit, and they have a crane based melee attack. Servitors now have 50% Infection and Intimidation resistance.