### PR TITLE
Expanded Fire Mode Power Bonus Scripts/Abort Rebalance

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -3133,14 +3133,14 @@ en-US:
 
   STR_POWER_SHOT: "Power Shot"
   STR_POWER_SHOT_2: "POWER! Shot"
-  STR_AUTO_POWER_BONUS: "Power Bonus for Auto"
-  STR_SNAP_POWER_BONUS: "Power Bonus for Snap"
-  STR_AIMED_POWER_BONUS: "Power Bonus for Aimed"
-  STR_MELEE_POWER_BONUS: "Power Bonus for Melee"
-  STR_AUTO_ACCURACY_POWER_BONUS: "Auto Mode Firing Accuracy Power Bonus"
-  STR_SNAP_ACCURACY_POWER_BONUS: "Snap Shot Firing Accuracy Power Bonus"
-  STR_AIMED_ACCURACY_POWER_BONUS: "Aimed Shot Firing Accuracy Power Bonus"
-  STR_POWER_BONUS_PERCENTILE: "Fire Mode Power Bonus is a Percentage?"
+  STR_AUTO_POWER_BONUS: "Damage Bonus for Auto"
+  STR_SNAP_POWER_BONUS: "Damage Bonus for Snap"
+  STR_AIMED_POWER_BONUS: "Damage Bonus for Aimed"
+  STR_MELEE_POWER_BONUS: "Damage Bonus for Melee"
+  STR_AUTO_ACCURACY_POWER_BONUS: "Auto Mode Firing Accuracy Damage Bonus"
+  STR_SNAP_ACCURACY_POWER_BONUS: "Snap Shot Firing Accuracy Damage Bonus"
+  STR_AIMED_ACCURACY_POWER_BONUS: "Aimed Shot Firing Accuracy Damage Bonus"
+  STR_POWER_BONUS_PERCENTILE: "Fire Mode Damage Bonus is a Percentage of Base Power?"
   STR_MAXIMAL_SHOT: "Maximal Shot"
   STR_PRECISION_SHOT: "Precision Shot"
 
@@ -3356,6 +3356,7 @@ en-US:
   STR_HEAT_AMMO_SPENT_FOR_INCREASE: "Heat increase after spending X ammo in one turn"
   STR_GRAVPERCENTAGE:  "% Bonus damage from target armor"
   # STR_YES: "Yes" # already exists
+  STR_BOTH: "Both"
 
 #Chaos Squats
   STR_CULTIST_SQUATS_LEADER: "Squat Cultist Champion"
@@ -4291,7 +4292,7 @@ en-US:
     "{NEWLINE}Abilities:
     {NEWLINE}> {ALT}Adv. Sensor Suite:{ALT} This weapon grants an analyzer, superior anti-camo, night and thermal vision.
     {NEWLINE}> {ALT}Sniper Weapon:{ALT} This weapon's damage scales with the user's Firing Accuracy.
-    {NEWLINE}> {ALT}Precision Shot:{ALT} This weapon's Aimed Shot targets vitals and weak points. Increases effective Power by 50."
+    {NEWLINE}> {ALT}Precision Shot:{ALT} This weapon's Aimed Shot targets vitals and weak points. Increases damage by this weapon's base power times 150% of the user's Firing Accuracy."
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK: "Inquisition Jumppack Armor"
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK_UFOPEDIA: "{NEWLINE}Specialized set of high mobility jumppack armor that is meant for use in assault, flanking and reconnaissence roles. Comes with an enhanced sensor array."
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK_UFOPEDIA_2:

--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -4292,7 +4292,7 @@ en-US:
     "{NEWLINE}Abilities:
     {NEWLINE}> {ALT}Adv. Sensor Suite:{ALT} This weapon grants an analyzer, superior anti-camo, night and thermal vision.
     {NEWLINE}> {ALT}Sniper Weapon:{ALT} This weapon's damage scales with the user's Firing Accuracy.
