### PR TITLE
Removed more getOneFree that don't exist

### DIFF
--- a/Ruleset/research_ROSIGMA.rul
+++ b/Ruleset/research_ROSIGMA.rul
@@ -437,9 +437,6 @@ research:
       - STR_ALIEN_ORIGINS
     getOneFree:
       - STR_NURGLE_SOLDIER
-      - STR_HAVOC_NURGLE
-      - STR_NURGLE_SISTER
-      - STR_NURGLE_TERMINATOR
       - STR_NURGLE_CHAMP
   - name: STR_SILACOID_TERRORIST
     cost: 170
@@ -465,8 +462,6 @@ research:
     getOneFree:
       - STR_SLAANESH_SOLDIER
       - STR_DIRE_DAEMONETTE
-      - STR_HAVOC_SLAANESH
-      - STR_CHRYSSALID_TERRORISTSELENE
   - name: STR_REAPER_TERRORIST
     cost: 170
     points: 50


### PR DESCRIPTION
Somebody has to confirm that they were causing crashes. 
I thought that @LeflairKunstler removed all problematic ones, but my game still crashes without removing these.