### PR TITLE
Adeptas Ammo Compatibility

### DIFF
--- a/Ruleset/ADEPTAS/weapons_adeptas.rul
+++ b/Ruleset/ADEPTAS/weapons_adeptas.rul
@@ -416,12 +416,13 @@ items:
       - STR_LIGHT_BOLTER_AMMO
       - STR_LIGHT_BOLTER_AMMO_MC
       - STR_LIGHT_BOLTER_AMMO_INF
+      - STR_LIGHT_BOLTER_AMMO_AP
       - STR_LIGHT_BOLTER_AMMO_PEN
       - STR_LIGHT_BOLTER_AMMO_EX
       - STR_LIGHT_FLAMETHROWER_CLIP
     ammo:
      0:
-      compatibleAmmo: [STR_LIGHT_BOLTER_AMMO, STR_LIGHT_BOLTER_AMMO_MC, STR_LIGHT_BOLTER_AMMO_INF, STR_LIGHT_BOLTER_AMMO_PEN, STR_LIGHT_BOLTER_AMMO_EX]
+      compatibleAmmo: [STR_LIGHT_BOLTER_AMMO, STR_LIGHT_BOLTER_AMMO_MC, STR_LIGHT_BOLTER_AMMO_INF, STR_LIGHT_BOLTER_AMMO_AP, STR_LIGHT_BOLTER_AMMO_PEN, STR_LIGHT_BOLTER_AMMO_EX]
      1:
       compatibleAmmo: [STR_LIGHT_FLAMETHROWER_CLIP]
 
@@ -458,6 +459,7 @@ items:
     armor: 300
     attraction: 7
     listOrder: 10495