-    {NEWLINE}> {ALT}Precision Shot:{ALT} This weapon's Aimed Shot targets vitals and weak points. Increases damage by this weapon's base power times 150% of the user's Firing Accuracy."
+    {NEWLINE}> {ALT}Precision Shot:{ALT} This weapon's Aimed Shot targets vitals and weak points. Increases damage by this weapon's base power times 150% of the user's Firing Accuracy, divided by 100."
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK: "Inquisition Jumppack Armor"
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK_UFOPEDIA: "{NEWLINE}Specialized set of high mobility jumppack armor that is meant for use in assault, flanking and reconnaissence roles. Comes with an enhanced sensor array."
   STR_INQ_STORMTROOPER_CARAPACE_ARMOR_JUMPPACK_UFOPEDIA_2:

--- a/Ruleset/ADEPTAS/weapons_adeptas.rul
+++ b/Ruleset/ADEPTAS/weapons_adeptas.rul
@@ -2,15 +2,14 @@ extended:
   tags:
     RuleItem:
       ITEM_DOESNT_HURT_USER: int
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
       ITEM_RECOIL: int
       ITEM_HAS_BIPOD: int
       ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
@@ -710,7 +709,7 @@ items:
       firing: [0.5, 0.005]
     tags:
       ITEM_RECOIL: 40
-      ITEM_AIMED_ACCURACY_POWER_BONUS: 25 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
       ITEM_POWER_BONUS_PERCENTILE: 1
       ITEM_IS_HEAVY_WEAPON: 1
 

--- a/Ruleset/BALANCE/las.rul
+++ b/Ruleset/BALANCE/las.rul
@@ -1,15 +1,14 @@
 extended:
   tags:
     RuleItem:
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
       ITEM_RECOIL: int
       ITEM_HAS_BIPOD: int
       ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
@@ -234,7 +233,7 @@ items:
       shortName: STR_POWER_SHOT_COUNT
 
     tags:
-      ITEM_AIMED_POWER_BONUS: 20
+      ITEM_AIMED_FLAT_POWER_BONUS: 20
 
   - type: STR_MCLASER_RIFLE # done # MC
     dropoff: 4
@@ -344,8 +343,8 @@ items:
       ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
       RandomWound: false
     tags:
-      ITEM_AUTO_POWER_BONUS: 20
-      ITEM_AIMED_POWER_BONUS: 30
+      ITEM_AUTO_FLAT_POWER_BONUS: 20
+      ITEM_AIMED_FLAT_POWER_BONUS: 30
 
 ## Heavy Weapons
 
@@ -627,5 +626,5 @@ items:
     tuSnap: 40
     tuAimed: 70
     tags:
-      ITEM_SNAP_POWER_BONUS: 50
-      ITEM_AIMED_POWER_BONUS: 50
+      ITEM_SNAP_FLAT_POWER_BONUS: 50
+      ITEM_AIMED_FLAT_POWER_BONUS: 50

--- a/Ruleset/ENEMY/ORK/weapons_ORK.rul
+++ b/Ruleset/ENEMY/ORK/weapons_ORK.rul
@@ -1,15 +1,14 @@
 extended:
   tags:
     RuleItem:
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
       ITEM_RECOIL: int
       ITEM_HAS_BIPOD: int
       ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons

--- a/Ruleset/ENEMY/TZEENTCH/weapons_tzeentch.rul
+++ b/Ruleset/ENEMY/TZEENTCH/weapons_tzeentch.rul
@@ -1,15 +1,14 @@
 extended:
   tags:
     RuleItem:
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
     #Infection system vars
       INFECTION_DAMAGE_FLAT: int #if 0 uses damage dealt
       INFECTION_DAMAGE_PERCENT: int #inflicts % of damage dealt as infection damage
@@ -81,8 +80,8 @@ items:
       - STR_LASPISTOL_CLIP_HOTSHOT
       - STR_LASGUN_CLIP_HOTSHOT_CHAOS #very heretical pistol config
     tags:
-      ITEM_SNAP_POWER_BONUS: 10
-      ITEM_AIMED_POWER_BONUS: 20
+      ITEM_SNAP_FLAT_POWER_BONUS: 10
+      ITEM_AIMED_FLAT_POWER_BONUS: 20
     battleType: 1
     twoHanded: false #Pistol
     invWidth: 1
