### PR TITLE
Ogryn Armor Tweaks

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -1200,7 +1200,7 @@ en-US:
   STR_SNAZZY_SHOOTA_CODEX: "{NEWLINE} The Wealthy Bad Moons clan sares no expense on kitting out their snazzy shootas and kustom guns, providing moderately improved accuray fitting their taste for ranged firepower."
   STR_SNAZZY_SHOOTA_KOMBI_ROKKIT_CODEX: "{NEWLINE} The Bad Moons mekboyz are quite skilled at kustomizing their shootas, adding far more attachements than other klans. This particular version fits a rokkit, equivalent to smaller imperial missiles."
   STR_SNAZZY_SHOOTA_KOMBI_BLASTA_CODEX: "{NEWLINE} The Bad Moons are so wealthy that they can afford to fit kustom blastas to their shootas, capable of discharging something akin to a plasma blast at shorter ranges."
-  
+
   STR_ORK_DEATHSKULLS_EARLY: "Deathskulls Boyz"
   STR_ORK_DEATHSKULLS: "Deathskulls Orks"
   STR_ORK_EARLY: "Greenskins"
@@ -1215,7 +1215,7 @@ en-US:
   STR_ORK_WARBIKER_UFOPEDIA: "{NEWLINE}{NEWLINE} CODEX ARMOR DETAIL"
 
   STR_ORK_BADMOONS: "Bad Moons Orks" #race
-  
+
   STR_BADMOONS_ORK_BOYZ: "Bad Moons Boy"
   STR_ORK_ARMORL_BADMOONS_BOYZ: "Bad Moons Boy"
   STR_BADMOONS_ORK_BOY_CORPSE: "Bad Moons Ork Corpse"
@@ -1227,13 +1227,13 @@ en-US:
   STR_BADMOONS_ORK_BIGBOY_CORPSE: "Bad Moons Big 'Un Corpse"
   STR_BADMOONS_ORK_BIGBOY_ORIGINS_CODEX: "Bad Moons Ork Big 'Un Origins"
   STR_BADMOONS_ORK_BIGBOYZ_ORIGINS_UFOPEDIA: "{NEWLINE} Bad Moon Big 'Uns are bigger and burlier than their runtier kin, just short of a proper Nob, with wealth and equipment to match their size. Preferring to hang back and blast away with their big shootas and snazzguns they provide withering fire support."
-  
+
   STR_BADMOONS_ORK_NOBZ: "Bad Moons Nob"
   STR_BADMOONS_ORK_NOBZ_CORPSE: "Bad Moons Nobz Corpse"
   STR_ORK_ARMORH_BADMOONS_NOBZ: "Bad Moons Nob"
   STR_BADMOONS_ORK_NOBZ_ORIGINS_CODEX: "Bad Moons Nobz Origins"
   STR_BADMOONS_ORK_NOBZ_ORIGINS_UFOPEDIA: "{NEWLINE} Leaders of Bad Moon Mobs, the Nobz of Clan Bad Moon are some of the wealthiest Orks around, decked out in thick armor plating and snazzy kustom shootas they are surprisingly decent shots as far as Orks go."
-  
+
   STR_BURNABOYZ: "Burna Boy"  #ORKMOD
   STR_ORK_ARMOR_BURNA: "Burna Boyz"
   STR_ORKBURNABOY_CORPSE: "Burna Corpse" #ORKMOD
@@ -1315,7 +1315,7 @@ en-US:
   STR_ORK_TELEPORT_GUN: "Shokk Attakk Cannon"
   STR_TELEPORT_GUN_GRETCHIN: "Shokk Attack Ammo"
   STR_ORK_TELEPORT_GUN_CODEX: "{NEWLINE} A Shokk attakk Cannon is one of the most bizarre weapons ever crafted by a Mechanic . The Shokk attakk gun  opens a local warp portal and draws in an item near the mek, sometimes this item can be oiler grot , And teleports it inside the target causing massive damage to machinery and living flesh."
-  
+
   STR_GRETCHIN_AMMO_BIT: "Small Blasta Ammo Bit" # 40k 031 removed space
 
   STR_ORK_TANKBUSTAZ: "Tankbusta Boy" #ORKMOD
@@ -2142,7 +2142,7 @@ en-US:
   STR_DEATHSKULL_MEKBOY: "Deathskulls Big Mek"
   STR_ORK_ARMOR_DEATHSKULL_MEKBOY: "Deathskulls Big Mek"
   STR_ORKDEATHSKULL_MEKBOY_CORPSE: "Deathskulls Big Mek Corpse"
