### PR TITLE
Fixes Plasma Generators to be Infection Proof; Tweaks to Nurgle Spawners

### DIFF
--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -1,4 +1,11 @@
-﻿units:
+﻿extended:
+  tags:
+    RuleArmor:
+      INFECTION_RESIST: int #reduces infection damage by this as a %
+      INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
+      INFECTION_RESIST_TYPE: int #bitmask; type of infection the unit resists. 0 = All, 1 = Nurgle, 2 = GSC, 4 = Slaanesh; 3 = Nurgle + GSC, 5 = Nurgle + Slaanesh, 6 = GSC + Slaanesh
+
+units:
   - delete: STR_TANK_CANNON
   - delete: STR_HOVERTANK_PLASMA
   - delete: STR_HOVERTANK_LAUNCHER
@@ -9039,5 +9046,40 @@ manufacture:
 #---------------------------------------------------------- CHAOS ARMOR --------------------------------
 
 #--------------------------------------------------------------- ARMOR --------------------------------
+armors:
+  - type: GENERATOR_ARMOR #TARGET
+    spriteSheet: GENERATOR.PCK
+    spriteInv: NOTDONEIMP
+    allowInv: false
+    zombiImmune: true
+    bleedImmune: true
+    fearImmune: true
+    painImmune: true
+    corpseBattle:
+      - STR_GENERATOR_CORPSE
+    frontArmor: 50
+    sideArmor: 50
+    rearArmor: 50
+    underArmor: 50
+    size: 1
+    damageModifier: #TARGET ARMOR
+      - 1.0 #none
+      - 1.0 #AP
+      - 1.0 #FLAMES
+      - 1.0 #HE
+      - 1.0 #LASCANON
+      - 1.0 #PLASMA
+      - 0.0 #STUN
+      - 1.0 #MELEE
+      - 1.0 #ACID
+      - 0.0 #SMOKE
+      - 1.0 #IMPACT
+      - 1.0 #MELTA
+    loftempsSet: [ 3 ]
+    drawingRoutine: 16
+    constantAnimation: true
+    tags:
+      INFECTION_RESIST: 100 #infection immune
+      INTIMIDATION_RESISTANCE: 100 #intimidate immune
 
 #--------------------------------------------------------------- CRAFT --------------------------------

--- a/Ruleset/ENEMY/items_spawner.rul
+++ b/Ruleset/ENEMY/items_spawner.rul
@@ -486,6 +486,7 @@ items:
       ArmorEffectiveness: 0.7
       ToMorale: 0.7
       ToStun: 0.7
+      ToHealth: 0.5
       ToEnergy: 1.0
       ToMana: 1.0
     battleType: 4
@@ -523,6 +524,7 @@ items:
       ArmorEffectiveness: 0.7
       ToMorale: 0.7
       ToStun: 0.7
+      ToHealth: 0.5
       ToEnergy: 1.0
       ToMana: 1.0
     battleType: 4


### PR DESCRIPTION
1. Surface base generators are now immune to infection and intimidation.

2. Nurgle unit spawner grenades now have proper reductions to their health damage.