### PR TITLE
Minor Bug Fixes/Balance Changes

### DIFF
--- a/Ruleset/ADEPTAS/armors_adeptas.rul
+++ b/Ruleset/ADEPTAS/armors_adeptas.rul
@@ -624,7 +624,7 @@ armors:
     frontArmor: 90
     sideArmor: 70
     rearArmor: 40
-    underArmor: 20
+    underArmor: 40
     damageModifier:
       - 1.0 #NONE
       - 0.6 #AP
@@ -736,7 +736,7 @@ armors:
     frontArmor: 50 #90
     sideArmor: 45 #60
     rearArmor: 30 #30
-    underArmor: 25 #20
+    underArmor: 30 #20
     damageModifier:
       - 1.0 #NONE
       - 0.8 #AP passes right through
@@ -793,7 +793,7 @@ armors:
     frontArmor: 60
     sideArmor: 50
     rearArmor: 30
-    underArmor: 20
+    underArmor: 30
     damageModifier:
       - 1.0 #NONE
       - 0.9 #AP

--- a/Ruleset/ADEPTAS/items_adeptas.rul
+++ b/Ruleset/ADEPTAS/items_adeptas.rul
@@ -232,12 +232,14 @@ items:
       ToTime: -1.00
       ToEnergy: -0.8
       ToArmor: 0.00
+      ToTile: 0.00 #this shouldn't blow up cover
+      ToItem: 0.00
     confAimed:
       name: STR_INSPIRE
     costAimed:
       time: 25
       energy: 30
-      stun: 15
+      stun: 20
     accuracyAimed: 100
     accuracyMultiplier:
       firing: 0.0

--- a/Ruleset/ADEPTAS/weapons_adeptas.rul
+++ b/Ruleset/ADEPTAS/weapons_adeptas.rul
@@ -278,6 +278,8 @@ items:
       RandomStun: true
       RandomType: 6 #[0% - 200%]
       FixRadius: 1
+      ToTile: 0.00 #this shouldn't blow up cover
+      ToItem: 0.00
     damageType: 6
     accuracyMultiplier:
       firing: 0.0
@@ -306,6 +308,8 @@ items:
       ToStun: 0.2
       ToWound: 0.0
       ArmorEffectiveness: 0.3
+      ToTile: 0.00 #this shouldn't blow up cover
+      ToItem: 0.00
 
     meleeBonus:
       strength: 0.2

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -3093,11 +3093,13 @@ items:
   - type: REAPER_WEAPON #Juggernaut Bite/Reaper Terrorist Bite
     power: 0
     weight: 0
+    bulletSprite: -1
+    fireSound: {mod: 40k, index: 48}
+    hitAnimation: 2130
     damageType: 7
     accuracyMelee: 100
     tuMelee: 15
-    clipSize: -1
-    battleType: 3
+    battleType: 1
     fixedWeapon: true
     invWidth: 2
     invHeight: 3
@@ -3112,6 +3114,32 @@ items:
       ToWound: 0.5 #rending jaws
       ToEnergy: 0.4
       ArmorEffectiveness: 0.9
+    meleePower: 1
+    meleeType: 7
+    confSnap:
+      name: STR_HALLEBARD_SNAPSHOT_LUNGE
+      shots: 1
+    costSnap:
+      time: 15
+    accuracySnap: 100
+    accuracyMultiplier:
+      firing: 0.0
+      melee: 1
+    skillApplied: true
+    meleeBonus:
+      strength: 1.0 #brute strength
+    meleeAlter: #Crushing, rending jaws
+      ToArmorPre: 0.1
+      ToArmor: 0.2
+      ToMorale: 2.0 #getting maimed by a juggernaut is harrowing
+      ToWound: 0.5 #rending jaws
+      ToEnergy: 0.4
+      ArmorEffectiveness: 0.9
+    snapRange: 2
+    maxRange: 2
+    clipSize: -1
+    powerRangeThreshold: 3
+    powerRangeReduction: 999
     tags: #Rampage mechanics; granting them power as they spill blood for Khorne
       TAG_HP_RETURNED_ON_KILL: 88 #regains 88 HP on kill; Sacred Khorne Number
       TAG_ENERGY_RETURNED_ON_KILL: 88 #regains 88 Energy on kill

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -3192,6 +3192,8 @@ items:
       ToTime: -1.00
       ToHealth: 0.0
       ToWound: 0.0
+      ToTile: 0.00 #this shouldn't blow up cover
+      ToItem: 0.00
       RadiusReduction: 0.0
       FixRadius: 3
     costAimed: # lowered cost
@@ -3276,6 +3278,8 @@ items:
       ToHealth: 0.0
       ToWound: 0.0
       ToArmor: 0.0
+      ToTile: 0.00 #this shouldn't blow up cover
+      ToItem: 0.00
     confAimed:
       name: STR_INSPIRE
     costAimed:

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -1419,6 +1419,8 @@ items:
       ToArmor: 0.0
       ToHealth: 0.0
       ToWound: 0.0
+      ToTile: 0.00 #this shouldn't blow up cover
+      ToItem: 0.00
       RandomWound: false
     confAimed:
       name: STR_INSPIRE


### PR DESCRIPTION
1. Inspire type abilities no longer damage terrain/objects.

2. Juggernaut melee has a Range 1 lunge so it can now attack you up elevators and react attack more readily.

3. Adeptas assassin armors have slightly improved under armor to prevent taking damage from droppods and to equalize it with rear armor.

4. Lead By Example Stun slightly increased to compensate for the massive stamina regeneration it affords.