### PR TITLE
Intimidation Tweaks 2

### DIFF
--- a/Ruleset/ADEPTAS/armors_adeptas.rul
+++ b/Ruleset/ADEPTAS/armors_adeptas.rul
@@ -193,8 +193,11 @@ armors:
     allowInv: false
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
     painImmune: true
+    fearImmune: false #manned turrets are not fear immune; they just regenerate morale fast
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     spriteInv: NOTDONEIMP
     corpseGeo:  STR_PREDATOR_CORPSE
     corpseBattle:
@@ -281,7 +284,10 @@ armors:
     allowInv: false
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
+    fearImmune: false
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     painImmune: true
     allowsMoving: false
     corpseGeo:  STR_EXORCIST_CORPSE
@@ -312,7 +318,6 @@ armors:
     drawingRoutine: 3
     tags:
       INFECTION_RESIST: 100 #infection immune
-      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     scripts:
       selectUnitSprite:
         var int aiming;
@@ -355,8 +360,11 @@ armors:
     allowInv: false
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
     painImmune: true
+    fearImmune: false #manned turrets are not fear immune; they just regenerate morale fast
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     allowsMoving: false
     corpseGeo:  STR_DREAD_CORPSE
     corpseBattle:
@@ -386,7 +394,6 @@ armors:
     drawingRoutine: 3
     tags:
       INFECTION_RESIST: 100 #infection immune
-      INTIMIDATION_RESISTANCE: 100 #intimidate immune
     scripts:
       selectUnitSprite:
         var int temp;
@@ -428,8 +435,11 @@ armors:
     allowInv: false
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
     painImmune: true
+    fearImmune: false #manned turrets are not fear immune; they just regenerate morale fast
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     allowsMoving: false
     corpseGeo:  STR_DREAD_CORPSE #needs new?
     corpseBattle:

--- a/Ruleset/ENEMY/GENE/armors_gene.rul
+++ b/Ruleset/ENEMY/GENE/armors_gene.rul
@@ -1393,12 +1393,12 @@ armors:
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 20
-    fearImmune: true
     bleedImmune: true
     zombiImmune: true
+    fearImmune: false
     tags:
       INFECTION_RESIST: 100 #infection immune
-      INTIMIDATION_RESISTANCE: 100 #intimidate immune
+      INTIMIDATION_RESISTANCE: 50 #intimidate resistance
     painImmune: true
     allowInv: false
     spriteSheet: GSC_ARMORED_CAR_BS.PCK

--- a/Ruleset/ENEMY/ORK/armors_ORK.rul
+++ b/Ruleset/ENEMY/ORK/armors_ORK.rul
@@ -15,8 +15,11 @@ armors:
     allowInv: false
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
     painImmune: true
+    fearImmune: false
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 50 #intimidate resistance
     frontArmor: 130
     sideArmor: 130
     rearArmor: 130
@@ -35,20 +38,20 @@ armors:
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.2 #MELTA
-    tags:
-      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: ORK_TURRET2_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 20
     allowInv: false
     zombiImmune: true
+    bleedImmune: true
+    painImmune: true
+    fearImmune: false
     tags:
       INFECTION_RESIST: 100 #infection immune
-      INTIMIDATION_RESISTANCE: 100 #intimidate immune
-    bleedImmune: true
-    fearImmune: true
-    painImmune: true
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     frontArmor: 120
     sideArmor: 110
     rearArmor: 110
@@ -72,10 +75,15 @@ armors:
     visibilityAtDark: 20
     heatVision: 20 #tech
     spriteSheet: ORKDR5.PCK
-    fearImmune: true
     bleedImmune: true
     zombiImmune: true
     painImmune: true
+    fearImmune: false
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     allowInv: false
     spriteInv: ORK10.SPK
     corpseBattle:
@@ -266,10 +274,12 @@ armors:
     visibilityAtDark: 20
     spriteSheet: ORKBIKE.PCK
     allowInv: true #false?
