### PR TITLE
Bug Fixes and Minor Improvements for 2.2A

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -45,7 +45,7 @@ en-US:
   STR_FINAL_BASE_: "EYE OF THE STORM"
   STR_BOLTERR: "Rubric Inferno Bolter"
   STR_RIFLE_CLIP_R: "Rubric Bolter Clip"
-  
+
   STR_ALIEN_ABDUCTION: "Slave Raid"
   STR_ALIEN_ABDUCTION_UFOPEDIA: "{NEWLINE} The Chaos forces seek ever fresh victims to be consumed in Heretek factorums or in dark rituals, creating battle servitors and summoning worse horrors yet. {NEWLINE} {NEWLINE} Increased Chaos incursions bring with them ever larger slave raids, stealing with them entire able bodied populations. These Imperials belong to the Master of Mankind! And The Adeptus Ministorum will not long tolerate the loss of imperial tithe, by bolter and chainsword, bring an end to this theft!"
 
@@ -3185,8 +3185,8 @@ en-US:
   STR_BASIC_SENTINEL: "Guard Basic Sentinels"
   STR_BASIC_SENTINEL_MISSILE: "Sentinels/Missile"
 
-
-
+  STR_CHAOS_SENTINEL_SUPERFRAG_ROCKET_POD: "Chaos Sentinel Superfrag Rocket Pod"
+  STR_CHAOS_SENTINEL_HB: "Chaos Sentinel Heavy Bolter"
 
 ## Skills
 
@@ -3887,8 +3887,20 @@ en-US:
   STR_FLAMETHROWER_CLIP: "Flamer Chemical Fuel"
   STR_FLAMETHROWER_PROMETHIUM_CLIP: "Flamer Promethium Fuel"
 
+# grenade activation/deactivation messages/text
+  STR_PRIME_BEACON: "Activate Orbital Beacon"
+  STR_PRIME_BEACON_MESSAGE: "Orbital beacon activated!"
+  STR_UNPRIME_BEACON: "Deactivate Orbital Beacon"
+
   STR_UNPRIME_GRENADE: "Unprime Grenade"
-  STR_UNPRIME_CHARGE: "Unprime Charge"
+
+  STR_PRIME_CHARGE: "Prime Explosive Charge"
+  STR_PRIME_CHARGE_MESSAGE: "Explosive charge activated! Warning! Will detonate while held!"
+  STR_UNPRIME_CHARGE: "Unprime Explosive Charge"
+
+  STR_PRIME_SKULL: "Activate Servo Skull"
+  STR_PRIME_SKULL_MESSAGE: "Servo Skull activated!"
+  STR_UNPRIME_SKULL: "Deactivate Servo Skull"
 
 # missions
   STR_HARDER_MISSIONS: "(Harder Missions)"

--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -6731,6 +6731,7 @@ units:
     intelligence: 2
     aggression: 2
     spotter: 2
+    sniper: 50
     energyRecovery: 80
 
   - type: STR_BLACKSTONE_STORMTROOPER                                          # RANK 5 weapons done

--- a/Ruleset/BALANCE/explosives.rul
+++ b/Ruleset/BALANCE/explosives.rul
@@ -422,8 +422,12 @@ items:
       ToHealth: 0.7
 
   - type: STR_HIGH_EXPLOSIVE #melta bomb    4009 #melta munition
+    primeActionName: STR_PRIME_CHARGE
+    primeActionMessage: STR_PRIME_CHARGE_MESSAGE
+    unprimeActionName: STR_UNPRIME_CHARGE
     throwRange: 10
     primeSound: 2425
+    weight: 30 #heavy; this is an explosive charge
     costThrow:
       energy: 40
       time: 80
@@ -432,12 +436,12 @@ items:
     costUnprime:
       time: 20
     isExplodingInHands: true
-    unprimeActionName: STR_UNPRIME_CHARGE
     flatPrime:
       time: false
       energy: true
     power: 200 #deadly
     damageAlter:
+      FireThreshold: 0 #even if it doesn't penetrate your armor you're still gonna burn alright
       ResistType: 11
       RandomType: 6
       ToArmorPre: 1.0
@@ -585,6 +589,7 @@ items:
     clipSize: 6
 
   - type: STR_HOLOGRAM_GRENADE