-  STR_DEATHSKULL_MEKBOY_ORIGINS_CODEX: "{NEWLINE} Meks play an integral part of Deathskull society, because it is they who build guns, tanks, and all other manner of wargear out of the bits and gubbins found on the battlefield by their less technologically inclined brethren. Deathskull Meks are proficient at constructing Kustom Kombi-weapons, due to the large amount of random weaponry they have a habit of ending up with." 
+  STR_DEATHSKULL_MEKBOY_ORIGINS_CODEX: "{NEWLINE} Meks play an integral part of Deathskull society, because it is they who build guns, tanks, and all other manner of wargear out of the bits and gubbins found on the battlefield by their less technologically inclined brethren. Deathskull Meks are proficient at constructing Kustom Kombi-weapons, due to the large amount of random weaponry they have a habit of ending up with."
   STR_ORK_ARMOR_MEKBOY: "Mek Boy"
   STR_ORKMEKBOY_CORPSE: "Mek Boy Corpse"
   STR_ORK_MEKBOYZ_UFOPEDIA: "{NEWLINE}{NEWLINE} CODEX ARMOR DETAIL"
@@ -4670,7 +4670,7 @@ en-US:
   AUX_STARCANNON: "Starcannon"
   STR_GRENADE_LAUNCHER_TAUROS_SMOKE: "Belt-Fed Grenade Launcher"
   STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER: "Heavy Stubber"
-  STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER_CODEX: "{NEWLINE} The Tauros is a lightweight multipurpose vehicle capable of being airdropped from a standard Valkyrie using magnetic clamps. Rather than using multifuel engines, the Tauros is equipped with a galvanic drive unit and can fit a number of weapons." 
+  STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER_CODEX: "{NEWLINE} The Tauros is a lightweight multipurpose vehicle capable of being airdropped from a standard Valkyrie using magnetic clamps. Rather than using multifuel engines, the Tauros is equipped with a galvanic drive unit and can fit a number of weapons."
   STR_IMMOLATOR_HEAVY_FLAMER: "Heavy Flamer"
   STR_MANTICORE_R: "Missile Launcher"
   STR_MANTICORE_L: "Missile Launcher"
@@ -4735,10 +4735,14 @@ en-US:
   STR_INTIMIDATION_NOTICE: "Unit has been intimidated!"
 
   STR_OGRYN_CARAPACE_BASIC: "Ogryn Carapace"
-  STR_OGRYN_CARAPACE_BASIC_UFOPAEDIA: "{NEWLINE}Basic carapace plating specifically built for an Ogryn's large abhuman frame. Low cost, sturdy and rugged, this compromises the standard issue armor for our Ogryn infantry."
+  STR_OGRYN_CARAPACE_BASIC_UFOPEDIA: "{NEWLINE}Basic carapace plating specifically built for an Ogryn's large abhuman frame. Low cost, sturdy and rugged, this compromises the standard issue armor for our Ogryn infantry."
   STR_OGRYN_CARAPACE: "Ogryn Reinforced Carapace"
-  STR_OGRYN_CARAPACE_UFOPAEDIA: "{NEWLINE}Custom-made carapace armor that further increases the already impressive survivability of our Ogryn combatants. This benefits from additional plating and reinforcement (and weight) versus standard issue armoring."
+  STR_OGRYN_CARAPACE_UFOPEDIA: "{NEWLINE}Custom-made carapace armor that further increases the already impressive survivability of our Ogryn combatants. This benefits from additional plating and reinforcement (and weight) versus standard issue armoring."
   STR_RIPPER_GUN_CLIP: "Ripper Gun Buckshot Drum"
-  STR_RIPPER_GUN_CLIP_UFOPAEDIA: "{NEWLINE}Standard high impact buckshot for the Ripper Gun. Brutally effective against light to medium armor with incredible stopping power."
+  STR_RIPPER_GUN_CLIP_UFOPEDIA: "{NEWLINE}Standard high impact buckshot for the Ripper Gun. Brutally effective against light to medium armor with incredible stopping power."
   STR_RIPPER_GUN_CLIP_AP: "Ripper Gun Flechette Drum"
-  STR_RIPPER_GUN_CLIP_AP_UFOPAEDIA: "{NEWLINE}Specialized armor piercing flechettes for the Ogryn Ripper Gun. Intended to puncture and defeat heavy armor and ceramite, these costly rounds trade the legendary stopping power of Ripper Gun buckshot for better shot grouping and greatly improved armor penetration."
+  STR_RIPPER_GUN_CLIP_AP_UFOPEDIA: "{NEWLINE}Specialized armor piercing flechettes for the Ogryn Ripper Gun. Intended to puncture and defeat heavy armor and ceramite, these costly rounds trade the legendary stopping power of Ripper Gun buckshot for better shot grouping and greatly improved armor penetration."
+
+  STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER: "Tauros Heavy Stubber"
+  STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER_UFOPEDIA: "{NEWLINE}The Tauros is a light, sturdily built, all-terrain utility and tractor vehicle used on many Imperial Frontier Worlds. Its rugged drive axles are individually powered by high-yield galvanic motors that allow the vehicle to maintain its speed and functionality even when heavily damaged.
+  {NEWLINE}This model is equipped with a heavy stubber mount for anti-infantry fire support."

