### PR TITLE
Added Anti-Dodge Tags; Minor Balance Tweaks/Fixes

### DIFF
--- a/Ruleset/BALANCE/explosives.rul
+++ b/Ruleset/BALANCE/explosives.rul
@@ -377,10 +377,9 @@ items:
 ## PLASMA
 
   - type: STR_ELDAR_GRENADE #Eldar Granade          16320
-    weight: 3
+    weight: 2
     primeSound: 2426
     throwRange: 18
-    weight: 2
     costThrow:
       energy: 5
       time: 30

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -1715,16 +1715,17 @@ armors:
     loftempsSet: [ 3 ]
 
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 35
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 10
+    heatVision: 50
     frontArmor: 30
     sideArmor: 20
     rearArmor: 15
     underArmor: 15
     stats:
-       tu: 5
-       stamina: 15
+      tu: 5
+      stamina: 15
     damageModifier: #GUARD ARMOR
       - 1.0 #none
       - 1.0 #AP

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -2063,7 +2063,7 @@ items:
       ITEM_POWER_BONUS_PERCENTILE: 1 #use %
       ITEM_COLOR_CHANGES_WITH_AMMO_NON_GRAY: 6
       ITEM_IS_HEAVY_WEAPON: 1
-
+      DODGE_CHANCE_FLAT_REDUCTION: 100 #it's impossible to dodge a Vindicare's shot; forget it
 
   - &STR_EXITUS_BULLETS
     type: STR_EXITUS_AMMO
@@ -2140,7 +2140,7 @@ items:
       - STR_MORTAR_AMMO_FRAG
     accuracyAimed: 30 #was 50, reduced for the waypoint system
     tuLoad: 30 #a bit of work to reload
-    tuAimed: 55 #two grenades per turn+some turn adjustment, or reload cost?
+    tuAimed: 50 #two grenades per turn+some turn adjustment, or reload cost?
     reloadSound: 2427
     autoRange: 0
     snapRange: 0 #no snap, to prevent reactions

--- a/Ruleset/scripts/scripts_heavy_weapon_teams.rul
+++ b/Ruleset/scripts/scripts_heavy_weapon_teams.rul
@@ -29,7 +29,6 @@ extended:
           # if bipod is not deployed and wielder has not enough strength
           if and eq bipod 1 eq deploy 0 lt strength weight;
             set bonus 0;
-            if
           end;
 
           return bonus;

--- a/Ruleset/scripts/scripts_ranged_dodge.rul
+++ b/Ruleset/scripts/scripts_ranged_dodge.rul
@@ -14,6 +14,9 @@ extended:
       DODGE_CHANCE: int
       FLIGHT_DODGE_CHANCE: int
       ARMOR_MAX_SUCCESSFUL_DODGES: int
+    RuleItem:
+      DODGE_CHANCE_FLAT_REDUCTION: int
+      DODGE_CHANCE_PERCENT_REDUCTION: int
 
 armors:
   - &STR_DODGE_ARMOR
@@ -47,6 +50,8 @@ armors:
         var int attackerDirection;
         var int counterSuccessfulDodges;
         var int maxSuccessfulDodges;
+        var int dodgeFlatReduction;
+        var int dodgePercentReduction;
 
         damaging_item.getRuleItem damagingItem;
         damagingItem.getDamageType damageType;
@@ -56,6 +61,12 @@ armors:
         # don't dodge when counter has reached max;
         unit.getTag counterSuccessfulDodges Tag.UNIT_COUNTER_SUCCESSFUL_DODGES;
         targetArmor.getTag maxSuccessfulDodges Tag.ARMOR_MAX_SUCCESSFUL_DODGES;
+        damagingItem.getTag dodgeFlatReduction Tag.DODGE_CHANCE_FLAT_REDUCTION;
+        damagingItem.getTag dodgePercentReduction Tag.DODGE_CHANCE_PERCENT_REDUCTION;
+
+        if or ge dodgeFlatReduction 100 ge dodgePercentReduction 100; #these weapons are undodgable
+          return power part side;
+        end;
 
         # assume that setting it has been forgotten
         if eq maxSuccessfulDodges 0;
@@ -102,9 +113,21 @@ armors:
         # debug_log "dodgeChance" dodgeChance;
 
         if gt isAoE 0;
-            set randomNumber 200; # always hit # 200 > 100
+          # debug_log "Attack is an AoE and cannot be dodged.";
+          return power part side;
         end;
 
+        #reduce the dodge chance by the dodgeFlatReduction amount
+        sub dodgeChance dodgeFlatReduction;
+        if le dodgeChance 0;
+          # debug_log "Dodge chance reduced to 0 by dodgeFlatReduction property.";
+          return power part side;
+        end;
+
+        #invert the dodgePercentReduction and multiply with the dodgeChance to get a % chance reduction
+        sub dodgePercentReduction 100;
+        mul dodgePercentReduction -1;
+        muldiv dodgeChance dodgePercentReduction 100;
 
         unit.getDirection unitDirection; # {0-7}
         attacker.getDirection attackerDirection;
@@ -166,6 +189,12 @@ armors:
     tags:
       DODGE_CHANCE: 33
       ARMOR_MAX_SUCCESSFUL_DODGES: 3
+
+  - type: STR_GUARD_IMPERIAL_ASSASSIN_UC #Vindicare are proper Temple assassins; they can dodge more than worth a damn; invul 4+ baby
+    refNode: *STR_DODGE_ARMOR
+    tags:
+      DODGE_CHANCE: 50
+      ARMOR_MAX_SUCCESSFUL_DODGES: 4
 
   - type: STR_ADEPTAS_ARMORR_UC
     refNode: *STR_DODGE_ARMOR


### PR DESCRIPTION
1. Added infrastructure for Flat and Percentile dodge reduction tags.

2. Exitus Rifle has 100% dodge reduction; no one can dodge a Vindicare.

3. Vindicare Assassin now has 50% dodge with 4 dodges; he's a proper temple assassin with Invul 4+.

4. Removed copy pasta from Eldar Grenade.

5. Slightly reduced the aimed shot cost of the Heavy Mortar from 55% of TUs to 50%.