### PR TITLE
Vindicare Rebalance

### DIFF
--- a/Ruleset/BALANCE/ballistics_ammo.rul
+++ b/Ruleset/BALANCE/ballistics_ammo.rul
@@ -390,12 +390,12 @@ items:
   - &STR_EXITUS_BULLETS
     type: STR_EXITUS_AMMO
     power: 150
+    damageType: 1
     damageAlter:
       ToTile: 0.0
       ToArmorPre: 0.1 #high velocity
       RandomType: 6
       ArmorEffectiveness: 0.8
-    damageType: 1
     clipSize: 2
 
   - type: STR_EXITUS_AMMO_HELLFIRE # attacks twice by being HE
@@ -409,13 +409,13 @@ items:
       ToStun: 0.5 #painful
       ToWound: 0.5 #acid and armor piercing needles cause lots of mortal wounds
       ToMorale: 2.0 #painful
-#      ToStun: 0.5
-    blastRadius: 1
+      FixRadius: 1
     damageType: 3
     power: 150
 
   - type: STR_EXITUS_AMMO_TURBOPENETRATOR
     refNode: *STR_EXITUS_BULLETS
+    damageType: 1
     damageAlter:
       ToTile: 1.0 #it'll destroy about anything it hits
       RandomType: 6
@@ -428,7 +428,9 @@ items:
   - type: STR_EXITUS_AMMO_SHELLBREAKER # shield piercing
     refNode: *STR_EXITUS_BULLETS
     power: 150
+    damageType: 2
     damageAlter:
+      ResistType: 1
       ToTile: 0.0
       RandomType: 6
       FireThreshold: 1000 # no fire
@@ -436,7 +438,7 @@ items:
       ArmorEffectiveness: 0.8
       FixRadius: 0
       IgnoreDirection: false
-    damageType: 2
+
 
 
 

--- a/Ruleset/IG/manufacture_IG.rul
+++ b/Ruleset/IG/manufacture_IG.rul
@@ -114,9 +114,9 @@ manufacture:
       - STR_GUARD_IMPERIAL_ASSASSIN_REQUISITION
     space: 0
     time: 3000 #was 1000
-    cost: 1000000 #was 250k
+    cost: 2000000 #was 250k
     requiredItems:
-      STR_KILLPOINT_TOKEN: 300
+      STR_KILLPOINT_TOKEN: 1000
       # STR_ALIEN_HABITAT: 5
     spawnedPersonType: STR_GUARD_IMPERIAL_ASSASSIN
     producedItems:
@@ -130,48 +130,57 @@ manufacture:
     requires:
       - STR_GUARD_IMPERIAL_ASSASSIN_REQUISITION
     space: 0
-    time: 100
+    time: 200
     cost: 25000
     producedItems:
-      STR_EXITUS_AMMO: 4
+      STR_EXITUS_AMMO: 5
     requiredItems:
-      STR_UFO_CONSTRUCTION: 1
+      STR_KILLPOINT_TOKEN: 20
+      STR_UFO_CONSTRUCTION: 2
+      STR_ALIEN_ALLOYS: 5
 
   - name: STR_EXITUS_AMMO_HELLFIRE
     category: STR_AMMUNITION
     requires:
       - STR_GUARD_IMPERIAL_ASSASSIN_REQUISITION
     space: 0
-    time: 100
+    time: 200
     cost: 10000
     producedItems:
-      STR_EXITUS_AMMO_HELLFIRE: 2
+      STR_EXITUS_AMMO_HELLFIRE: 5
     requiredItems:
-      STR_UFO_CONSTRUCTION: 1
+      STR_KILLPOINT_TOKEN: 20
+      STR_UFO_CONSTRUCTION: 2
+      STR_ELERIUM_115: 10
 
   - name: STR_EXITUS_AMMO_TURBOPENETRATOR
     category: STR_AMMUNITION
     requires:
       - STR_GUARD_IMPERIAL_ASSASSIN_REQUISITION
     space: 0
