### PR TITLE
Guard Heavy Sniper Rifle Fix

### DIFF
--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -630,7 +630,7 @@ items:
     autoRange: 0
     snapRange: 20
     aimRange: 33
-    accuracySnap: 0
+    accuracySnap: 25
     accuracyAuto: 0
     accuracyAimed: 90
     tuAuto: 0
@@ -644,7 +644,7 @@ items:
     tags:
       ITEM_RECOIL: 50
       ITEM_IS_HEAVY_WEAPON: 1
-      ITEM_AIMED_ACCURACY_POWER_BONUS: 25
+      ITEM_AIMED_ACCURACY_POWER_BONUS: 50
       ITEM_POWER_BONUS_PERCENTILE: 1 #use %
 
   - type: STR_HEAVY_SNIPER_RIFLEG_AMMO


### PR DESCRIPTION
1. IG's Heavy Sniper Rifle now can snap shot (badly).

2. Improved Firing Accuracy aimed shot damage bonus for the IG Heavy Sniper Rifle (50% of FA up from 25%).