+
   - type: STR_HAND_FLAMETHROWER_CLIP ## Handflamer fuel tank
     categories: [STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.1
@@ -573,8 +575,8 @@ items:
     requiresBuy:
      - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
      - STR_BOLTER_HELLSPITE
-    costBuy: 6000
-    costSell: 2500
+    costBuy: 1500
+    costSell: 500
     bigSprite: 2056
     floorSprite: 2061
     handSprite: { mod: 40k, index: 336 } #Needs new

--- a/Ruleset/ADEPTAS/weapons_adeptas.rul
+++ b/Ruleset/ADEPTAS/weapons_adeptas.rul
@@ -17,6 +17,7 @@ extended:
 
 items:
   - type: STR_SACRESANT_SHIELD
+    categories: [STR_CAT_MELEE, STR_CAT_BOLTER, STR_CAT_ADEPTAS]
     weight: 20
     invWidth: 2
     invHeight: 3
@@ -27,6 +28,8 @@ items:
     compatibleAmmo:
       - STR_LIGHT_BOLTPISTOL_AMMO
       - STR_LIGHT_BOLTPISTOL_AMMO_MC
+      - STR_LIGHT_BOLTPISTOL_AMMO_AP
+      - STR_LIGHT_BOLTPISTOL_AMMO_EX
       - STR_LIGHT_BOLTPISTOL_PENITENCE_AMMO
     battleType: 1
     dropoff: 6
@@ -63,7 +66,7 @@ items:
     defaultInventorySlot: STR_LEFT_HAND
 
   - type: STR_AUTOGUN_ADEPTAS
-    categories: [STR_CAT_AUTO]
+    categories: [STR_CAT_AUTO, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_ADEPTAS
     size: 0.2
@@ -118,7 +121,7 @@ items:
       time: true
 
   - type: STR_AUTOGUN_ADEPTAS_SCOPED
-    categories: [STR_CAT_AUTO]
+    categories: [STR_CAT_AUTO, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_ADEPTAS
     size: 0.2
@@ -158,6 +161,7 @@ items:
     listOrder: 10741
 
   - type: STR_SENTINEL_MELTALANCE
+    categories: [STR_CAT_MELTA, STR_CAT_ADEPTAS]
     weight: 0
     vaporColorSurface: {mod: 40k, index: 2}
     vaporDensitySurface: 6
@@ -178,6 +182,7 @@ items:
     recover: false
 
   - type: STR_ADEPTAS_SENTINEL_HBOLTER
+    categories: [STR_CAT_BOLTER, STR_CAT_ADEPTAS]
     #requires:
       #- STR_FAITHFUL_ARMORY  #commented out, unecessary and interferes with normal adeptas start.
     weight: 0
@@ -196,7 +201,7 @@ items:
     clipSize: 400 # required for ROSIGMA.zip
 
   - type: STR_CHOIR_GUN # Adeptas Hymn Choir Weapon Projector    11790
-    categories: [STR_CAT_PLASMA]
+    categories: [STR_CAT_PLASMA, STR_CAT_ADEPTAS]
     size: 0.3
     costSell: 33000
     weight: 35
@@ -217,7 +222,7 @@ items:
     listOrder: 11790
 
   - type: STR_NEURAL_WHIP           #12600           DA POWER
-    categories: [STR_CAT_MELEE]
+    categories: [STR_CAT_MELEE, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -322,7 +327,7 @@ items:
       ITEM_DOESNT_HURT_USER: 1
 
   - type: STR_BOLTPISTOL_SERAPHIM
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS_ARMORS
@@ -349,7 +354,7 @@ items:
     listOrder: 10090
 
   - type: STR_LIGHT_BOLTPISTOL_SERAPHIM_AMMO
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS_ARMORS
@@ -372,7 +377,7 @@ items:
 
 
   - type: STR_LIGHT_BOLTPISTOL_PENITENCE_AMMO
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS_ARMORS
@@ -394,7 +399,7 @@ items:
     clipSize: 15
 
   - type: STR_BOLTER_MEPHISTO #SoB Adeptas Mephisto Underslung Grenade launcher kombi bolter ROSEMOD
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.3
     requiresBuy:
       - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
@@ -411,10 +416,12 @@ items:
       - STR_LIGHT_BOLTER_AMMO
       - STR_LIGHT_BOLTER_AMMO_MC
       - STR_LIGHT_BOLTER_AMMO_INF
+      - STR_LIGHT_BOLTER_AMMO_PEN
+      - STR_LIGHT_BOLTER_AMMO_EX
       - STR_LIGHT_FLAMETHROWER_CLIP
     ammo:
      0:
-      compatibleAmmo: [STR_LIGHT_BOLTER_AMMO, STR_LIGHT_BOLTER_AMMO_MC, STR_LIGHT_BOLTER_AMMO_INF]
+      compatibleAmmo: [STR_LIGHT_BOLTER_AMMO, STR_LIGHT_BOLTER_AMMO_MC, STR_LIGHT_BOLTER_AMMO_INF, STR_LIGHT_BOLTER_AMMO_PEN, STR_LIGHT_BOLTER_AMMO_EX]
      1:
       compatibleAmmo: [STR_LIGHT_FLAMETHROWER_CLIP]
 
@@ -429,7 +436,7 @@ items:
     listOrder: 10328
 
   - type: STR_HAND_FLAMETHROWER
-    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL]
+    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.15
     requiresBuy:
      - STR_HAND_FLAMETHROWER_REQUISITION
@@ -452,7 +459,7 @@ items:
     attraction: 7
     listOrder: 10495
   - type: STR_HAND_FLAMETHROWER_CLIP ## Handflamer fuel tank
-    categories: [STR_CAT_FLAMER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
      - STR_ADEPTAS
@@ -477,7 +484,7 @@ items:
     listOrder: 10496
 
   - type: STR_LIGHT_FLAMETHROWER_CLIP # MEPHISTO FLAMER                     10520
-    categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_FLAMER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.2
     requiresBuy:
      - STR_LIGHT_FLAMETHROWER_CLIP
@@ -502,7 +509,7 @@ items:
     listOrder: 10329
 
   - type: STR_BOLTER_HELLSPITE #SoB Adeptas Hellspite Underslung Grenade launcher kombi bolter ROSEMOD
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.3
     requiresBuy:
       - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
@@ -519,15 +526,18 @@ items:
       - STR_LIGHT_BOLTER_AMMO
       - STR_LIGHT_BOLTER_AMMO_MC
       - STR_LIGHT_BOLTER_AMMO_INF
+      - STR_LIGHT_BOLTER_AMMO_AP
+      - STR_LIGHT_BOLTER_AMMO_PEN
+      - STR_LIGHT_BOLTER_AMMO_EX
       - STR_INCENDIARY_GRENADE40
       - STR_PENITENCE_GRENADE40
       - STR_KRAK_GRENADE40
       - STR_MELTA_GRENADE40
     ammo:
-     0:
-      compatibleAmmo: [STR_LIGHT_BOLTER_AMMO, STR_LIGHT_BOLTER_AMMO_MC, STR_LIGHT_BOLTER_AMMO_INF]
-     1:
-      compatibleAmmo: [STR_INCENDIARY_GRENADE40, STR_PENITENCE_GRENADE40, STR_KRAK_GRENADE40, STR_MELTA_GRENADE40]
+      0:
+        compatibleAmmo: [STR_LIGHT_BOLTER_AMMO, STR_LIGHT_BOLTER_AMMO_MC, STR_LIGHT_BOLTER_AMMO_INF, STR_LIGHT_BOLTER_AMMO_AP, STR_LIGHT_BOLTER_AMMO_PEN, STR_LIGHT_BOLTER_AMMO_EX]
+      1:
+        compatibleAmmo: [STR_INCENDIARY_GRENADE40, STR_PENITENCE_GRENADE40, STR_KRAK_GRENADE40, STR_MELTA_GRENADE40]
     battleType: 1
     twoHanded: true
     oneHandedPenalty: 80
@@ -557,7 +567,7 @@ items:
     listOrder: 10331
 
   - type: STR_PENITENCE_GRENADE40 #Hellspite underslung grenade
-    categories: [ STR_CAT_GRENADES, STR_CAT_ADEPTAS]
+    categories: [STR_CAT_GRENADES, STR_CAT_ADEPTAS]
     size: 0.1
     weight: 3
     requiresBuy:
@@ -593,7 +603,7 @@ items:
     listOrder: 10331
 
   - type: STR_BOLTER_ELOHIM
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS
@@ -612,7 +622,8 @@ items:
       - STR_LIGHT_BOLTER_AMMO_MC
       - STR_LIGHT_BOLTER_AMMO_AP
       - STR_LIGHT_BOLTER_AMMO_INF
-      - STR_RIFLE_CLIP_AP
+      - STR_LIGHT_BOLTER_AMMO_PEN
+      - STR_LIGHT_BOLTER_AMMO_EX
     battleType: 1
     twoHanded: true
     invWidth: 2
@@ -641,7 +652,7 @@ items:
       time: true
 
   - type: STR_SNIPER_ARCHE #Adeptas Sniper
-    categories: [STR_CAT_BOLTER, STR_CAT_SNIPER]
+    categories: [STR_CAT_BOLTER, STR_CAT_SNIPER, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_ADEPTAS
       - STR_FAITHFUL_ARMORY
@@ -657,6 +668,8 @@ items:
     compatibleAmmo:
       - STR_LIGHT_BOLTER_AMMO_AP
       - STR_LIGHT_BOLTER_AMMO_INF
+      - STR_LIGHT_BOLTER_AMMO_PEN
+      - STR_LIGHT_BOLTER_AMMO_EX
       - STR_HC_HE_AMMO
       - STR_HC_I_AMMO
     battleType: 1
@@ -701,7 +714,7 @@ items:
     listOrder: 13100
 
   - type: STR_BOLTER_CANTUS #SoB Novice trainee pattern, lighter, cheaper and easier to use. Not as good as DEAZ otherwise.
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_TRAINING_BOLTERS_ADEPTAS
     size: 0.3
@@ -742,7 +755,7 @@ items:
       time: true
 
   - type: STR_LIGHT_BOLTER_AMMO_AP #Elohim ammo
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS
@@ -765,12 +778,12 @@ items:
     clipSize: 15
 
   - type: STR_CANTUS_BOLTER_AMMO #Ammo for the Cantus light bolter
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_TRAINING_BOLTERS_ADEPTAS
     size: 0.1
     costBuy: 250
-    costSell: 125
+    costSell: 100
     weight: 2
     bigSprite: {mod: 40k, index: 2}
     floorSprite: {mod: 40k, index: 2}
@@ -785,7 +798,7 @@ items:
     listOrder: 10287
 
   - type: STR_LIGHT_BOLTER_AMMO_INF #         10430     INFERNO FLAME        ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_LOWTIER_ADEPTAS
       - STR_ADEPTAS
@@ -805,7 +818,7 @@ items:
     listOrder: 10298
 
   - type: STR_ADEPTAS_BOLTGUN_JOVE
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS_MIDTIER_ADEPTAS
       - STR_FAITHFUL_ARMORY
@@ -837,7 +850,7 @@ items:
 
 
   - type: STR_BOLTER_DOMINION #BOLTER DOMINION PATTERN 10320           AIMED
-    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     requiresBuy:
      - STR_ADEPTAS
      - STR_UFO_CONSTRUCTION #WAS STR_ADEPTAS_HIGHTIER
@@ -852,6 +865,7 @@ items:
       - STR_RIFLE_CLIP
       - STR_RIFLE_CLIP_MC
       - STR_RIFLE_CLIP_AP
+      - STR_RIFLE_CLIP_EX
       - STR_RIFLE_CLIP_DOM
     battleType: 1
     twoHanded: true
@@ -877,7 +891,7 @@ items:
     flatMelee:
       time: true
   - type: STR_RIFLE_CLIP_DOM # Dominion special rounds DETONATOR       10430     EXPLOSIVE        ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL]
+    categories: [STR_CAT_BOLTER, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
      - STR_ADEPTAS
@@ -895,7 +909,7 @@ items:
     listOrder: 10430
 
   - type: STR_DOMINION_HALBERD #              3008           DA POWER
-    categories: [STR_CAT_MELEE]
+    categories: [STR_CAT_MELEE, STR_CAT_ADEPTAS]
     requiresBuy:
      - STR_DOMINION_HALBERD
      - STR_ADEPTAS_MIDTIER
@@ -935,7 +949,7 @@ items:
     strengthApplied: false
     listOrder: 13400
   - type: STR_ADEPTAS_POWER_AXE #         3009           DA POWER
-    categories: [STR_CAT_MELEE]
+    categories: [STR_CAT_MELEE, STR_CAT_ADEPTAS]
     size: 0.2
     costSell: 12000
     weight: 30
@@ -971,7 +985,7 @@ items:
     attraction: 8
     listOrder: 15200
   - type: STR_ADEPTAS_ZWEIHANDER #              3008           DA POWER
-    categories: [STR_CAT_MELEE]
+    categories: [STR_CAT_MELEE, STR_CAT_ADEPTAS]
     size: 0.3
     costSell: 50000
     weight: 55
@@ -1103,7 +1117,7 @@ items:
   - type: STR_REDEEMER_SHELLS_INC #                       10612
     requiresBuy:
       - STR_ADEPTAS
-    categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT]
+    categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT, STR_CAT_ADEPTAS]
     size: 0.2
     costBuy: 500
     costSell: 250
@@ -1124,7 +1138,7 @@ items:
   - type: STR_REDEEMER_PENITENCE_SHELLS #                        10613
     requiresBuy:
       - STR_ADEPTAS
-    categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT]
+    categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT, STR_CAT_ADEPTAS]
     size: 0.1
     costBuy: 1000
     costSell: 200
@@ -1140,7 +1154,7 @@ items:
     listOrder: 10715
 
   - type: STR_AUTO_CANNON_RETRIBUTOR                      #SoB Adeptas Retributor Pattern ROSEMOD
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_ADEPTAS]
     size: 0.3
     requiresBuy:
       - STR_ADEPTAS
@@ -1169,7 +1183,7 @@ items:
     attraction: 8
     listOrder: 10525
   - type: STR_AUTO_CANNON_RETRIBUTOR_2                      #SoB Adeptas Retributor Pattern Mk II ROSEMOD
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_ADEPTAS]
     size: 0.3
     requiresBuy:
       - STR_ADEPTAS