+    unprimeActionName: STR_UNPRIME_GRENADE
     throwRange: 18
     primeSound: 2425
     weight: 2
@@ -595,13 +600,13 @@ items:
       time: 30
     costUnprime:
       time: 15
-    unprimeActionName: STR_UNPRIME_GRENADE
     flatPrime:
       time: false
       energy: true
 
 
   - type: STR_SMOKE_BOMB
+    unprimeActionName: STR_UNPRIME_CHARGE
     throwRange: 10
     primeSound: 2425
     costThrow:
@@ -612,13 +617,13 @@ items:
     costUnprime:
       time: 20
     isExplodingInHands: true
-    unprimeActionName: STR_UNPRIME_CHARGE
     flatPrime:
       time: false
       energy: true
 
 
   - type: STR_PROXIMITY_GRENADE
+    unprimeActionName: STR_UNPRIME_GRENADE
     throwRange: 15
     primeSound: 2425
     weight: 3
@@ -629,7 +634,6 @@ items:
       time: 30
     costUnprime:
       time: 15
-    unprimeActionName: STR_UNPRIME_GRENADE
     flatPrime:
       time: false
       energy: true
@@ -647,8 +651,12 @@ items:
 
 
   - type: STR_GK_SPAWNER
+    primeActionName: STR_PRIME_BEACON
+    primeActionMessage: STR_PRIME_BEACON_MESSAGE
+    unprimeActionName: STR_UNPRIME_BEACON
     throwRange: 10
     primeSound: 2425
+    weight: 30 #heavy; it's a support beacon
     costThrow:
       energy: 40
       time: 80
@@ -657,7 +665,24 @@ items:
     costUnprime:
       time: 20
     isExplodingInHands: true
-    unprimeActionName: STR_UNPRIME_CHARGE
+    flatPrime:
+      time: false
+      energy: true
+
+  - type: STR_SKULL_SPAWNER
+    primeActionName: STR_PRIME_SKULL
+    primeActionMessage: STR_PRIME_SKULL_MESSAGE
+    unprimeActionName: STR_UNPRIME_SKULL
+    primeSound: 2425
+    throwRange: 18
+    weight: 2
+    costThrow:
+      energy: 5
+      time: 30
+    costPrime:
+      time: 30
+    costUnprime:
+      time: 15
     flatPrime:
       time: false
       energy: true

--- a/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
+++ b/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
@@ -102,7 +102,7 @@ armors:
     allowsKneeling: false
     allowsRunning: false
     allowsMoving: false
-    
+
   - type: STR_CHAOS_HERETEK_ARMOR
     visibilityAtDay: 40
     visibilityAtDark: 25 #night vision augmented
@@ -661,6 +661,9 @@ armors:
       - 0.0 #SMOKE
       - 0.2 #IMPACT
       - 1.2 #MELTA
+    builtInWeapons:
+      - STR_CHAOS_SENTINEL_SUPERFRAG_ROCKET_POD
+      - AUX_SENTINEL_STOMP
 
   - type: SNAKEMAN_TURRET
     scripts:

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -5694,11 +5694,11 @@ items:
 
   - type: STR_CHAOS_SENTINEL_SUPERFRAG_ROCKET_POD
     weight: 0
-    bigSprite: 813
+    bigSprite: {mod: 40k, index: 813}
     floorSprite: 0
     handSprite: 0
     bulletSprite: 0
-    fireSound: 52
+    fireSound: {mod: 40k, index: 52}
     dropoff: 4
     accuracyAimed: 150 #laser guided
     tuAimed: 75

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -5637,3 +5637,101 @@ items:
       STR_DESERTER_SCOUT_FEMALE_ARMOR: STR_NURGLE_CULTIST_FEM,
       STR_DESERTER_GUARD_OFFICER_ARMOR: STR_NURGLE_CULTIST_FEM
     }
