### PR TITLE
Fixes Chaos Sentinel; Tweaks Weapons

### DIFF
--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -6711,6 +6711,7 @@ units:
             - STR_CSERVITOR_MIKRAK_AMMO #Missile Massacre "KRAK" rounds
           - - STR_CSERVITOR_MILAUNCHER #Chaos servitor MISSILE LAUNCHER
             - STR_CSERVITOR_MIMELTA_AMMO #Missile Massacre "MELTA" rounds
+
   - type: STR_SNAKEMAN_SENTINEL                                         # RANK 7
     race: STR_SNAKEMAN
     rank: STR_LIVE_TERRORIST
@@ -6725,7 +6726,7 @@ units:
       strength: 100
       psiStrength: 50
       psiSkill: 0
-      melee: 0
+      melee: 50
     armor: STR_CHAOS_SENTINEL_ARMOR
     deathSound: {mod: 40k, index: 23}
     intelligence: 2
@@ -6733,6 +6734,14 @@ units:
     spotter: 2
     sniper: 50
     energyRecovery: 80
+    livingWeapon: true
+    builtInWeaponSets:
+      - - STR_CHAOS_SENTINEL_SUPERFRAG_ROCKET_POD
+        - AUX_CHAOS_SENTINEL_STOMP
+      - - STR_CHAOS_SENTINEL_GUIDED_HE_ROCKET_POD
+        - AUX_CHAOS_SENTINEL_STOMP
+      - - STR_CHAOS_SENTINEL_KRAK_ROCKET_POD
+        - AUX_CHAOS_SENTINEL_STOMP
 
   - type: STR_BLACKSTONE_STORMTROOPER                                          # RANK 5 weapons done
     race: STR_SNAKEMAN

--- a/Ruleset/ENEMY/GENE/weapons_gene.rul
+++ b/Ruleset/ENEMY/GENE/weapons_gene.rul
@@ -165,7 +165,7 @@ items:
     aimRange: 25
     damageType: 8 #acid
     damageAlter:
-      ArmorEffectiveness: 0.6 #low power but high penetration
+      ArmorEffectiveness: 0.5 #low power but high penetration
       ToHealth: 0.7
       ToWound: 0.05
       ToArmor: 0.05

--- a/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
+++ b/Ruleset/ENEMY/TRAITOR_GUARD/armors_traitor_guard.rul
@@ -662,8 +662,8 @@ armors:
       - 0.2 #IMPACT
       - 1.2 #MELTA
     builtInWeapons:
-      - STR_CHAOS_SENTINEL_SUPERFRAG_ROCKET_POD
-      - AUX_SENTINEL_STOMP
+      - INV_NULL_2X1_RL
+      - INV_NULL_2X1_LL
 
   - type: SNAKEMAN_TURRET
     scripts:

--- a/Ruleset/ENEMY/weapons_chaos.rul
+++ b/Ruleset/ENEMY/weapons_chaos.rul
@@ -5735,3 +5735,106 @@ items:
       RandomWound: false
       ToTile: 0.25 #it's shrapnel; deals relatively little damage to the terrain.
       ToItem: 0.25 #it's shrapnel; deals relatively little damage to items.
