### PR TITLE
Unsuckifying Thunderbolts/Adeptas Avenger/Xiphon

### DIFF
--- a/Ruleset/ADEPTAS/crafts_adeptas.rul
+++ b/Ruleset/ADEPTAS/crafts_adeptas.rul
@@ -273,3 +273,15 @@ crafts:
       - STR_ADEPTAS
       - STR_DEATHWATCH_AND_ADEPTAS
 
+  - type: STR_THUNDERBOLT_ADEPTAS
+    armor: 2 #was 0; gets some armor in lieu of the Lightning's higher avoid bonus
+    avoidBonus: 5
+    repairRate: 3 #was 1
+    accel: 4 #was 5; heavier and takes a bit more time to get up to speed
+    fuelMax: 1500 #was 1000
+
+  - type: STR_AVENGER_ADEPTAS
+    avoidBonus: 10 #was 0; to bring it in line with Lightning Interceptor
+    repairRate: 5 #was 1; to bring it in line with Lightning Interceptor
+    hitBonus: 7 #was 0; this benefit accrues because it requires 2 pilots versus the Lightning Interceptor's 1. Having a devoted gunner helps
+

--- a/Ruleset/ARBITES/crafts_arbites.rul
+++ b/Ruleset/ARBITES/crafts_arbites.rul
@@ -73,7 +73,11 @@ crafts:
 
 
   - type: STR_THUNDERBOLTPD
-    repairRate: 5 #was 1
+    armor: 2 #was 0; gets some armor in lieu of the Lightning's higher avoid bonus
+    avoidBonus: 5
+    repairRate: 3 #was 1
+    accel: 4 #was 5; heavier and takes a bit more time to get up to speed
+    fuelMax: 1500 #was 1000
     requires:
       - STR_ARBITES
 #      - STR_NEW_FIGHTER_PD

--- a/Ruleset/IG/crafts_IG.rul
+++ b/Ruleset/IG/crafts_IG.rul
@@ -409,7 +409,7 @@ crafts:
     maxLargeUnits: 4
 
   - type: STR_THUNDERBOLT_INTERCEPTOR
-    armor: 1 #was 0; gets some armor in lieu of the Lightning's higher avoid bonus
+    armor: 2 #was 0; gets some armor in lieu of the Lightning's higher avoid bonus
     avoidBonus: 5
     repairRate: 3 #was 1
     accel: 4 #was 5; heavier and takes a bit more time to get up to speed

--- a/Ruleset/SM/GREY KNIGHTS/crafts_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/crafts_GK.rul
@@ -6,10 +6,10 @@ crafts:
     vehicles: -1
     maxLargeUnits: 1
 
-  - type: STR_ARVUS_GK      
+  - type: STR_ARVUS_GK
     requires: !remove
       - STR_GREYKNIGHTS
-      
+
     battlescapeTerrainData:
       name: ARVUSGK
       mapDataSets:
@@ -26,11 +26,11 @@ crafts:
       - STR_GREYKNIGHTS
     vehicles: -1
     maxLargeUnits: 1
-      
+
   - type: STR_STORMRAVEN_GK
     requires: !add
       - STR_CHAMBERMILITANT
-      
+
     fuelMax: 600 # was 1200
     refuelRate: 10 # was 5
     repairRate: 5 # was 1
@@ -62,23 +62,29 @@ crafts:
 
   - type: STR_STORMEAGLE_GK
     requires: !add
-      - STR_CHAMBERMILITANT  
+      - STR_CHAMBERMILITANT
     vehicles: -1
     maxLargeUnits: 1
-      
+
   - type: STR_STORMEAGLE_GK
     requires: !remove
       - STR_GREYKNIGHTS
-      
+
     fuelMax: 500 # was 1000
     refuelRate: 10 # was 5
     repairRate: 5 # was 1
 
   - type: STR_THUNDERHAWNK_GK
     requires: !add
-      - STR_CHAMBERMILITANT  
-      
+      - STR_CHAMBERMILITANT
+
   - type: STR_THUNDERHAWNK_GK
     requires: !remove
       - STR_GREYKNIGHTS
     repairRate: 5 # was 1
+
+  - type: STR_XIPHON_GK
+    armor: 1 #compensates for slower speed and acceleration vs Lightning Interceptor
+    avoidBonus: 5 #was 0; to bring it in line with Lightning Interceptor
+    hitBonus: 5 #was 0; to bring it in line with Lightning Interceptor
+    repairRate: 5 #was 1; to bring it in line with Lightning Interceptor


### PR DESCRIPTION
1. Rosigma Thunderbolt improvements made standard.
2. Adeptas Avenger stats made more in line with the Rosigma Lightning; given an additional +7 hit bonus due to devoted gunner.
3. Xiphon given 1 armor, 5 dodge, 5 hit bonus and repair rates on par with other basic interceptors; less speedy and maneuverable but more accurate.