+
+
+  - type: STR_CHAOS_SENTINEL_HB #Chaos sentinel heavybolter               12000
+    categories: [STR_CAT_BOLTER, STR_CAT_DEVASTATOR]
+    size: 0.1
+    requires:
+      - STR_ALIENS_ONLY
+    dropoff: 4
+    weight: 40
+    bigSprite: 2800
+    bulletSprite: 6
+    fireSound: 2138
+    accuracyAimed: 0
+    accuracySnap: 70 #semi-mounted
+    accuracyAuto: 60 #semi-mounted
+    tuAimed: 0
+    tuSnap: 30 #not great reactions, melee should be viable against it
+    tuAuto: 40 #only two auto fire per turn
+    snapRange: 20 #mounted + AI bonus
+    autoRange: 14 #consider accuracy and skill of wielder + autoshot number, will be plenty dangerous up to 20 tiles out
+    autoShots: 7
+    sprayWaypoints: 2
+    bulletSpeed: 50
+    clipSize: -1
+    confSnap:
+      name: STR_BURST_SNAP_SHOT
+      arcing: false
+      shots: 3 #Three shot burst
+    hitSound: {mod: 40k, index: 708}
+    hitAnimation: {mod: 40k, index: 0}
+    power: 80 #Slightly stronger for anti armor but weaker vs health
+    damageType: 3
+    damageAlter:
+      ResistType: 1
+      RandomType: 6 #gaussian
+      FixRadius: 2
+      ToArmorPre: 0.2 #HEAT/Krak rounds
+      ArmorEffectiveness: 0.7 #HEAT/Krak rounds
+      ToArmor: 0.2 #HEAT/Krak rounds
+      ToHealth: 0.8 #HEAT/Krak rounds
+      ToTile: 1.0
+      ToItem: 1.0
+    explosionSpeed: 5
+    powerForAnimation: 5
+    battleType: 1
+    twoHanded: false
+    blockBothHands: false
+    invWidth: 2
+    invHeight: 3
+    armor: 200
+    attraction: 4
+    fixedWeapon: true
+    recover: false
+
+
+  - type: STR_CHAOS_SENTINEL_SUPERFRAG_ROCKET_POD
+    weight: 0
+    bigSprite: 813
+    floorSprite: 0
+    handSprite: 0
+    bulletSprite: 0
+    fireSound: 52
+    dropoff: 4
+    accuracyAimed: 150 #laser guided
+    tuAimed: 75
+    accuracySnap: 80
+    tuSnap: 30
+    accuracyAuto: 50
+    tuAuto: 35
+    confAuto: #barrage mode
+      shots: 4
+      arcing: true
+    aimRange: 25
+    snapRange: 20
+    autoRange: 15
+    battleType: 1
+    fixedWeapon: true
+    invWidth: 2
+    invHeight: 3
+    hitSound: 0
+    hitAnimation: 0
+    clipSize: 40
+    recover: false
+    power: 100
+    damageType: 1 #frag munition
+    damageAlter:
+      FixRadius: 6
+      ToArmorPre: 0.05 #small ablation
+      ArmorEffectiveness: 1.1 #concussive + shrapnel everywhere
+      ToHealth: 0.7 #much damage dealt in the form of debuffs
+      ToTime: 0.2 #painful
+      ToStun: 0.4 #painful
+      ToMorale: 0.5 #painful
+      ToEnergy: 0.4 #painful
+      ToWound: 0.4 #shrapnel
+      RandomWound: false
+      ToTile: 0.25 #it's shrapnel; deals relatively little damage to the terrain.
+      ToItem: 0.25 #it's shrapnel; deals relatively little damage to items.

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -846,58 +846,6 @@ items:
     fixedWeaponShow: true #armor attached specialWeapon
     listOrder: 10761
 