@@ -130,9 +129,9 @@ items:
       - STR_LASGUN_CLIP
       - STR_LASGUN_CLIP_HOTSHOT_CHAOS
     tags:
-      ITEM_SNAP_POWER_BONUS: 10
-      ITEM_AUTO_POWER_BONUS: 10
-      ITEM_AIMED_POWER_BONUS: 20
+      ITEM_SNAP_FLAT_POWER_BONUS: 10
+      ITEM_AUTO_FLAT_POWER_BONUS: 10
+      ITEM_AIMED_FLAT_POWER_BONUS: 20
     battleType: 1
     twoHanded: false #compact carbine, enough to use single handed
     invWidth: 1

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -24,15 +24,14 @@ extended:
       YTAG_DAMAGE_RETURNED_AS_STUN: int
       YTAG_DAMAGE_RETURNED_RESIST_TYPE: int
 #aim mode damage bonuses
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-#intimidation scripts
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.#intimidation scripts
       INTIMIDATION_TU_DAMAGE_MULTIPLIER: int #TU damage multiplier 100 = baseline
       INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: int #morale damage multiplier 100 = baseline
       INTIMIDATION_STUN_DAMAGE_MULTIPLIER: int #stun damage multiplier 100 = baseline

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -1,15 +1,14 @@
 extended:
   tags: # Remember to add tag definitions to same file as item/armor rulesets!
     RuleItem:
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-#intimidation scripts
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.#intimidation scripts
       INTIMIDATION_TU_DAMAGE_MULTIPLIER: int #TU damage multiplier 100 = baseline
       INTIMIDATION_MORALE_DAMAGE_MULTIPLIER: int #morale damage multiplier 100 = baseline
 #bomb/kamikazi scripts

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -10,15 +10,14 @@ extended:
       ITEM_DOESNT_HURT_FRIENDS: int
       ITEM_IS_VOX_DUMMY: int
       ITEM_IS_VOX_WEAPON: int
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
       ITEM_IS_TOOL: int
 
       ITEM_RECOIL: int
@@ -108,7 +107,7 @@ items:
       - STR_SMALL_ROCKET
       - STR_LARGE_ROCKET
       - STR_INCENDIARY_ROCKET
-    accuracySnap: 0 
+    accuracySnap: 0
     accuracyAuto: 50 #-10
     accuracyAimed: 80 #-10
     tuSnap: 0 #no reaction fire
@@ -1784,9 +1783,9 @@ items:
       shortName: STR_POWER_SHOT_2_COUNT
     armor: 200 #to avoid item pile destruction
     tags:
-      ITEM_SNAP_POWER_BONUS: 20
-      ITEM_AUTO_POWER_BONUS: 15 #brrt mode
-      ITEM_AIMED_POWER_BONUS: 50
+      ITEM_SNAP_FLAT_POWER_BONUS: 20
+      ITEM_AUTO_FLAT_POWER_BONUS: 15 #brrt mode
+      ITEM_AIMED_FLAT_POWER_BONUS: 50
     listOrder: 11056
 
   - type: STR_LASGUN_TANITH
@@ -2091,7 +2090,7 @@ items:
     dropoff: 3
     autoRange: 0
     snapRange: 21
-    aimRange: 32
+    aimRange: 40 #it's an Exitus rifle; it has the best aimed range of any sniper rifle in the game
     accuracyAuto: 0
     accuracySnap: 80
     accuracyAimed: 160
@@ -2102,7 +2101,7 @@ items:
     accuracyMultiplier: #sniper rifle accuracy
       firing: [0.5, 0.005]
     tags:
