### PR TITLE
Infection Damage Cap

### DIFF
--- a/Ruleset/ENEMY/items_spawner.rul
+++ b/Ruleset/ENEMY/items_spawner.rul
@@ -490,6 +490,7 @@ items:
       ToMana: 1.0
     battleType: 4
     blastRadius: 6
+    throwRange: 20 #capping range on the spawner grenades
     fuseTriggerEvents:
       throwExplode: true
     spawnUnit: STR_CELATID_TERRORIST
@@ -526,6 +527,7 @@ items:
       ToMana: 1.0
     battleType: 4
     blastRadius: 6
+    throwRange: 20 #capping range on the spawner grenades
     fuseTriggerEvents:
       throwExplode: true
     spawnUnit: STR_NURGLINGS

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -1859,7 +1859,7 @@ items:
     power: 60
     damageType: 2
     damageAlter: #DA BLIGHT
-      ArmorEffectiveness: 0.8
+      ArmorEffectiveness: 0.7
       ToArmorPre: 0.3
       ToArmor: 0.3
       ToHealth: 0.7
@@ -1876,7 +1876,7 @@ items:
     blastRadius: 3
     listOrder: 10352
     tags:
-      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
       INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
     specialChance: 5 #tiny chance of zombifying its victims
     zombieUnit: STR_NURGLE_ZOMBIE #generic placeholder
@@ -2223,7 +2223,7 @@ items:
     blastRadius: 4
     listOrder: 10353
     tags:
-      INFECTION_DAMAGE_PERCENT: 50 #inflicts % of damage dealt as infection damage
+      INFECTION_DAMAGE_PERCENT: 25 #inflicts % of damage dealt as infection damage
       INFECTION_TYPE: 1 #the type of infection. Thus far: 1: Nurgle, 2: GSC, 3: Slaanesh 4: Tzeentch
 
   - type: STR_LIGHT_BOLTER_AMMO_NURGLE

--- a/Ruleset/scripts/scripts_infection_mechanics.rul
+++ b/Ruleset/scripts/scripts_infection_mechanics.rul
@@ -274,6 +274,7 @@ extended:
           var int infectionType;
           var int infectionFaction;
           var int remainingHealth;
+          var int temp;
           var int INFECTION_LOW_THRESHOLD;
           var int INFECTION_MID_THRESHOLD;
           var int INFECTION_HIGH_THRESHOLD;
@@ -309,6 +310,9 @@ extended:
             unit.setTag Tag.CURRENT_INFECTION_TYPE 0; #untag
             return;
           end;
+
+          unit.getHealthMax temp;
+          limit_upper infectionDamage temp; #infection damage cannot exceed the victim's maximum health
 
           #debug_log "Infection Scripts; damageUnit, offset 23: Fatal Damage Incurred; Remaining Health:" remainingHealth;
           if eq infectionType 1; #if Nurgle
@@ -456,6 +460,10 @@ extended:
           end;
 
           #beyond this point it's assumed the victim has suffered lethal infection damage; time to transform it appropriately
+
+          unit.getHealthMax temp;
+          limit_upper infectionDamage temp; #infection damage cannot exceed the victim's maximum health
+
           set INFECTION_LOW_THRESHOLD 20;
           set INFECTION_MID_THRESHOLD 40;
           set INFECTION_HIGH_THRESHOLD 80;


### PR DESCRIPTION
1. Throw range for Nurgle spawner grenades capped at 20.

2. Reduced infection ratio on some Nurgle grenades.

3. Infection damage capped to a unit's maximum health; this generally means weaker units cannot spawn more powerful daemons when they succumb to infection/corruption.