@@ -1198,7 +1212,7 @@ items:
     attraction: 8
     listOrder: 10527
   - type: STR_AUTO_CANNON_POTESTAS #SoB Adeptas Potestas kombi bolter ROSEMOD
-    categories: [STR_CAT_BOLTER, STR_CAT_MELTA]
+    categories: [STR_CAT_BOLTER, STR_CAT_MELTA, STR_CAT_ADEPTAS]
     size: 0.3
     requiresBuy:
       - STR_AUTO_CANNON_POTESTAS
@@ -1233,7 +1247,7 @@ items:
     listOrder: 10527
 
   - type: STR_AC_AP_ADEPTAS_AMMO #HEAVYBOLTER adeptas ap belt                 12010                           ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -1252,7 +1266,7 @@ items:
     hitAnimation: {mod: xcom1, index: 26}
 
   - type: STR_AC_INC_ADEPTAS_AMMO #HEAVYBOLTER adeptas inc belt                 12010                           ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -1269,7 +1283,7 @@ items:
     invHeight: 1
     listOrder: 10526
   - type: STR_AC_HE_ADEPTAS_AMMO #HEAVYBOLTER adeptas HE belt                 12010                           ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -1287,7 +1301,7 @@ items:
     invHeight: 1
     listOrder: 10526
   - type: STR_AC_AP_ADEPTAS_BOXAMMO #HEAVYBOLTER adeptas ap belt                 12010                           ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -1305,7 +1319,7 @@ items:
     listOrder: 10528
     hitAnimation: {mod: xcom1, index: 26}
   - type: STR_AC_INC_ADEPTAS_BOXAMMO #HEAVYBOLTER adeptas inc belt                 12010                           ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -1322,7 +1336,7 @@ items:
     invHeight: 1
     listOrder: 10528
   - type: STR_AC_HE_ADEPTAS_BOXAMMO #HEAVYBOLTER adeptas HE belt                 12010                           ToStun