-      ITEM_AIMED_ACCURACY_POWER_BONUS: 50 #Sniper rifle bonus to aimed shots; power of precision
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 75 #Sniper rifle bonus to aimed shots; power of precision
       ITEM_POWER_BONUS_PERCENTILE: 1 #use %
       ITEM_COLOR_CHANGES_WITH_AMMO_NON_GRAY: 6
       ITEM_IS_HEAVY_WEAPON: 1

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -5,15 +5,14 @@ extended:
       ITEM_AMMO_COLOR: int
       ITEM_AMMO_SHADE: int
       ITEM_STRENGTH_REQUIREMENT: int
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
       ITEM_RECOIL: int
       ITEM_HAS_BIPOD: int
       ITEM_IS_HEAVY_WEAPON: int # infantry but not mounted/vehicle heavy weapons
@@ -846,8 +845,8 @@ items:
     armor: 200
     listOrder: 10761
     tags:
-      ITEM_SNAP_POWER_BONUS: 10 #INQ BONUS
-      ITEM_AIMED_POWER_BONUS: 20 #INQ BONUS
+      ITEM_SNAP_FLAT_POWER_BONUS: 10 #INQ BONUS
+      ITEM_AIMED_FLAT_POWER_BONUS: 20 #INQ BONUS
 
   - type: STR_INQ_FLAMER #Special Inquisition Stormtrooper only flamer
     categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL]
@@ -941,6 +940,7 @@ items:
       firing: [0.5, 0.005]
     kneelBonus: 130 #sniper weapon gains additional accuracy from kneeling
     snapRange: 24
+    aimRange: 38
     tuSnap: 50
     tuAimed: 75
     confAimed: #Called Precision Shot to emphasize the added lethality
@@ -948,8 +948,6 @@ items:
     battleType: 1
     power: 50
     damageType: 4
-    damageBonus: #damage scales aggressively with accuracy due to being a precision sniper weapon
-      firing: [0.0, 0.0025]
     damageAlter: #hellgun properties
       RandomType: 6 #gaussian; consistent damage with the chance to critically hit/miss
       ToArmorPre: 0.3
@@ -971,7 +969,7 @@ items:
     blockBothHands: true
     listOrder: 10764
     tags:
-      ITEM_AIMED_ACCURACY_POWER_BONUS: 100 #Precision Shot Bonus
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 150 #Precision Shot Bonus
       ITEM_POWER_BONUS_PERCENTILE: 1 #use %
       ITEM_IS_HEAVY_WEAPON: 1 #Sniper platform
 

--- a/Ruleset/alienDeployments_40k.rul
+++ b/Ruleset/alienDeployments_40k.rul
@@ -307,7 +307,7 @@ alienDeployments:
       STR_NECRON_TERROR: 50 # was 25
       STR_NECRON_BASE: 25
     objectiveComplete: [STR_NECRON_BASE_DESTROYED, 1000]
-    objectiveFailed: [STR_NECRON_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_NECRON_BASE_NOT_DESTROYED, -500]
 
   - type: STR_MONOLITH    #NECRON
     data:
@@ -648,8 +648,8 @@ alienDeployments:
         STR_CULTIST_BASE_LEVEL_2: 50
       3:
         STR_CULTIST_BASE_LEVEL_2: 100
-    objectiveFailed: [STR_CULTIST_BASE_NOT_DESTROYED, -100]
     objectiveComplete: [STR_CULTIST_BASE_DESTROYED, 200]
+    objectiveFailed: [STR_CULTIST_BASE_NOT_DESTROYED, -100]
 
   - type: STR_CULTIST_BASE_LEVEL_2
     randomRace: [STR_SECTOID, STR_CULTIST_SQUATS]
@@ -707,8 +707,8 @@ alienDeployments:
         STR_CULTIST_BASE_LEVEL_3: 25
       4:
         STR_CULTIST_BASE_LEVEL_3: 100
-    objectiveFailed: [STR_CULTIST_BASE_NOT_DESTROYED, -150]
     objectiveComplete: [STR_CULTIST_BASE_DESTROYED, 300]
+    objectiveFailed: [STR_CULTIST_BASE_NOT_DESTROYED, -150]
 
   - type: STR_CULTIST_BASE_LEVEL_3
     randomRace: [STR_SECTOID_ELITE, STR_SECTOID_ELITE, STR_SECTOID_ELITE, STR_NEVERBORN_CULT, STR_ALPHA_CULT]