-    fearImmune: true
     bleedImmune: true
     zombiImmune: true
     painImmune: true
+    fearImmune: false
+    tags:
+      INFECTION_RESIST: 100 #infection immune
     spriteInv: ORKBIKEINV.SPK
     corpseGeo: STR_ORK_BIKE_CORPSE
     stats:

--- a/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
+++ b/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
@@ -363,12 +363,14 @@ armors:
     antiCamouflageAtDark: 6
     heatVision: 30 #% of smoke that is ignored by superior sensors
     zombiImmune: true
+    bleedImmune: true
+    painImmune: true
+    fearImmune: false
     tags:
       INFECTION_RESIST: 100 #infection immune
-      INTIMIDATION_RESISTANCE: 100 #immune to intimidation
-    bleedImmune: true
-    fearImmune: true
-    painImmune: true
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     frontArmor: 130
     sideArmor: 130
     rearArmor: 130

--- a/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
@@ -339,7 +339,7 @@ armors:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 75
       ARMOR_ENERGY_SHIELD_DECAY: 50
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: 6
-      INFECTION_RESIST: 50
+      INFECTION_RESIST: 50 #infection resist
       INTIMIDATION_RESISTANCE: 50 #intimidate immune
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -512,7 +512,7 @@ armors:
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
     tags:
-      INFECTION_RESIST: 50 #infection immune
+      INFECTION_RESIST: 50 #infection resist
       INTIMIDATION_RESISTANCE: 50
 
   - type: STR_TZEENTCH_MUTANT_ARMOR
@@ -544,7 +544,7 @@ armors:
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
     tags:
-      INFECTION_RESIST: 50 #infection immune
+      INFECTION_RESIST: 50 #infection resist
 
   - type: STR_TZEENTCH_LESSER_DAEMON_ARMOR #Gleaming One Mr Crabby
     visibilityAtDay: 40
@@ -733,7 +733,7 @@ armors:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 66
       ARMOR_ENERGY_SHIELD_DECAY: 66
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: 6
-      INFECTION_RESIST: 50
+      INFECTION_RESIST: 50 #infection resist
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 10
@@ -771,7 +771,7 @@ armors:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 66
       ARMOR_ENERGY_SHIELD_DECAY: 66
       UNIT_IMMOBILIZED_UNTIL_MISSION_TIMER: 1
-      INFECTION_RESIST: 50
+      INFECTION_RESIST: 50 #infection resist
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 10

--- a/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/armors_tzeentch.rul
@@ -328,6 +328,7 @@ armors:
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
     tags:
+      INFECTION_RESIST: 100
       INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
   - type: MUTON_ARMORTZS                                          #TZEENTCH SORCER
@@ -338,6 +339,8 @@ armors:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 75
       ARMOR_ENERGY_SHIELD_DECAY: 50
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: 6
+      INFECTION_RESIST: 50
+      INTIMIDATION_RESISTANCE: 50 #intimidate immune
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 30
@@ -430,6 +433,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 50
     damageModifier: #CSERVITOR ARMOR
       - 1.0 #none
       - 0.8 #AP
@@ -463,6 +467,7 @@ armors:
     zombiImmune: true
     tags:
       INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 50
     damageModifier: #CSERVITOR ARMOR
       - 1.0 #none
       - 0.8 #AP
@@ -506,6 +511,9 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
+    tags:
+      INFECTION_RESIST: 50 #infection immune
+      INTIMIDATION_RESISTANCE: 50
 
   - type: STR_TZEENTCH_MUTANT_ARMOR
     visibilityAtDay: 40
@@ -535,6 +543,8 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 3 ]
+    tags:
+      INFECTION_RESIST: 50 #infection immune
 
   - type: STR_TZEENTCH_LESSER_DAEMON_ARMOR #Gleaming One Mr Crabby
     visibilityAtDay: 40