-    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.1
     requiresBuy:
       - STR_ADEPTAS
@@ -1341,7 +1355,7 @@ items:
     listOrder: 10528
 
   - type: STR_GALGALIM_ASSCANNON #Adeptas assault cannon                                                              #13200
-    categories: [STR_CAT_TERMINATOR]
+    categories: [STR_CAT_TERMINATOR, STR_CAT_ADEPTAS]
     size: 0.6
     costSell: 40000
     weight: 80
@@ -1386,7 +1400,7 @@ items:
     listOrder: 13230
 
   - type: STR_ADEPTAS_ROCKET_LAUNCHER # ADEPTAS THRONE MISSILE LAUNCHER                       12100                                  AIMED
-    categories: [ STR_CAT_ROCKETL]
+    categories: [ STR_CAT_ROCKETL, STR_CAT_ADEPTAS]
     size: 0.4
     requiresBuy:
       - STR_ADEPTAS
@@ -1424,7 +1438,7 @@ items:
     armor: 200
     listOrder: 12180
   - type: STR_ADEPTAS_PANZERFAUST # ADEPTAS FAUST LAUNCHER                 12100                                  AIMED
-    categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR, STR_CAT_ORK]
+    categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.4
     requiresBuy:
      - STR_ADEPTAS
@@ -1450,7 +1464,7 @@ items:
     armor: 200
     listOrder: 12179
   - type: STR_ADEPTAS_HABORYM # ADEPTAS HABORYM LAUNCHER                 12100                                  AIMED