@@ -778,8 +778,8 @@ alienDeployments:
         STR_CULTIST_BASE_START: 100
       3:
         STR_CULTIST_BASE_LEVEL_3: 100
-    objectiveFailed: [STR_CULTIST_BASE_NOT_DESTROYED, -150]
     objectiveComplete: [STR_CULTIST_BASE_DESTROYED, 300]
+    objectiveFailed: [STR_CULTIST_BASE_NOT_DESTROYED, -150]
 
   - type: STR_CULTIST_SACRIFICES_LEVEL_1
     data:
@@ -1490,7 +1490,7 @@ alienDeployments:
     huntMissionMaxFrequency: 1440 # 300       # generate hunt mission max every 300 minutes (= 5 hours)
     unlockedResearch: STR_ORK_MIG_UFO
     objectiveComplete: [STR_ORK_BASE_DESTROYED, 500]
-    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -250]
 
   - type: STR_ORKBASE4 #ORKBASE4 INC.
     data: &orkBaseTier4Data
@@ -1541,7 +1541,7 @@ alienDeployments:
     huntMissionMaxFrequency: 1440 # 300       # generate hunt mission max every 300 minutes (= 5 hours)
     unlockedResearch: STR_ORK_MIG_UFO
     objectiveComplete: [STR_ORK_BASE_DESTROYED, 800]
-    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -400]
 
   - type: STR_ORKBASE5 #ORKBASE5 INC.
     data:
@@ -1605,7 +1605,7 @@ alienDeployments:
     huntMissionMaxFrequency: 1440 # 200       # generate hunt mission max every 300 minutes (= 5 hours)
     unlockedResearch: STR_ORK_BASE_LEVEL5_DEFEATED
     objectiveComplete: [STR_ORK_BASE_DESTROYED, 1200]
-    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -600]
 
   - type: STR_ORKBASE_START
     data: *orkBaseTier4Data
@@ -1624,7 +1624,7 @@ alienDeployments:
     huntMissionMaxFrequency: 1440 # 300       # generate hunt mission max every 300 minutes (= 5 hours)
     unlockedResearch: STR_ORK_MIG_UFO
     objectiveComplete: [STR_ORK_BASE_DESTROYED, 800]
-    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_ORK_BASE_NOT_DESTROYED, -400]
 
   - type: STR_ORK_OUTPOST
     data: *orkBaseTier1Data
@@ -2112,7 +2112,7 @@ alienDeployments:
     height: 9
     unlockedResearch: STR_CHAOS_VOSS
     objectiveComplete: [STR_TRAITOR_GUARD_BASE_DESTROYED, 500]
-    objectiveFailed: [STR_TRAITOR_GUARD_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_TRAITOR_GUARD_BASE_NOT_DESTROYED, -250]
 
   - type: STR_TRAITOR_GUARD_BASE_START
     randomRace: [STR_SNAKEMAN, STR_SNAKEMAN, STR_SNAKEMAN, STR_SNAKEMAN_ELITE, STR_TRAITOR_SQUATS]
@@ -2177,7 +2177,7 @@ alienDeployments:
     height: 9
     unlockedResearch: STR_CHAOS_VOSS
     objectiveComplete: [STR_TRAITOR_GUARD_BASE_DESTROYED, 800]
-    objectiveFailed: [STR_TRAITOR_GUARD_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_TRAITOR_GUARD_BASE_NOT_DESTROYED, -400]
 
   - type: STR_TRAITOR_CHIMERA_MAINTENANCE
     data:
@@ -6443,7 +6443,7 @@ alienDeployments:
     #customUfo: STR_IMP_TRANSPORT_BATTLESHIP #should mix this 20x30 ship into the city map
     #objectiveType: 100 # not used until we have the tiles for it
     objectiveComplete: [STR_GSC_BASE_DESTROYED, 500]
-    objectiveFailed: [STR_GSC_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_GSC_BASE_NOT_DESTROYED, -250]
     #objectivePopup: STR_ORK_CONTROL_CENTER_DESTROYED # not used until we have an objectiveType
     data:
       - alienRank: 0 #COMMANDER