@@ -723,6 +733,7 @@ armors:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 66
       ARMOR_ENERGY_SHIELD_DECAY: 66
       ARMOR_GAINS_PSISKILL_SECONDARY_EXPERIENCE: 6
+      INFECTION_RESIST: 50
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 10
@@ -760,6 +771,7 @@ armors:
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: 66
       ARMOR_ENERGY_SHIELD_DECAY: 66
       UNIT_IMMOBILIZED_UNTIL_MISSION_TIMER: 1
+      INFECTION_RESIST: 50
     visibilityAtDay: 40
     visibilityAtDark: 25
     heatVision: 10

--- a/Ruleset/ENEMY/armors_chaos.rul
+++ b/Ruleset/ENEMY/armors_chaos.rul
@@ -218,6 +218,7 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
+
   - type: STR_MUTON_ARMOR1 #SORCER
     visibilityAtDay: 40
     visibilityAtDark: 25
@@ -243,6 +244,8 @@ armors:
       - 1.0 #IMPACT
       - 1.0 #MELTA
     loftempsSet: [ 4 ]
+    tags:
+      INFECTION_RESIST: 50 #infection resist
 
   - type: MUTON_ARMORHAVOC #HAVOC         UNDIVIDED
     visibilityAtDay: 40
@@ -1342,6 +1345,7 @@ armors:
     zombiImmune: true #Rubric Marines are dust
     tags:
       INFECTION_RESIST: 100 #Rubric Marines are dust
+      INTIMIDATION_RESISTANCE: 100  #Rubric Marines are dust
 
   - type: MUTON_ARMORHAVOCT #HAVOC                                #TZEENTCH
     painImmune: true #Rubric Marines are dust
@@ -1349,3 +1353,4 @@ armors:
     zombiImmune: true #Rubric Marines are dust
     tags:
       INFECTION_RESIST: 100 #Rubric Marines are dust
+      INTIMIDATION_RESISTANCE: 100  #Rubric Marines are dust

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -2349,11 +2349,13 @@ armors:
     allowInv: false
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
     painImmune: true
+    fearImmune: false
     tags:
       INFECTION_RESIST: 100 #infection immune
-      INTIMIDATION_RESISTANCE: 100 #intimidation immune
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     spriteInv: CHIMPD.SPK #doesnt show up
     corpseGeo:  STR_CHIMERA_TURRET_CORPSE
     corpseBattle:

--- a/Ruleset/SM/armors_SM.rul
+++ b/Ruleset/SM/armors_SM.rul
@@ -1405,7 +1405,7 @@ armors:
     spriteInv: KMARINE_INV
     fearImmune: true
     tags:
-      INTIMIDATION_RESISTANCE: 75 #intimidation resistant
+      INTIMIDATION_RESISTANCE: 100 #intimidation
     storeItem: STR_KHORNECHAMP_ARMOR_PLAYER
     customArmorPreviewIndex: 142 #needs custom
     spriteFaceGroup: 6

--- a/Ruleset/eldar.rul
+++ b/Ruleset/eldar.rul
@@ -568,8 +568,13 @@ armors:
     visibilityAtDark: 30
     antiCamouflageAtDay: 3
     antiCamouflageAtDark: 3
-    fearImmune: true
     bleedImmune: true
+    fearImmune: false
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     scripts:
       selectUnitSprite: |
         var int temp;
@@ -630,8 +635,13 @@ armors:
       INTIMIDATION_RESISTANCE: 100 #intimidate immune
     zombiImmune: true
     bleedImmune: true
-    fearImmune: true
     painImmune: true
+    fearImmune: false
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+    recovery: #Manned turrets recover morale rapidly
+      morale:
+        flatHundred: 0.5
     frontArmor: 130
     sideArmor: 130
     rearArmor: 130

--- a/Ruleset/scripts/scripts_intimidation_ability.rul
+++ b/Ruleset/scripts/scripts_intimidation_ability.rul
@@ -130,3 +130,45 @@ extended:
           battle_game.flashMessage "STR_INTIMIDATION_NOTICE";
 
           return;
