### PR TITLE
Bomberman Deathbomb Fix 2.0

### DIFF
--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -2440,7 +2440,7 @@ items:
     power: 100
     blastRadius: 7
     damageType: 8
-    invWidth: 3
+    invWidth: 2
     invHeight: 3
     damageAlter: ## Plague-inflicting weapon
       RandomType: 2 #TFTD [50% - 150%]
@@ -2453,9 +2453,6 @@ items:
     recover: false
     tuThrow: 999 #only to be thrown via scripts
     tuUnprime: 999 #not meant to be unprimed
-    supportedInventorySections:
-      - STR_GROUND
-      - STR_BACK_PACK
     tuPrime: 999 #only to be thrown via scripts
     throwRange: 1 #not meant to be thrown
     fixedWeapon: false #has to be false so kamikazi tag and scripts work properly
@@ -2463,7 +2460,7 @@ items:
     hiddenOnMinimap: true
     defaultInventorySlot: STR_BACK_PACK
     spawnUnit: STR_NURGLINGS
-    spawnUnitFaction: -1
+    spawnUnitFaction: 1
     tags:
       ITEM_IS_BOMB: 1
       ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death
@@ -3050,6 +3047,8 @@ items:
     hitAnimation: 2160 #WarpBurn
     explosionHitSound: {mod: 40k, index: 771}
     hitSound: {mod: 40k, index: 788}
+    invWidth: 2
+    invHeight: 3
     power: 25
     damageType: 2
     damageAlter:
@@ -3059,8 +3058,11 @@ items:
       FixRadius: 4
       ToHealth: 0.1
       ToTime: 0.5
+      ToWound: 0.0
+      RandomWound: false
+      ToMana: 2.0
       ToEnergy: 2.0
-      ToMorale: 6.0
+      ToMorale: 10.0
       ArmorEffectiveness: 0.5
     battleType: 4 # grenade
     recover: false
@@ -3071,9 +3073,9 @@ items:
     fixedWeapon: false #has to be false so kamikazi tag and scripts work properly
     isExplodingInHands: true
     hiddenOnMinimap: true
-    defaultInventorySlot: STR_BELT
+    defaultInventorySlot: STR_BACK_PACK
     spawnUnit: STR_BLUE_HORROR_TERRORIST
-    spawnUnitFaction: -1
+    spawnUnitFaction: 1
     tags:
       ITEM_IS_BOMB: 1
       ITEM_IS_BOMB_ON_DEATH: 1 #we blow this bomb up on death

--- a/Ruleset/scripts/scripts_bomberman.rul
+++ b/Ruleset/scripts/scripts_bomberman.rul
@@ -131,7 +131,7 @@ extended:
               else;
                 sub temp 1;
               end;
-              someItem.InventoryMoveCost.setBaseTimePercent 999;
+              #someItem.InventoryMoveCost.setBaseTimePercent 999;
               someItem.setFuseTimer temp;
               someItem.setFuseEnabled 1;
               #debug_log "Bomberman Scripts; damageUnit, offset 24: Successful. Bomb Triggered. Bomb Item:" someItem;


### PR DESCRIPTION
1. Suicide spawner bombs no longer spawn friendly units.