-  - type: STR_HAND_MULTILASER_PAI #Inquisition version, for the codex to function
-    categories: [STR_CAT_LASGUN, STR_CAT_TACTICAL]
-    size: 0.2
-    dropoff: 5 #worse than Hotshot Volleygun
-    #requiresBuy: #armor attached specialWeapon, the armor is bought with the gun
-      #- STR_CHAMBERMILITANT
-      #- STR_MT_GK #Midtier Inquisition #Guard gets a manufacturing option
-    #costBuy: 1000000 #more than double initial cost vs rotor cannon, but no ammo cost
-    #costSell: 150000
-    weight: 45 #Inq version is slightly lighter, used by storm troopers, still gets integrated power and what not.
-    bigSprite: 910 #multilaser black
-    floorSprite: 922
-    handSprite: 650
-    bulletSprite: {mod: 40k, index: 12}
-    bulletSpeed: 50
-    fireSound: {mod: 40k, index: 741}
-    hitSound: {mod: 40k, index: 19}
-    hitAnimation: {mod: 40k, index: 36}
-    battleType: 1
-    twoHanded: true
-    blockBothHands: true
-    invWidth: 2
-    invHeight: 3
-    armor: 200
-    accuracySnap: 0 #60 # 40k 70
-    accuracyAuto: 45 # -5 vs volleygun, +5 vs rotorcannon
-    accuracyAimed: 0
-    tuSnap: 0 #30
-    tuAuto: 70
-    tuAimed: 0
-    autoShots: 12 #-3 vs Rotorcannon, +5 vs volleygun
-    autoRange: 11 #Hellgun +2
-    snapRange: 0 #16
-    aimRange: 0
-    clipSize: -1 #infinite ammo is a boon vs rotorcannon
-    power: 60 #-5 vs Hotshot volleygun, higher ROF instead
-    damageType: 1 # AP instead of LAS
-    damageAlter: #Hotshot
-      ToArmorPre: 0.3
-      ArmorEffectiveness: 0.75
-      ToHealth: 1.0
-      ToArmor: 0.1 # 40k 0.0
-      ToStun: 0.3 #painful las burns
-      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
-      RandomWound: false
-    followProjectiles: false   # the camera stays still while shooting (prevents minigun seizures)
-    sprayWaypoints: 2
-    recover: false #armor attached specialWeapon
-    fixedWeapon: true #armor attached specialWeapon
-    fixedWeaponShow: true #armor attached specialWeapon
-    listOrder: 10761
-
   - type: STR_ROTOR_CANNON
     categories: [STR_CAT_AUTO]
 #    requiresBuy:

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -94,7 +94,7 @@ items:
       - STR_DEATHWATCH
     bigSprite: 2010 #artifex boltgun bigob
     floorSprite: 210 #red
-    handSprite: 3020
+    handSprite: 700
     size: 0.3
     dropoff: 5
     costBuy: 10000
@@ -801,7 +801,7 @@ items:
     weight: 9
     bigSprite: 2510
     floorSprite: 2510
-    handSprite: 3000
+    handSprite: 703
     fireSound: 2261 #chunky Nihilus sound
     hitSound: {mod: 40k, index: 19}
     bulletSprite: {mod: 40k, index: 12}
@@ -863,6 +863,62 @@ items:
       ITEM_SNAP_FLAT_POWER_BONUS: 10 #INQ BONUS
       ITEM_AIMED_FLAT_POWER_BONUS: 20 #INQ BONUS
 
+  - type: STR_HAND_MULTILASER_PAI #Inquisition version, for the codex to function
+    categories: [STR_CAT_LASGUN, STR_CAT_TACTICAL]
+    size: 0.2
+    dropoff: 5 #worse than Hotshot Volleygun
+    #requiresBuy: #armor attached specialWeapon, the armor is bought with the gun
+      #- STR_CHAMBERMILITANT
+      #- STR_MT_GK #Midtier Inquisition #Guard gets a manufacturing option
+    #costBuy: 1000000 #more than double initial cost vs rotor cannon, but no ammo cost
+    #costSell: 150000
+    weight: 45 #Inq version is slightly lighter, used by storm troopers, still gets integrated power and what not.
+    bigSprite: 910 #multilaser black
+    floorSprite: 922
+    handSprite: 650
+    bulletSprite: {mod: 40k, index: 12}
+    bulletSpeed: 100
+    fireSound: {mod: 40k, index: 741}
+    hitSound: {mod: 40k, index: 19}
+    hitAnimation: {mod: 40k, index: 36}
+    battleType: 1
+    twoHanded: true
+    blockBothHands: true
+    invWidth: 2
+    invHeight: 3
+    armor: 200
+    accuracySnap: 55
+    accuracyAuto: 45 # -5 vs volleygun, +5 vs rotorcannon
+    accuracyAimed: 0
+    tuSnap: 35
+    tuAuto: 45
+    tuAimed: 0
+    confSnap: #3 shot burst
+      shots: 3
+      name: STR_BURST_SNAP_SHOT
+      arcing: false
+    autoShots: 12 #-3 vs Rotorcannon, +5 vs volleygun
+    autoRange: 12 #Hellgun +2
+    snapRange: 15
+    aimRange: 0
+    clipSize: -1 #infinite ammo is a boon vs rotorcannon
+    kneelBonus: 150 #big accuracy benefit from deploying
+    power: 60 #-5 vs Hotshot volleygun, higher ROF instead
+    damageType: 1 # AP instead of LAS
+    damageAlter: #Hotshot
+      ToArmorPre: 0.3
+      ArmorEffectiveness: 0.75
+      ToHealth: 1.0
+      ToArmor: 0.1 # 40k 0.0
+      ToStun: 0.3 #painful las burns
+      ToWound: 0.05 #cauterizes, but there's still explosive thermal expansion of tissues; melta level wounding
+      RandomWound: false
+    sprayWaypoints: 2
+    recover: false #armor attached specialWeapon
+    fixedWeapon: true #armor attached specialWeapon
+    fixedWeaponShow: true #armor attached specialWeapon
+    listOrder: 10761
+
   - type: STR_INQ_FLAMER #Special Inquisition Stormtrooper only flamer
     categories: [ STR_CAT_FLAMER, STR_CAT_TACTICAL]
     weight: 10
