### PR TITLE
Fixes DW Dreadnoughts Not Being Buildable

### DIFF
--- a/Ruleset/SM/GREY KNIGHTS/soldierTransformations_GK.rul
+++ b/Ruleset/SM/GREY KNIGHTS/soldierTransformations_GK.rul
@@ -3,7 +3,8 @@ soldierTransformation:
     requiredItems:
       STR_ALIEN_ALLOYS: 30 #halved
       STR_ELERIUM_115: 30
-      STR_KILLPOINT_TOKEN: 60
+      STR_UFO_CONSTRUCTION: 10
+      STR_KILLPOINT_TOKEN: 300
   - name: STR_RESURRECT_MARINE_GK
     allowedSoldierTypes:
       - STR_GK_LV1

--- a/Ruleset/SM/soldierTransformations.rul
+++ b/Ruleset/SM/soldierTransformations.rul
@@ -11,8 +11,8 @@ soldierTransformation:
     allowsWoundedSoldiers: true
     allowedSoldierTypes:
       - STR_SOLDIER
-    transferTime: 0 
-    requiredCommendations: 
+    transferTime: 0
+    requiredCommendations:
       STR_TERMINATOR_CROSS: 0
 
   - name: STR_RESURRECT_MARINE
@@ -20,9 +20,10 @@ soldierTransformation:
       - STR_DREADNOUGHT_MARINE
       - STR_NOT_PRIMARIS
     requiredItems:
-      STR_ALIEN_ALLOYS: 50
+      STR_ALIEN_ALLOYS: 30 #halved
       STR_ELERIUM_115: 30
-      STR_KILLPOINT_TOKEN: 60
+      STR_UFO_CONSTRUCTION: 10
+      STR_KILLPOINT_TOKEN: 300
       # STR_ALIEN_HABITAT: 1
 
     allowedSoldierTypes:
@@ -79,7 +80,7 @@ soldierTransformation:
     recoveryTime: 0
     reset: true
     #soldierBonusType: STR_BLESSING_SAINT #add some sort of Chaos blessing?
-    
+
   - name: STR_CONVERT_TO_CHAOS
     requires:
       - STR_CONVERT_TO_CHAOS_RESEARCH
@@ -123,7 +124,7 @@ soldierTransformation:
       - STR_PRIMARISLV1
       - STR_SOLDIER_JOAN
     transferTime: 1
-    recoveryTime: 1 
+    recoveryTime: 1
     lowerBoundAtMinStats: true
 
   - name: STR_CONVERT_TO_NIGHT_LORDS
@@ -153,7 +154,7 @@ soldierTransformation:
       - STR_GUARDSM
       - STR_GUARD_VETERAN
       - STR_STORMTROOPER
-      - STR_STORMTROOPER_OFFICER     
+      - STR_STORMTROOPER_OFFICER
       - STR_GUARD_OFFICER_VETERAN
       - STR_COMMISSAR
       - STR_PENITENT_GUARD
@@ -163,9 +164,9 @@ soldierTransformation:
       - STR_GUARD_TANITH
       - STR_GUARD_KRIEG_GRENADIER
     transferTime: 1
-    recoveryTime: 1 
+    recoveryTime: 1
     lowerBoundAtMinStats: true
-    
+
   - name: STR_CONVERT_TO_NURGLE_MARINE
     requires:
       - STR_CONVERT_TO_CHAOS_RESEARCH
@@ -270,3 +271,10 @@ soldierTransformation:
     transferTime: 1
     recoveryTime: 9 #sacred chaos number
     lowerBoundAtMinStats: true
+
+  - name: STR_RESURRECT_MARINE_DW
+    requiredItems:
+      STR_ALIEN_ALLOYS: 30 #halved
+      STR_ELERIUM_115: 30
+      STR_UFO_CONSTRUCTION: 10
+      STR_KILLPOINT_TOKEN: 300


### PR DESCRIPTION
1. Dreadnought construction fixed for DW.

2. Dreadnoughts now cost 300 Honor points and require 10 Ceramite.