@@ -6778,7 +6778,7 @@ alienDeployments:
     customUfo: STR_IMP_TRANSPORT_BATTLESHIP
     #objectiveType: 100 # not used until we have the tiles for it
     objectiveComplete: [STR_GSC_BASE_DESTROYED, 500]
-    objectiveFailed: [STR_GSC_BASE_NOT_DESTROYED, -200]
+    objectiveFailed: [STR_GSC_BASE_NOT_DESTROYED, -250]
     #objectivePopup: STR_ORK_CONTROL_CENTER_DESTROYED # not used until we have an objectiveType
     data:
       - alienRank: 0 #COMMANDER
@@ -8626,7 +8626,7 @@ alienDeployments:
       0:
         STR_SLAAN_INTERCEPTION: 100
     objectiveComplete: [STR_ALIEN_BASE_CONTROL_DESTROYED, 1000]
-    objectiveFailed: [STR_ALIEN_BASE_CONTROL_FAILED, -200]
+    objectiveFailed: [STR_ALIEN_BASE_CONTROL_FAILED, -500]
 
   - type: STR_ALIEN_BASE_ASSAULT2_SLAANESH   #not functional
     randomRace: [STR_SLAANESH]
@@ -8695,7 +8695,7 @@ alienDeployments:
       desc: STR_ALIEN_BASE_ASSAULT2_SLAANESH_BRIEFING
     objectiveType: 3
     objectiveComplete: [STR_ALIEN_BASE_CONTROL_DESTROYED, 1000]
-    objectiveFailed: [STR_ALIEN_BASE_CONTROL_FAILED, -200]
+    objectiveFailed: [STR_ALIEN_BASE_CONTROL_FAILED, -500]
     objectivePopup: STR_CONTROL_CENTER_DESTROYED
     missionBountyItem: STR_CHAOS_BASE_DATA
 

--- a/Ruleset/scripts/scripts_highpower_shot.rul
+++ b/Ruleset/scripts/scripts_highpower_shot.rul
@@ -7,19 +7,19 @@
 #    compatibleAmmo:
 #      - STR_LASGUN_CLIP
 #    tags:
-#      ITEM_AUTO_POWER_BONUS: 20
+#      ITEM_AUTO_FLAT_POWER_BONUS: 20
 
 extended:
   tags:
     RuleItem:
-      ITEM_AUTO_POWER_BONUS: int #percent bonus to damage equal to this amount for this fire mode
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int #percent bonus to damage equal to this amount for this fire mode
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
 
   scripts:
     hitUnit: # increase power if bonus exists for fire mode
@@ -36,17 +36,17 @@ extended:
           weapon_item.getRuleItem rItem;
 
           if eq battle_action battle_action_snapshot;
-            rItem.getTag powerBonus Tag.ITEM_SNAP_POWER_BONUS;
+            rItem.getTag powerBonus Tag.ITEM_SNAP_FLAT_POWER_BONUS;
             rItem.getTag accuracyBonus Tag.ITEM_SNAP_ACCURACY_POWER_BONUS;
           end;
 
           if eq battle_action battle_action_autoshoot;
-            rItem.getTag powerBonus Tag.ITEM_AUTO_POWER_BONUS;
+            rItem.getTag powerBonus Tag.ITEM_AUTO_FLAT_POWER_BONUS;
             rItem.getTag accuracyBonus Tag.ITEM_AUTO_ACCURACY_POWER_BONUS;
           end;
 
           if eq battle_action battle_action_aimshoot;
-            rItem.getTag powerBonus Tag.ITEM_AIMED_POWER_BONUS;
+            rItem.getTag powerBonus Tag.ITEM_AIMED_FLAT_POWER_BONUS;
             rItem.getTag accuracyBonus Tag.ITEM_AIMED_ACCURACY_POWER_BONUS;
           end;
 
@@ -55,37 +55,38 @@ extended:
           end;
 
           if gt accuracyBonus 0; #if we're scaling the bonus with firing accuracy, we define the bonus here