-    time: 100
+    time: 200
     cost: 10000
     producedItems:
-      STR_EXITUS_AMMO_TURBOPENETRATOR: 2
+      STR_EXITUS_AMMO_TURBOPENETRATOR: 5
     requiredItems:
-      STR_UFO_CONSTRUCTION: 1
+      STR_KILLPOINT_TOKEN: 20
+      STR_UFO_CONSTRUCTION: 2
+      STR_ALIEN_ALLOYS: 10
 
   - name: STR_EXITUS_AMMO_SHELLBREAKER
     category: STR_AMMUNITION
     requires:
       - STR_GUARD_IMPERIAL_ASSASSIN_REQUISITION
     space: 0
-    time: 100
+    time: 200
     cost: 10000
     producedItems:
-      STR_EXITUS_AMMO_SHELLBREAKER: 2
+      STR_EXITUS_AMMO_SHELLBREAKER: 5
     requiredItems:
-      STR_UFO_CONSTRUCTION: 1
+      STR_KILLPOINT_TOKEN: 20
+      STR_UFO_CONSTRUCTION: 2
+      STR_ALIEN_ALLOYS: 10
+      STR_ELERIUM_115: 10
 
 # halved costs for promotion to reward the player somewhat for getting Veterans
 #  - name: STR_VETERAN_PROMOTION

--- a/Ruleset/IG/soldiers_IG.rul
+++ b/Ruleset/IG/soldiers_IG.rul
@@ -296,53 +296,53 @@ soldiers:
     requires:
         - STR_GUARD_IMPERIAL_ASSASSIN_REQUISITION
     value: 40
-    costSalary: 200000 #was 100k
+    costSalary: 500000 #was 100k
     minStats:
       tu: 60
       stamina: 70
       health: 40
-      bravery: 50
-      reactions: 60
-      firing: 70
+      bravery: 80
+      reactions: 100
+      firing: 110
       throwing: 60
-      strength: 30
+      strength: 40
       psiStrength: 60
       psiSkill: 0
-      melee: 60
+      melee: 70
     maxStats:
-      tu: 70
+      tu: 80
       stamina: 80
       health: 50
-      bravery: 70
-      reactions: 70
-      firing: 90
+      bravery: 100
+      reactions: 110
+      firing: 120
       throwing: 80
-      strength: 40
+      strength: 50
       psiStrength: 100
       psiSkill: 0
-      melee: 70
+      melee: 80
     statCaps:
-      tu: 80
+      tu: 100
       stamina: 120
-      health: 60
+      health: 80
       bravery: 110
-      reactions: 80
-      firing: 130 # was 90 # Scion was highest
-      throwing: 70
+      reactions: 150
+      firing: 180 # was 90 # Scion was highest
+      throwing: 110
+      strength: 80
+      psiStrength: 100
+      psiSkill: 100
+      melee: 110
+    trainingStatCaps:
+      tu: 90
+      stamina: 100
+      health: 60
+      firing: 130
+      throwing: 90
       strength: 60
       psiStrength: 100
       psiSkill: 100
-      melee: 120
-    trainingStatCaps:
-      tu: 60
-      stamina: 70
-      health: 40
-      firing: 70
-      throwing: 60
-      strength: 30
-      psiStrength: 60
-      psiSkill: 1
-      melee: 60
+      melee: 90
     armor: STR_GUARD_IMPERIAL_ASSASSIN_UC
 #    dogfightExperience:
 #      bravery: 10


### PR DESCRIPTION
1. Vindicare ammo is now made in bundles of 5, is more expensive and requires 20 Honor Tokens per batch.  Requires 200 man hours per batch up from 100.

2. Vindicare starting min/max, cap, training stats all increased substantially (this is a Temple Assassin).

3. Vindicare monthly salary/upkeep cost increased to 500k

4. Vindicare recruitment cost increased to 2 mil, and 1000 Honor.