+
+    #reactionUnitAction: #ignore fear immune targets with intimidate reactions
+    #  - new: ROSIGMA_rUA_intimidation
+    #    offset: 21
+    #    code: |
+    #      var int moraleMultiplier; #percent of damage the triggering attack inflicts
+    #      var int intimidateResist;
+    #      var ptr RuleArmor armorRule;
+    #      var ptr BattleItem intimidateWeapon;
+    #      var int temp;
+
+    #      action_unit.getRightHandWeapon intimidateWeapon;
+    #      intimidateWeapon.getTag moraleMultiplier Tag.INTIMIDATION_MORALE_DAMAGE_MULTIPLIER; #get morale damage multiplier
+
+    #      if le moraleMultiplier 0; #this is not an intimidate weapon; continue as normal
+    #        action_unit.getLeftHandWeapon intimidateWeapon;
+    #        intimidateWeapon.getTag moraleMultiplier Tag.INTIMIDATION_MORALE_DAMAGE_MULTIPLIER; #get morale damage multiplier
+    #        if le moraleMultiplier 0; #this is not an intimidate weapon; continue as normal
+    #          #debug_log "Intimidation Scripts; ROSIGMA_rUA_intimidation, offset 24: Aborting. Weapon has no intimidation parameters." moraleMultiplier;
+    #          return reaction_chance;
+    #        end;
+    #      end;
+
+    #      if le moraleMultiplier 0; #this is not an intimidate weapon; continue as normal
+    #        #debug_log "Intimidation Scripts; ROSIGMA_rUA_intimidation, offset 24: Aborting. Weapon has no intimidation parameters." moraleMultiplier;
+    #        return reaction_chance;
+    #      end;
+
+    #      action_unit.isFearable temp; #ignore fear immune with this reaction
+    #      if lt temp 1;
+    #        #debug_log "Intimidation Scripts; ROSIGMA_rUA_intimidation, offset 24: Aborting. Target is fear immune.";
+    #        return 0; #don't bother reacting to those immune to fear
+    #      end;
+
+    #      action_unit.getRuleArmor armorRule;
+    #      armorRule.getTag intimidateResist Tag.INTIMIDATION_RESISTANCE; #if our intimidation resist is 100% we're immune; abort
+    #      if ge intimidateResist 100;
+    #        #debug_log "Intimidation Scripts; ROSIGMA_rUA_intimidation, offset 24: Aborting. Target is intimidation immune.";
+    #        return 0; #don't bother reacting to those immune to fear
+    #      end;
+
+    #      return reaction_chance;

--- a/Ruleset/scripts/scripts_intimidation_ability.rul
+++ b/Ruleset/scripts/scripts_intimidation_ability.rul
@@ -25,6 +25,12 @@ extended:
             return;
           end;
 
+          unit.isFearable temp; #fear immune targets ignore this
+          if gt temp 0;
+            #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Target is fear immune.";
+            return;
+          end;
+
           unit.getFaction temp;
           attacker.getFaction temp2;
           if eq temp temp2;
@@ -71,6 +77,11 @@ extended:
           if le intimidateDamage 0; #if our net power is null or negative, abort.
             #debug_log "Intimidation Scripts; damageUnit, offset 24: Aborting. Null or negative morale damage:" temp;
             return;
+          end;
+
+          armorRule.getSize temp;
+          if eq temp 2; #divide damage to 2x2 by 4, because they get hit 4x as much.
+            muldiv intimidateDamage 25 100;
           end;
 
           #calculate target Morale; we bypass to_morale because high Bravery reduces damage too aggressively


### PR DESCRIPTION
1. Intimidation respects fear immunity; going forward we'll probably have to review what should and should not be fear immune (manned stuff like Sentinels should not be fear immune for example). I've adjusted a bunch of stat blocks on this basis thus far.

2. Intimidation after Bravery reductions is only 25% effective versus 2x2 due to hitting 4x.