-            attacker.Stats.getFiring powerBonus; #get attacker's firing accuracy
-            #debug_log "ROSIGMA_hU_highpower_shot: Attacker's accuracy bonus." powerBonus;
-            muldiv accuracyBonus powerBonus 100;
-            set powerBonus accuracyBonus;
+            attacker.Stats.getFiring temp; #get attacker's firing accuracy
+            #debug_log "ROSIGMA_hU_highpower_shot, line 59: Attacker's firing accuracy." temp;
+            #debug_log "ROSIGMA_hU_highpower_shot, line 60: Attacker's accuracy power bonus." accuracyBonus;
+            muldiv accuracyBonus temp 100;
+            #debug_log "ROSIGMA_hU_highpower_shot, line 62: Attacker's adjusted firing accuracy power flat bonus, plus % damage bonus." accuracyBonus;
+            add powerBonus accuracyBonus;
           end;
 
           if eq powerBonus 0; #cancel out if our powerBonus is undefined
-            #debug_log "ROSIGMA_hU_highpower_shot: No power bonus detected; aborting.";
+            #debug_log "ROSIGMA_hU_highpower_shot, line 67: No power bonus detected; aborting.";
             return power part side;
           end;
 
 
           rItem.getTag temp Tag.ITEM_POWER_BONUS_PERCENTILE; #check whether we're using a percentile or flat bonus
 
-          if eq temp 0;
-            weapon_item.getAmmoItem ammoItem;
-            ammoItem.getRuleItem rItem;
-            rItem.getPower weaponPower; #this will be a defacto flat bonus to damage
-            #debug_log "ROSIGMA_hU_highpower_shot: Flat damage bonus.";
+          if ge temp 1;
+            muldiv powerBonus power 100; #we deal powerBonus % more damage relative to the base power;
+            #debug_log "ROSIGMA_hU_highpower_shot, line 76: Percentile damage bonus." powerBonus;
+            if ge temp 2; #if it's 2+ we use both flat and percentile, adding them together
+              add powerBonus accuracyBonus; #add the applicable % of firing accuracy as a flat damage bonus in addition to the percentile bonus
+              #debug_log "ROSIGMA_hU_highpower_shot, line 79: Firing accuracy scaled flat damage bonus." powerBonus;
+            end;
           else;
-            set weaponPower 100; #this will be a percentile bonus to damage
-            #debug_log "ROSIGMA_hU_highpower_shot: Percentile damage bonus.";
+            #debug_log "ROSIGMA_hU_highpower_shot, line 82: Flat damage bonuses only." powerBonus;
           end;
 
-          #debug_log "ROSIGMA_hU_highpower_shot: Old Power" power;
+          #debug_log "ROSIGMA_hU_highpower_shot, line 85: Old Power" power;
 
-          muldiv powerBonus power weaponPower;
           add power powerBonus;
 
-
-          #debug_log "ROSIGMA_hU_highpower_shot: Bonus Power" powerBonus;
-          #debug_log "ROSIGMA_hU_highpower_shot: New Power" power;
+          #debug_log "ROSIGMA_hU_highpower_shot, line 89: Final Bonus Power" powerBonus;
+          #debug_log "ROSIGMA_hU_highpower_shot, line 90: New Power" power;
 
           return power part side;

--- a/Ruleset/scripts/scripts_plasma_heat.rul
+++ b/Ruleset/scripts/scripts_plasma_heat.rul
@@ -6,15 +6,14 @@ extended:
       ITEM_HEAT_MAX_LEVEL: int
       ITEM_HEAT_DISSIPATION_PER_TURN: int
       ITEM_HEAT_AMMO_SPENT_FOR_INCREASE: int
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
     BattleItem:
       ITEM_HEAT_CURRENT_LEVEL: int
       ITEM_HEAT_PREVIOUS_AMMO_COUNT: int
@@ -332,7 +331,7 @@ items:
       ITEM_HEAT_MAX_LEVEL: 7
       ITEM_HEAT_DISSIPATION_PER_TURN: 2
       ITEM_HEAT_AMMO_SPENT_FOR_INCREASE: 1
