### PR TITLE
Hot Fix for Inq Multimelta

### DIFF
--- a/Ruleset/BALANCE/explosives.rul
+++ b/Ruleset/BALANCE/explosives.rul
@@ -498,9 +498,22 @@ items:
   - type: STR_PHOTON_GRENADE #photon munition
     costBuy: 1000
     costSell: 400
+    primeSound: 2424
+    throwRange: 18
+    weight: 2 #Light grenade
+    costThrow:
+      energy: 5
+      time: 30
+    costPrime:
+      time: 30
+    costUnprime:
+      time: 15
+    unprimeActionName: STR_UNPRIME_GRENADE
+    flatPrime:
+      time: false
+      energy: true
     tuAimed: 0
     accuracyAimed: 0
-    throwRange: 18
     power: 50
     damageType: 6
     damageAlter:
@@ -512,7 +525,6 @@ items:
       ToWound: 0.00
       RandomWound: false
       FixRadius: 3
-    weight: 2
     noLOSAccuracyPenalty: 75 #indirect fire weapon
 
 ## CHAOS

--- a/Ruleset/SM/items_SM.rul
+++ b/Ruleset/SM/items_SM.rul
@@ -1138,6 +1138,9 @@ items:
     shotgunSpread: 0
     powerRangeReduction: 0.5
     powerRangeThreshold: 16.0
+    fixedWeapon: true
+    fixedWeaponShow: true
+    recover: false
     clipSize: -1
     listOrder: 10765
 


### PR DESCRIPTION
1. Inq Multimeltas no longer recoverable/removable.

2. Photon grenades use the new grenade standard.