--- a/Ruleset/ALLFACTIONS/items.rul
+++ b/Ruleset/ALLFACTIONS/items.rul
@@ -327,12 +327,12 @@ items:
     damageType: 3
     damageAlter:
       RandomType: 3
-      ToTile: 1 #obliterate the earth
+      ToTile: 2 #obliterate the earth
       ToArmorPre: 1 #annihilate the armor
       FireThreshold: 1 #incinerate the sea
       FixRadius: 200 #melt the map
       ToMorale: 5 #mash the mind
-      RadiusReduction: 5
+      RadiusReduction: 4.5
       IgnoreOverKill: false #leave no trace; this is the end of days
     clipSize: 1
     defaultInventorySlot: STR_RIGHT_HAND

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -1409,14 +1409,15 @@ armors:
     type: STR_BULLGRYN_SLAB
     refNode: *STR_GUARD_ARMOR_OGRYN_CARAPACE_DAMAGE
     frontArmor: 130
-    sideArmor: 70
+    sideArmor: 110
     rearArmor: 50
     underArmor: 50
-    weight: 25
+    weight: 30
     stats:
       tu: -5
       stamina: -15
       reactions: -5
+      melee: 5
 
 
   - &STR_GUARD_ARMOR_BULLGRYN_BUCKLER # DAMAGE + STATS

--- a/Ruleset/IG/ufopaedia_IG.rul
+++ b/Ruleset/IG/ufopaedia_IG.rul
@@ -1083,7 +1083,7 @@ ufopaedia:
     type_id: 15
     section: STR_ARMORPEDIA
     image_id: TAUROS.SPK
-    text: STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER_CODEX
+    text: STR_GUARD_ARMORS_TAUROS_HEAVY_STUBBER_UFOPEDIA
 #    requires:
 #        - STR_KRIEG_GUARDSMEN
     listOrder: 7860
@@ -1096,7 +1096,16 @@ ufopaedia:
     type_id: 15
     section: STR_ARMORPEDIA
     image_id: OGRYN_CARAPACE.SPK
-    text: STR_OGRYN_CARAPACE_BASIC_UFOPAEDIA
+    text: STR_OGRYN_CARAPACE_BASIC_UFOPEDIA
+    listOrder: 7600
+
+  - id: STR_OGRYN_CARAPACE
+    requires:
+      - STR_OGRYN_REQUISITION
+    type_id: 15
+    section: STR_ARMORPEDIA
+    image_id: OGRYN_CARAPACE.SPK
+    text: STR_OGRYN_CARAPACE_UFOPEDIA
     listOrder: 7600
 
   - id: STR_RIPPER_GUN
@@ -1105,7 +1114,7 @@ ufopaedia:
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: RIPPER_GUN.SPK
-    text: STR_RIPPER_GUN_UFOPAEDIA
+    text: STR_RIPPER_GUN_UFOPEDIA
     listOrder: 10780
 
   - id: STR_RIPPER_GUN_CLIP
@@ -1114,7 +1123,7 @@ ufopaedia:
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: RIPPER_GUN.SPK
-    text: STR_RIPPER_GUN_CLIP_UFOPAEDIA
+    text: STR_RIPPER_GUN_CLIP_UFOPEDIA
     listOrder: 10780
 
   - id: STR_RIPPER_GUN_CLIP_AP
@@ -1124,5 +1133,5 @@ ufopaedia:
     type_id: 14
     section: STR_WEAPONS_AND_EQUIPMENT
     image_id: RIPPER_GUN.SPK
-    text: STR_RIPPER_GUN_CLIP_AP_UFOPAEDIA
+    text: STR_RIPPER_GUN_CLIP_AP_UFOPEDIA
     listOrder: 10780


### PR DESCRIPTION
1. Fixes white spaces.

2. Normalizes some UFOPAEDIA titled entries to UFOPEDIA.

3. Fixes side armor for Ogryn Bulgryn Slab armor to be at an appropriate value (110 up from 70).

4. Fixes Reinforced Ogryn Carapace armor description.

5. Fixes explosion falloff for Orbital Strike (fix of opportunity).