@@ -870,7 +926,7 @@ items:
     vaporDensitySurface: 4
     vaporProbabilitySurface: 100
     bigSprite: 1013
-    handSprite: 3022
+    handSprite: 702
     bulletSprite: {mod: 40k, index: 5}
     fireSound: {mod: 40k, index: 706}
     accuracySnap: 70
@@ -888,6 +944,8 @@ items:
     autoShots: 6
     confSnap: #Double Shot
       shots: 2
+      name: STR_BURST_SNAP_SHOT
+      arcing: true
     hitSound: {mod: 40k, index: 12}
     hitAnimation: {mod: 40k, index: 88} #XFIRE
     power: 60
@@ -926,7 +984,7 @@ items:
       RandomWound: false
     meleeBonus:
       psiSkill: 0.2 #consecrated weapon
-      strength: 0.3 #heavy weapon; biased towards strength over skill
+      strength: 0.2 #heavy weapon; biased towards strength over skill
       melee: 0.1
     clipSize: -1
     bulletSpeed: 50
@@ -944,7 +1002,7 @@ items:
     weight: 10
     fireSound: 2261 #chunky Nihilus sound
     bigSprite: 1011
-    handSprite: 3023
+    handSprite: 704
     hitSound: {mod: 40k, index: 19}
     bulletSprite: {mod: 40k, index: 12}
     bulletSpeed: 50
@@ -1012,8 +1070,9 @@ items:
     tuSnap: 33
     tuAimed: 33 #Maximal Shot
     confSnap:
-      name: STR_BURST_SNAP_SHOT
       shots: 2
+      name: STR_BURST_SNAP_SHOT
+      arcing: false
     confAimed: #Maximal Shot
       name: STR_MAXIMAL_SHOT
       spendPerShot: 4 #more powerful focused shot that creates more heat
@@ -1021,6 +1080,7 @@ items:
     power: 110 #75 #*** PLASMA rebalance
     damageType: 5
     damageAlter: #DA PLASMA
+      RandomType: 6
       ArmorEffectiveness: 0.75 #*** PLASMA rebalance
       ToArmorPre: 0.1
       ToArmor: 0.2
@@ -1031,6 +1091,8 @@ items:
     twoHanded: true
     blockBothHands: true
     listOrder: 10765
+    tags:
+      ITEM_AIMED_FLAT_POWER_BONUS: 50 #Overcharged
 
   - type: STR_INQ_MULTIMELTA #Inquisition Multimelta
     categories: [STR_CAT_MELTA, STR_CAT_DEVASTATOR]
@@ -1038,8 +1100,10 @@ items:
     weight: 20
     accuracySnap: 90
     tuSnap: 45
-    confSnap:
+    confSnap: #Double Shot
       shots: 2
+      name: STR_BURST_SNAP_SHOT
+      arcing: false
     snapRange: 16 #+2 over base
     accuracyAuto: 60
     tuAuto: 60