-      ITEM_AIMED_POWER_BONUS: 50 #Maximal Shot Bonus
+      ITEM_AIMED_FLAT_POWER_BONUS: 50 #Maximal Shot Bonus
 
   - type: STR_PLASMA_GUN_TWINCORE_DEKKER #Dekker Twincore Plasma
     refNode: *STR_OVERHEATING_PLASMA

--- a/Ruleset/scripts/scripts_statsforNerds.rul
+++ b/Ruleset/scripts/scripts_statsforNerds.rul
@@ -47,15 +47,14 @@ extended:
       ITEM_STRENGTH_REQUIREMENT: int
       ITEM_HEAT_MAX_LEVEL: int
       ITEM_HEAT_DISSIPATION_PER_TURN: int
-      ITEM_AUTO_POWER_BONUS: int
-      ITEM_SNAP_POWER_BONUS: int
-      ITEM_AIMED_POWER_BONUS: int
+      ITEM_AUTO_FLAT_POWER_BONUS: int
+      ITEM_SNAP_FLAT_POWER_BONUS: int
+      ITEM_AIMED_FLAT_POWER_BONUS: int
       ITEM_MELEE_POWER_BONUS: int
       ITEM_AIMED_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_SNAP_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
       ITEM_AUTO_ACCURACY_POWER_BONUS: int #percent of the user's Firing Accuracy that applies as a damage bonus; used for precision weapons like sniper rifles
-      ITEM_POWER_BONUS_PERCENTILE: int #TRUE or FALSE; if true, the power bonus is a percentile as opposed to an effectively flat amount
-
+      ITEM_POWER_BONUS_PERCENTILE: int #0-2+; if 0 we just add the flat bonus and add the % of applicable firing accuracy as bonus power. If 1, we apply the bonuses as a percentile bonus of the attack power. If 2+, we do both.
       ITEM_HEAT_AMMO_SPENT_FOR_INCREASE: int
       GravPercentage: int
     RuleArmor:
@@ -145,15 +144,15 @@ extended:
           if gt temp 0;
             stats_state.addIntRow "STR_STRENGTH_REQUIREMENT" temp;
           end;
-          rule.getTag temp Tag.ITEM_AIMED_POWER_BONUS;
+          rule.getTag temp Tag.ITEM_AIMED_FLAT_POWER_BONUS;
           if gt temp 0;
             stats_state.addIntRow "STR_AIMED_POWER_BONUS" temp;
           end;
-          rule.getTag temp Tag.ITEM_AUTO_POWER_BONUS;
+          rule.getTag temp Tag.ITEM_AUTO_FLAT_POWER_BONUS;
           if gt temp 0;
             stats_state.addIntRow "STR_AUTO_POWER_BONUS" temp;
           end;
-          rule.getTag temp Tag.ITEM_SNAP_POWER_BONUS;
+          rule.getTag temp Tag.ITEM_SNAP_FLAT_POWER_BONUS;
           if gt temp 0;
             stats_state.addIntRow "STR_SNAP_POWER_BONUS" temp;
           end;
@@ -174,8 +173,10 @@ extended:
             stats_state.addIntRow "STR_AUTO_ACCURACY_POWER_BONUS" temp;
           end;
           rule.getTag temp Tag.ITEM_POWER_BONUS_PERCENTILE;
-          if gt temp 0;
+          if eq temp 1;
             stats_state.addTextRow "STR_POWER_BONUS_PERCENTILE" "STR_YES";
+          else ge temp 2;
+            stats_state.addTextRow "STR_POWER_BONUS_PERCENTILE" "STR_BOTH";
           end;
           rule.getTag temp Tag.ITEM_HEAT_MAX_LEVEL;
           if gt temp 0;


### PR DESCRIPTION
1. Expanded functionality of fire mode power bonus scripts.

2. Minor rebalance of Inquisition Longlas and Exitus Rifle.

3. Mission failure penalties for base raids no longer capped at -200; now they are equal to half the bonus for success.