+
+  - type: STR_CHAOS_SENTINEL_KRAK_ROCKET_POD
+    weight: 0
+    bigSprite: {mod: 40k, index: 813}
+    floorSprite: 0
+    handSprite: 0
+    bulletSprite: 0
+    fireSound: {mod: 40k, index: 52}
+    dropoff: 4
+    accuracyAimed: 200 #laser guided; more accurate than the frag launcher
+    tuAimed: 75
+    accuracySnap: 100
+    tuSnap: 30
+    accuracyAuto: 75
+    tuAuto: 35
+    confAuto: #barrage mode
+      shots: 4
+      arcing: true
+    aimRange: 25
+    snapRange: 20
+    autoRange: 15
+    battleType: 1
+    fixedWeapon: true
+    invWidth: 2
+    invHeight: 3
+    hitSound: 0
+    hitAnimation: 0
+    clipSize: 40
+    recover: false
+    power: 100
+    damageType: 3 # inherit from HE
+    damageAlter:
+      ResistType: 1
+      RandomType: 6 #gaussian
+      ToHealth: 0.8
+      ToArmorPre: 0.3
+      ToArmor: 0.3
+      ArmorEffectiveness: 0.7
+      ToTile: 1.0
+      ToItem: 1.0
+      FixRadius: 2
+    powerForAnimation: 5 # 5 / 5 = 1
+
+  - type: STR_CHAOS_SENTINEL_GUIDED_HE_ROCKET_POD
+    weight: 0
+    bigSprite: {mod: 40k, index: 813}
+    floorSprite: 0
+    handSprite: 0
+    bulletSprite: 0
+    fireSound: {mod: 40k, index: 52}
+    dropoff: 4
+    accuracyAimed: 200 #laser guided + smart ammo
+    tuAimed: 60
+    aimRange: 30
+    battleType: 1
+    fixedWeapon: true
+    waypoints: 5
+    invWidth: 2
+    invHeight: 3
+    hitSound: 0
+    hitAnimation: 0
+    clipSize: 40
+    recover: false
+    power: 110
+    damageType: 3
+    damageAlter: #high explosive
+      ToArmorPre: 0.1
+      RandomType: 6
+      ArmorEffectiveness: 0.9 #concussive
+      ToStun: 0.6 #concussive
+      ToEnergy: 0.4 #concussive
+      ToTime: 0.3 #concussive
+      ToTile: 0.75 #high explosive
+      ToItem: 0.75 #high explosive
+      FixRadius: 5 #1 for hand grenade version
+    powerForAnimation: 5 # 5 / 5 = 1
+
+
+
+  - type: AUX_CHAOS_SENTINEL_STOMP #removing the stomp aoe because it doesn't play nicely with its other weapons
+    weight: 0
+    confMelee:
+      name: STR_STOMP
+    bigSprite: {mod: 40k, index: 358}
+    meleeSound: {mod: 40k, index: 754}
+    meleeHitSound: {mod: 40k, index: 700}
+    meleeAnimation: 0
+    power: 80
+    damageAlter:
+      ArmorEffectiveness: 0.75
+      RandomType: 2 #TFTD [50% - 150%]
+    damageType: 7
+    accuracyMelee: 150
+    tuMelee: 30
+    clipSize: -1
+    battleType: 3
+    twoHanded: false
+    invWidth: 2
+    invHeight: 3
+    fixedWeapon: true
+    recover: false
+    skillApplied: false
+    strengthApplied: false

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -2164,13 +2164,15 @@ items:
     handSprite: { mod: 40k, index: 352 } #Needs new
     power: 100
     damageType: 3
-    damageAlter:
+    damageAlter: #high explosive
+      ToArmorPre: 0.1
+      RandomType: 6
       ArmorEffectiveness: 0.9 #concussive
       ToStun: 0.6 #concussive
       ToEnergy: 0.4 #concussive
       ToTime: 0.3 #concussive
-      ToTile: 1.0 #high explosive
-      ToItem: 1.0 #high explosive
+      ToTile: 0.75 #high explosive
+      ToItem: 0.75 #high explosive
       FixRadius: 5 #1 for hand grenade version
     clipSize: 1
     battleType: 2


### PR DESCRIPTION
1. Fixes Chaos Sentinels not using their main guns (it prioritized the short range stomp over all other weapons).

2. Adds the Superfrag, Krak and Guided HE launchers for the Chaos Sentinel.

3. HE heavy explosives have minor pre-armor ablation now.

4. Improved GSC Needler penetration slightly.

5. Gave Sentinel the Sniper 50 AI property so it can take advantage of friendly spotters.