--- a/Ruleset/extraSprites_HANDOB.rul
+++ b/Ruleset/extraSprites_HANDOB.rul
@@ -55,6 +55,13 @@ extraSprites:
       660: Resources/Handobs/HANDOBS_LASGUN_ESCHER.png
       668: Resources/Handobs/HANDOB_STUBCANNON_GUARD.png
       669: Resources/Handobs/handob_riot_shield.png #from Arbites mod
+#Inquisition Weapons
+      700: Resources/Bolter/HANDOB_BOLTGUN_ARTIFEX.png
+      701: Resources/Handobs/HANDOB_INQ_FLAMER.png
+      702: Resources/Handobs/HANDOB_INQ_FLAMER_CHAINSWORD.png
+      703: Resources/Handobs/HANDOB_INQ_HELLGUN.png
+      704: Resources/Handobs/HANDOB_INQ_LONGHELLGUN.png
+
 
 #ADEPTAS EXTRA
       752: Resources/Bolter/752.png #restores blue ultra handob
@@ -131,7 +138,7 @@ extraSprites:
       2740: Resources/longlas/handob_longlas_deserter.png
       2750: Resources/Grenade/SCAREGRENADE_HANDOB.png
       2880: Resources/Handobs/HANDOB_IW_AUTOCANNON.png
- #Tzeentch Weapons
+#Tzeentch Weapons
       2900: Resources/TzeentchWeapons/TZEENTCH_NIHILIUS_LASPISTOL_HANDOB.png
       2910: Resources/TzeentchWeapons/TZEENTCH_NIHILIS_LASGUN_HANDOB.png
       2920: Resources/TzeentchWeapons/longlas_tzeentch_handob.png
@@ -140,12 +147,6 @@ extraSprites:
       2950: Resources/TzeentchWeapons/TZEENTCH_LBOLTERSOLO_SCOPED_HANDOB.png
       2960: Resources/TzeentchWeapons/TZEENTCH_PLASMAPISTOL_HANDOB.png
       2970: Resources/TzeentchWeapons/TZEENTCH_BATTLE_PLASMA_HANDOB.png
-#Inquisition Weapons
-      3000: Resources/Handobs/HANDOB_INQ_HELLGUN.png
-      3020: Resources/Bolter/HANDOB_BOLTGUN_ARTIFEX.png
-      3021: Resources/Handobs/HANDOB_INQ_FLAMER.png
-      3022: Resources/Handobs/HANDOB_INQ_FLAMER_CHAINSWORD.png
-      3023: Resources/Handobs/HANDOB_INQ_LONGHELLGUN.png
 
 #GENE TYRANID Weapons
       3400: Resources/FOES/HANDOB_AUTOSTUB_KELER.png

--- a/Ruleset/scripts/scripts_damage_feedback.rul
+++ b/Ruleset/scripts/scripts_damage_feedback.rul
@@ -11,13 +11,15 @@ extended:
     # hitUnit required to find side hit
     # Otherwise we cannot get the armor value delta
     hitUnit:
-    - offset: 20
-      code: |
-        var int unit_id;
-        unit.getId unit_id;
-        return power part side;
+      - new: ROSIGMA_hU_damage_feedback
+        offset: 20
+        code: |
+          var int unit_id;
+          unit.getId unit_id;
+          return power part side;
     damageUnit:
-      - offset: 20
+      - new: ROSIGMA_dU_damage_feedback
+        offset: 20
         code: |
           var int temp;
           var int unit_id;


### PR DESCRIPTION
1. Added more language lines to grenade priming/unpriming for clarity/QoL.

2. Beacons and Melta Bombs now weight 30 pounds; these are not meant to be combat grenades.

3. Moved the Inq Multilaser to the Inquisition Stormtrooper weapon section; slightly improved its autofire, gave it a 33% TU 3 shot burst snap, and greatly increased its kneel bonus. This weapon benefits most from setting up a static emplacement with it.

4. Fixed hand sprite issues with the Inquisitorial Flamer.

5. Standardized the Servo Skull to be compliant with baseline grenade stats.

6. Named the damage indicator scripts.

7. Added missing overcharge damage bonus to Inquisition Plasma Rifle

8. Gave Chaos Sentinels a dumbfire rocket pod that fires superfrag missiles; hopefully this will fix its passivity issues.