### PR TITLE
Adeptas Meltalance Sentinel Improved

### DIFF
--- a/Ruleset/ADEPTAS/armors_adeptas.rul
+++ b/Ruleset/ADEPTAS/armors_adeptas.rul
@@ -28,10 +28,10 @@ armors:
       - ADEPTAS_SENTINEL_CORPSE2
       - ADEPTAS_SENTINEL_CORPSE3
       - ADEPTAS_SENTINEL_CORPSE4
-    frontArmor: 135 #extra adeptas front armor
-    sideArmor: 120 #extra adeptas front armor
+    frontArmor: 140 #extra adeptas front armor
+    sideArmor: 130 #extra adeptas front armor
     rearArmor: 70 #weaker rear armor
-    underArmor: 180 #drop pod proof
+    underArmor: 140 #drop pod proof
     size: 2
     moveSound: {mod: 40k, index: 700}
     stats:
@@ -93,7 +93,7 @@ armors:
     frontArmor: 130 #reinforce front
     sideArmor: 120 #reinforced front
     rearArmor: 60 #glas back
-    underArmor: 180 #Drop Pod proof
+    underArmor: 130 #Drop Pod proof
     size: 2
     weight: -15
     moveSound: {mod: 40k, index: 700}

--- a/Ruleset/BALANCE/melta.rul
+++ b/Ruleset/BALANCE/melta.rul
@@ -127,27 +127,26 @@ items:
     powerRangeReduction: 0.5
     powerRangeThreshold: 16.0
 
-  - type: STR_SENTINEL_MELTALANCE # done
+  - type: STR_SENTINEL_MELTALANCE # basically a super conversion beamer
     dropoff: 6 # + 1 for lance
     autoRange: 0
-    snapRange: 8 # / 3 for lance
-    aimRange: 11 # / 3 for lance
+    snapRange: 15 # / 3 for lance
+    aimRange: 20 # / 3 for lance
 
     accuracyAuto: 0
     accuracySnap: 80
     accuracyAimed: 100
 
     tuAuto: 0
-    tuSnap: 33
-    tuAimed: 60
+    tuSnap: 30
+    tuAimed: 55
 
-    maxRange: 20
+    maxRange: 30
     minRange: 5
-
-    power: 150
+    power: 180
     damageType: 11
     damageAlter: #DA MELTA LANCE BEAMER
-      RandomType: 7
+      RandomType: 6 #gaussian
       ToArmorPre: 1.0
       ToHealth: 1.0
       ToTile: 6.0
@@ -155,4 +154,4 @@ items:
       RandomWound: false
       TileDamageMethod: 2
     powerRangeReduction: 10
-    powerRangeThreshold: 12.0
+    powerRangeThreshold: 16.0


### PR DESCRIPTION
1. Slightly improved armor of Meltalance Sentinel.
2. Significantly improved range of Meltalance Sentinel to 15 Snap, 20 Aimed; meant to be a longer range, vehicle mounted Conversion Beamer Melta.
3. Slightly decreased TU cost of Snap from 33% to 30% and Aimed from 60% to 55%.
4. Meltalance has Gaussian damage variance; increased base damage 150 to 180.