-    categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR, STR_CAT_ORK]
+    categories: [ STR_CAT_ROCKETL, STR_CAT_DEVASTATOR, STR_CAT_ADEPTAS]
     size: 0.4
     requiresBuy:
      - STR_ADEPTAS
@@ -1557,7 +1571,7 @@ items:
     listOrder: 11852
 
   - type: STR_LIGHT_ROCKET #Throne Light Missile Adeptas
-    categories: [ STR_CAT_ROCKETL]
+    categories: [ STR_CAT_ROCKETL, STR_CAT_ADEPTAS]
     requiresBuy:
      - STR_ADEPTAS
      - STR_FAITHFUL_ARMORY
@@ -1577,7 +1591,7 @@ items:
     listOrder: 12181
 
   - type: STR_LASCAN_MALTHUS #LASCANON ADEPTAS                         2017  amied
-    categories: [STR_CAT_LASGUN]
+    categories: [STR_CAT_LASGUN, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LASCAN_MALTHUS
     size: 0.4
@@ -1602,7 +1616,7 @@ items:
     bulletSpeed: 100
 
   - type: STR_LASCANNON_CLIP_MALTHUS #LASCANON MALTHUS POWER PACK               2018
-    categories: [STR_CAT_LASGUN]
+    categories: [STR_CAT_LASGUN, STR_CAT_ADEPTAS]
     size: 0.2
     requiresBuy:
       - STR_LASCANNON_CLIP_MALTHUS
@@ -1642,7 +1656,7 @@ items:
     listOrder: 11101
 
   - type: STR_HARMONIC_MELTAGUN #ADEPTAS MELTAGUN                    2019
-    categories: [STR_CAT_MELTA, STR_CAT_TACTICAL]
+    categories: [STR_CAT_MELTA, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.3
     requiresBuy:
       - STR_ADEPTAS
@@ -1666,7 +1680,7 @@ items:
     listOrder: 11102
 
   - type: STR_GRAVGUN_ADEPTAS #GRAVGUN ADEPTAS                  11800
-    categories: [STR_CAT_GRAVGUN, STR_CAT_TACTICAL]
+    categories: [STR_CAT_GRAVGUN, STR_CAT_TACTICAL, STR_CAT_ADEPTAS]
     size: 0.2
     costSell: 15000
     weight: 10
@@ -1686,7 +1700,7 @@ items:
 
 
   - type: STR_BOLTPISTOL_SCOURGE
-    categories: [STR_CAT_BOLTER]
+    categories: [STR_CAT_BOLTER, STR_CAT_ADEPTAS]
     requiresBuy:
       - STR_LIGHT_BOLTERS
       - STR_ADEPTAS
@@ -1702,6 +1716,8 @@ items:
     compatibleAmmo:
       - STR_LIGHT_BOLTPISTOL_AMMO
       - STR_LIGHT_BOLTPISTOL_AMMO_MC
+      - STR_LIGHT_BOLTPISTOL_AMMO_AP
+      - STR_LIGHT_BOLTPISTOL_AMMO_EX
       - STR_LIGHT_BOLTPISTOL_PENITENCE_AMMO
     battleType: 1
     twoHanded: false

--- a/Ruleset/BALANCE/ballistics_ammo.rul
+++ b/Ruleset/BALANCE/ballistics_ammo.rul
@@ -56,6 +56,7 @@ items:
 
   - type: STR_LIGHT_BOLTPISTOL_AMMO # done
     refNode: *STR_BOLTER_AMMO
+    costSell: 75
     power: 55
 
   - type: STR_LIGHT_BOLTPISTOL_AMMO_MC # done

--- a/Ruleset/IG/manufacture_IG.rul
+++ b/Ruleset/IG/manufacture_IG.rul
@@ -349,10 +349,10 @@ manufacture:
       - STR_ROTOR_CANNON_KOMBI
     space: 2
     time: 200
-    cost: 25000 #2500 per grenade pack
+    cost: 2500 #250 per grenade pack + resources
     requiredItems:
-      STR_ALIEN_ALLOYS: 5
-      STR_ELERIUM_115: 5 #incendiary
+      STR_ALIEN_ALLOYS: 2
+      STR_ELERIUM_115: 2 #incendiary
     producedItems:
       STR_INCENDIARY_GRENADE40: 10
 
@@ -363,13 +363,38 @@ manufacture:
       - STR_ROTOR_CANNON_KOMBI
     space: 2
     time: 200
-    cost: 50000 #5000 per grenade pack
+    cost: 2500 #250 per grenade pack + resources
     requiredItems:
-      STR_ALIEN_ALLOYS: 5
-      STR_ELERIUM_115: 10 #melta cost
+      STR_ALIEN_ALLOYS: 2
+      STR_ELERIUM_115: 5 #melta cost
     producedItems:
       STR_MELTA_GRENADE40: 10
 
+  - name: STR_PENITENCE_GRENADE40 #used by the Hellspite (adeptas)
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 500
+    requiredItems:
+      STR_ALIEN_ALLOYS: 1
+    producedItems:
+      STR_PENITENCE_GRENADE40: 10
+
+  - name: STR_KRAK_GRENADE40 #used by the Hellspite (adeptas) and the guard Rotor Cannon Kombi
+    category: STR_AMMUNITION
+    requires:
+      - STR_ROTOR_CANNON_RESEARCH
+      - STR_ROTOR_CANNON_KOMBI
+    space: 2
+    time: 100
+    cost: 2500 #250 per grenade pack + resources
+    requiredItems:
+      STR_ALIEN_ALLOYS: 1
+      STR_ELERIUM_115: 1
+    producedItems:
+      STR_KRAK_GRENADE40: 10
 
   - name: STR_HEAVY_STUBBER_CLIP_MC
     category: STR_AMMUNITION
@@ -383,7 +408,6 @@ manufacture:
       STR_UFO_CONSTRUCTION: 5
     producedItems:
       STR_HEAVY_STUBBER_CLIP_MC: 10
-
 
   - name: STR_HEAVY_STUBBER_LIGHT
     category: STR_WEAPON

--- a/Ruleset/SM/manufacture_SM.rul
+++ b/Ruleset/SM/manufacture_SM.rul
@@ -935,6 +935,30 @@ manufacture:
     producedItems:
       STR_LIGHT_BOLTER_AMMO_INF: 7
 
+  - name: STR_LIGHT_FLAMETHROWER_CLIP
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 500
+    requiredItems:
+      STR_ELERIUM_115: 1
+    producedItems:
+      STR_LIGHT_FLAMETHROWER_CLIP: 15
+
+  - name: STR_HAND_FLAMETHROWER_CLIP
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 500
+    requiredItems:
+      STR_ELERIUM_115: 1
+    producedItems:
+      STR_HAND_FLAMETHROWER_CLIP: 15
+
   - name: STR_CANTUS_BOLTER_AMMO
     category: STR_AMMUNITION
     requires:

--- a/Ruleset/SM/manufacture_SM.rul
+++ b/Ruleset/SM/manufacture_SM.rul
@@ -569,7 +569,7 @@ manufacture:
     category: STR_PERSONAL_ARMOR
     requires:
       - STR_TEC_BAYR
-      - STR_MARINES_AND_DEATHWATCH 
+      - STR_MARINES_AND_DEATHWATCH
     space: 12
     time: 800
     cost: 30000
@@ -727,7 +727,7 @@ manufacture:
   - name: STR_DREAD3_ARMOR               #1 BADGE 1
     category: STR_PERSONAL_ARMOR
     requires:
-      - STR_MARINES_AND_DEATHWATCH 
+      - STR_MARINES_AND_DEATHWATCH
       - STR_FUSION_MISSILE
       - STR_NEW_FIGHTER_CRAFT
       - STR_NOT_PRIMARIS
@@ -742,7 +742,7 @@ manufacture:
   - name: STR_DREAD4_ARMOR               #1 BADGE 1
     category: STR_PERSONAL_ARMOR
     requires:
-      - STR_MARINES_AND_DEATHWATCH 
+      - STR_MARINES_AND_DEATHWATCH
       - STR_LASER_CANNON
       - STR_NEW_FIGHTER_CRAFT
       - STR_NOT_PRIMARIS
@@ -757,7 +757,7 @@ manufacture:
   - name: STR_DREAD5_ARMOR               #1 BADGE 5
     category: STR_PERSONAL_ARMOR
     requires:
-      - STR_MARINES_AND_DEATHWATCH 
+      - STR_MARINES_AND_DEATHWATCH
       - STR_PLASMA_CANNON
       - STR_NEW_FIGHTER_CRAFT
       - STR_VETERAN
@@ -782,7 +782,7 @@ manufacture:
       STR_ALIEN_ALLOYS: 350 # was 650
       STR_UFO_POWER_SOURCE: 1
       STR_UFO_NAVIGATION: 1
-      
+
   - name: STR_REPULSOR_T
     requiredItems:
       STR_ALIEN_ALLOYS: 350 # was 650
@@ -794,7 +794,7 @@ manufacture:
       STR_ALIEN_ALLOYS: 350 # was 650
       STR_UFO_POWER_SOURCE: 1
       STR_UFO_NAVIGATION: 1
-      
+
   - name: STR_ARMY_P
     requiredItems:
       STR_ALIEN_ALLOYS: 600 # was 1200
@@ -806,7 +806,7 @@ manufacture:
       STR_ALIEN_ALLOYS: 600 # was 1200
       STR_UFO_POWER_SOURCE: 2
       STR_UFO_NAVIGATION: 2
-      
+
   - name: STR_STORMEAGLE
     requiredItems:
       STR_ALIEN_ALLOYS: 500 # was 1000
@@ -851,8 +851,8 @@ manufacture:
       STR_UFO_NAVIGATION: 1
 
   - name: STR_DW_THUNDERHAWNK #thunderhawnk Type 1
-    refNode: *STR_THUNDERHAWK_TRANSPORT    
-      
+    refNode: *STR_THUNDERHAWK_TRANSPORT
+
   - name: STR_TTASS #thunderhawnk Transport ASS
     refNode: *STR_THUNDERHAWK_TRANSPORT
 
@@ -869,10 +869,10 @@ manufacture:
   - name: STR_HB_CLIP
     producedItems:
       STR_HB_CLIP: 5 # # was 1 # now: 5 clips for 10 prom
-    requiredItems:      
+    requiredItems:
       STR_ELERIUM_115: 0 # was 50
       STR_ALIEN_ALLOYS: 10 # was 20
-      
+
   - name: STR_HB_CLIP_MC
     requiredItems:
       STR_ELERIUM_115: 30 # was 50
@@ -880,6 +880,16 @@ manufacture:
       STR_UFO_CONSTRUCTION: 10 # was 20
     producedItems:
       STR_HB_CLIP_MC: 5
+
+  - name: STR_LIGHT_BOLTER_AMMO
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 1200
+    producedItems:
+      STR_LIGHT_BOLTER_AMMO: 7
 
   - name: STR_LIGHT_BOLTER_AMMO_EX
     category: STR_AMMUNITION
@@ -901,6 +911,48 @@ manufacture:
     producedItems:
       STR_LIGHT_BOLTER_AMMO_PEN: 7
 
+  - name: STR_LIGHT_BOLTER_AMMO_AP
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 500
+    requiredItems:
+      STR_ALIEN_ALLOYS: 1
+    producedItems:
+      STR_LIGHT_BOLTER_AMMO_AP: 7
+
+  - name: STR_LIGHT_BOLTER_AMMO_INF
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 500
+    requiredItems:
+      STR_ELERIUM_115: 1
+    producedItems:
+      STR_LIGHT_BOLTER_AMMO_INF: 7
+
+  - name: STR_CANTUS_BOLTER_AMMO
+    category: STR_AMMUNITION
+    requires:
+      - STR_ADEPTAS
+    space: 2
+    time: 100
+    cost: 1200
+    producedItems:
+      STR_CANTUS_BOLTER_AMMO: 10
+
+  - name: STR_LIGHT_BOLTPISTOL_AMMO
+    category: STR_AMMUNITION
+    space: 2
+    time: 100
+    cost: 1200
+    producedItems:
+      STR_LIGHT_BOLTPISTOL_AMMO: 14
+
   - name: STR_LIGHT_BOLTPISTOL_AMMO_EX
     category: STR_AMMUNITION
     space: 2
@@ -920,6 +972,14 @@ manufacture:
       STR_ALIEN_ALLOYS: 1
     producedItems:
       STR_LIGHT_BOLTPISTOL_AMMO_AP: 14
+
+  - name: STR_RIFLE_CLIP
+    category: STR_AMMUNITION
+    space: 2
+    time: 100
+    cost: 1200
+    producedItems:
+      STR_RIFLE_CLIP: 5
 
   - name: STR_RIFLE_CLIP_EX
     category: STR_AMMUNITION


### PR DESCRIPTION
1. Added missing ammo compatibility with Kraken Penetrators and Metal Storm for Adeptas weapons.

2. Added some missing ammo crafting recipes.

3. Added missing category tags for Adeptas weapons.

4. Added missing 40mm grenade and Adeptas hand/light flamethrower recipes.

5. Made the cost/store buy and sell of 40mm grenades more sane.