### PR TITLE
Turret and Daemon Sense Tweaks

### DIFF
--- a/Ruleset/ALLFACTIONS/weapons_turrets.rul
+++ b/Ruleset/ALLFACTIONS/weapons_turrets.rul
@@ -310,10 +310,10 @@ items:
       time: 1
     dropoff: 4
     autoRange: 0
-    snapRange: 27
+    snapRange: 20
     aimRange: 36
     accuracyAuto: 0
-    accuracySnap: 60
+    accuracySnap: 50
     accuracyAimed: 90
     tuAuto: 0
 

--- a/Ruleset/ARBITES/armors_arbites.rul
+++ b/Ruleset/ARBITES/armors_arbites.rul
@@ -26,7 +26,7 @@ armors:
     visibilityAtDay: 40
     visibilityAtDark: 9
     spriteSheet: GUARDPD.PCK
-    spriteInv: FEMALE_IMPERIAL_PDF_INV.SPK 
+    spriteInv: FEMALE_IMPERIAL_PDF_INV.SPK
     customArmorPreviewIndex: 51
     spriteFaceGroup: 6
     spriteFaceColor: [96, 96, 96, 96, 160, 160, 163, 163, 96, 96, 96, 96, 96, 96, 96, 96, 160, 160, 163, 163] #M0 F0 M1 F1 M2 F2 M3 F3 M4 F4 M5 F5 M6 F6 M7 F7 M8 F8 M9 F9
@@ -241,7 +241,7 @@ armors:
       - 0.9 #PLASMA
       - 0.9 #STUN
       - 0.9 #MELEE
-      - 0.1 #ACID
+      - 0.5 #ACID
       - 0.0 #SMOKE
       - 1.0 #IMPACT
       - 1.0 #MELTA

--- a/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
+++ b/Ruleset/ENEMY/NURGLE/armors_nurgle.rul
@@ -212,11 +212,12 @@ armors:
     specialWeapon: STR_NURGLING_CLAWS
 
   - type: STR_NURGLE_ZOMBIE_ARMOR   # NURGLE ZOMBIE ARMOR
-    visibilityAtDay: 30
-    visibilityAtDark: 30
+    visibilityAtDay: 40
+    visibilityAtDark: 40 #daemons have perfect night vision
+    heatVision: 33 #daemons have at least 33% heat vision as standard
+    psiVision: 5 #daemons have at least 5 psi vision as standard
     antiCamouflageAtDay: 5
     antiCamouflageAtDark: 5
-    psiVision: 5 #they can sense the living
     spriteSheet: NURGLEZOMBIE_WALKER_BS.PCK
     spriteInv: NURGLEZOMBIE_INV.SPK
     allowInv: false
@@ -254,11 +255,12 @@ armors:
       - STR_NURGLING_CLAWS
 
   - type: STR_NURGLE_BOOMER_ARMOR
-    visibilityAtDay: 30
-    visibilityAtDark: 30 #undead
+    visibilityAtDay: 40
+    visibilityAtDark: 40 #daemons have perfect night vision
+    heatVision: 33 #daemons have at least 33% heat vision as standard
+    psiVision: 5 #daemons have at least 5 psi vision as standard
     antiCamouflageAtDay: 5
     antiCamouflageAtDark: 5
-    psiVision: 5 #they can sense the living
     spriteSheet: NURGLEZOMBIE_BOOMER_BS.PCK
     spriteInv: NURGLEBOOMER_INV.SPK
     corpseBattle:
@@ -293,13 +295,14 @@ armors:
       - STR_NURGLING_CLAWS
     tags:
       INFECTION_RESIST: 100 #infection immune
-      ARMOR_IS_EXPLODE_ON_DEATH: 1 #used for bomberman scripts
+      BOMBERMAN_ARMOR_IS_EXPLODE_ON_DEATH: 1 #used for bomberman scripts
       ARMOR_IS_KAMIKAZI: 1 #used for bomberman scripts; kamikazis on hit
 
 
   - type: STR_NURGLE_DAEMONETTE_ARMOR   #DAEMONETTE NURGLE ARMOR
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
+    heatVision: 33 #daemons have at least 33% heat vision as standard
     antiCamouflageAtDay: 5
     antiCamouflageAtDark: 5
     psiVision: 10 #they can sense the living
@@ -318,7 +321,7 @@ armors:
     painImmune: true #Plague Daemons don't care about pain
     tags:
       INFECTION_RESIST: 100 #infection immune
-      ARMOR_IS_EXPLODE_ON_DEATH: 1 #we can explode on death
+      BOMBERMAN_ARMOR_IS_EXPLODE_ON_DEATH: 1 #we can explode on death
     recovery: #Plague Daemons regenerate health
       health:
         healthCurrent: 0.2
@@ -985,9 +988,9 @@ armors:
 
   - type: NURGLINGS_ARMOR #NURGLE ANIMATED Blessed variant
     visibilityAtDay: 40
-    visibilityAtDark: 20
-    heatVision: 20
-    psiVision: 5
+    visibilityAtDark: 40 #daemons have perfect night vision
+    heatVision: 33 #daemons have at least 33% heat vision as standard
+    psiVision: 5 #daemons have at least 5 psi vision as standard
     spriteSheet: NURGLINGS2.PCK
     spriteInv: NURGLING_INV.SPK
     allowInv: true
@@ -1212,9 +1215,9 @@ armors:
 
   - type: NURGLE_BLIGHT_HAULER_ARMOR
     visibilityAtDay: 40
-    visibilityAtDark: 30
-    heatVision: 30
-    psiVision: 5
+    visibilityAtDark: 40 #daemons have perfect night vision
+    heatVision: 33 #daemons have at least 33% heat vision as standard
+    psiVision: 5 #daemons have at least 5 psi vision as standard
     allowInv: false
     spriteSheet: NURGLE_BLIGHT_HAULER_BS.PCK
     spriteInv: NURGLETANK_INV.SPK #NURGLETANK_INV.png

--- a/Ruleset/ENEMY/armors_daemon.rul
+++ b/Ruleset/ENEMY/armors_daemon.rul
@@ -14,10 +14,10 @@ extended:
 armors:
   - type: CYBERDISC_ARMOR #Flying Deamon
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
-    heatVision: 33
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 10
     frontArmor: 60
     sideArmor: 50
@@ -43,10 +43,10 @@ armors:
 
   - type: STR_SILACOID_ARMORT                          #khorne Deamon#    DEAMONS ARMOR
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
-    heatVision: 33
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 10
     frontArmor: 60 #decently armored; Brass armor of Khorne
     sideArmor: 60
@@ -74,10 +74,10 @@ armors:
 
   - type: STR_CELATID_ARMOR                            #Nurgle Deamon
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
-    heatVision: 33
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 10
     frontArmor: 20
     sideArmor: 15
@@ -88,7 +88,7 @@ armors:
     tags:
       INFECTION_RESIST: 100 #infection immune
       INTIMIDATION_RESISTANCE: 50 #intimidation resistant
-      ARMOR_IS_EXPLODE_ON_DEATH: 1 #can have a boomer bomb that detonates on death
+      BOMBERMAN_ARMOR_IS_EXPLODE_ON_DEATH: 1 #can have a boomer bomb that detonates on death
     painImmune: true #Most daemons don't care about pain; especially not Plaguebearers
     recovery: #Plaguebearers regenerate health
       health:
@@ -112,10 +112,10 @@ armors:
     spriteSheet: CH4.PCK
     spriteInv: DaemonetteINV.SPK
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 15
     antiCamouflageAtDark: 10
-    heatVision: 33
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 15
     frontArmor: 30
     sideArmor: 30
@@ -142,10 +142,10 @@ armors:
 
   - type: STR_CHRYSSALID_ARMORSELENE     #DEMON HARPY
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
-    heatVision: 33
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 15
     spriteSheet: CHRYS.PCK
     spriteInv: DaemonetteINV.SPK
@@ -177,10 +177,10 @@ armors:
 
   - type: STR_CHRYSSALID_ARMOR_DIRE    #CRABBY
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
-    heatVision: 33
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 15
     spriteSheet: DIRE_DAEMONETTE_BS.PCK
     spriteInv: DIRE_DAEMONETTE_INV.SPK
@@ -277,7 +277,7 @@ armors:
 
   - type: STR_FLAMER_ARMOR                          #TZ     Deamon
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     antiCamouflageAtDay: 10
     antiCamouflageAtDark: 6
     psiVision: 15
@@ -309,12 +309,12 @@ armors:
 
   - type: STR_NEVERBORN_TERRORIST_ARMOR                        #Undivided Deamon
     visibilityAtDay: 40
-    visibilityAtDark: 30
+    visibilityAtDark: 40 #daemons have perfect night vision
     camouflageAtDay: 10 # visible at 10 tiles out without anticamo
     camouflageAtDark: 5 # visible at 5 tiles out without anticamo - made of shadows
     antiCamouflageAtDay: 15
     antiCamouflageAtDark: 10
-    heatVision: 30
+    heatVision: 33 #daemons have 33% heat vision as standard
     psiVision: 5
     spriteSheet: DAEMONNEVERBORN.PCK
     allowInv: false

--- a/Ruleset/ENEMY/corpses_chaos.rul
+++ b/Ruleset/ENEMY/corpses_chaos.rul
@@ -37,7 +37,7 @@ items:
     recover: true
     recoveryPoints: 10
     battleType: 11
-    
+
   - type: STR_IRON_WARRIOR_WARSMITH_CORPSE
     size: 0.2
     costSell: 20000
@@ -50,7 +50,7 @@ items:
     recover: true
     recoveryPoints: 5
     battleType: 11
-    
+
   - type: STR_BLACK_LEGION_CSM_CORPSE
     name: STR_CORPSE
     costSell: 20000
@@ -62,14 +62,14 @@ items:
     invHeight: 3
     armor: 50
     recover: true
-    battleType: 11   
-    
+    battleType: 11
+
   - type: STR_CULTIST_SQUATS_CORPSE   #19100
     size: 0.3
     costSell: 7500
     weight: 30
     bigSprite: 2850
-    floorSprite: 2850 
+    floorSprite: 2850
     invWidth: 2
     invHeight: 3
     recoveryPoints: 4
@@ -81,7 +81,7 @@ items:
     costSell: 7500
     weight: 30
     bigSprite: 2850
-    floorSprite: 2850 
+    floorSprite: 2850
     invWidth: 2
     invHeight: 3
     recoveryPoints: 4
@@ -93,7 +93,7 @@ items:
     costSell: 7500
     weight: 30
     bigSprite: 2850
-    floorSprite: 2850 
+    floorSprite: 2850
     invWidth: 2
     invHeight: 3
     recoveryPoints: 4
@@ -105,7 +105,7 @@ items:
     costSell: 10000
     weight: 40
     bigSprite: 2850
-    floorSprite: 2850 
+    floorSprite: 2850
     invWidth: 2
     invHeight: 3
     recoveryPoints: 7
@@ -117,26 +117,26 @@ items:
     costSell: 20000
     weight: 40
     bigSprite: 2850
-    floorSprite: 2850 
+    floorSprite: 2850
     invWidth: 2
     invHeight: 3
     recoveryPoints: 15
     battleType: 11
     armor: 26
-    listOrder: 19100   
+    listOrder: 19100
   - type: STR_CHAOS_SQUATS_EXO_CORPSE     #20400
     size: 0.0
     weight: 50
     recoveryPoints: 15
-    bigSprite: 2850 
-    floorSprite: 2851 
+    bigSprite: 2850
+    floorSprite: 2851
     invWidth: 2
     invHeight: 3
     battleType: 11
     costSell: 20000
     armor: 40
     listOrder: 19100
-    
+
   - type: STR_ALPHA_LEGION_CORPSE #fake decoy corpse for flavor
     name: STR_CORPSE
     size: 0.2
@@ -177,7 +177,7 @@ items:
     armor: 30
     recover: true
     battleType: 11
-    
+
   - type: STR_NEVERBORN_CORPSE
     name: STR_CORPSE
     costSell: 15000
@@ -241,7 +241,7 @@ items:
     armor: 60
     recover: true
     battleType: 11
-  - type: STR_NIGHTLORD_RAPTOR_OFFICER_CORPSE 
+  - type: STR_NIGHTLORD_RAPTOR_OFFICER_CORPSE
     name: STR_CORPSE
     costSell: 28000
     size: 0.2
@@ -253,6 +253,7 @@ items:
     armor: 60
     recover: true
     battleType: 11
+
   - type: STR_NIGHTLORD_WARPTALON_CORPSE
     name: STR_CORPSE
     costSell: 30000

--- a/Ruleset/ENEMY/weapons_daemons.rul
+++ b/Ruleset/ENEMY/weapons_daemons.rul
@@ -2550,6 +2550,7 @@ items:
     damageAlter: ## Plague-inflicting weapon
       RandomType: 2 #TFTD [50% - 150%]
       ArmorEffectiveness: 0.7
+      SmokeThreshold: 0.0
       ToArmorPre: 0.5 #higher than normal plague weapons
       ToArmor: 0.5
       ToHealth: 0.1

--- a/Ruleset/IG/units_IG.rul
+++ b/Ruleset/IG/units_IG.rul
@@ -104,10 +104,10 @@ units:
         - STR_LASGUN_CLIP
         - STR_KRAK_GRENADE
 #        - STR_UNIT_TURNER_FT1
-   
+
   - type: FEMALE_CIVILIAN
     refNode: *STR_GUARD_FLAK_NPC
-    armor: STR_NPC_GUARDPD_ARMOR_UC 
+    armor: STR_NPC_GUARDPD_ARMOR_UC
     liveAlien: FEMALE_CIVILIAN # oxce_40k sets this to ""
 
   - &STR_GUARD_CARAPACE_NPC
@@ -118,8 +118,8 @@ units:
 
   - type: STR_HEAVY_GUARDSMAN_FEMALE
     refNode: *STR_GUARD_CARAPACE_NPC
-    armor: STR_NPC_GUARDPD_ARMOR_UC 
-    
+    armor: STR_NPC_GUARDPD_ARMOR_UC
+
 #IG Expanded Zombie Traitor Foes Units (can be moved somewhere else)
   - type: STR_GUARD_SQUAT_FLAK_MALE_ZOMBIE
     race: STR_ZOMBIEM
@@ -136,7 +136,7 @@ units:
       psiSkill: 0
       melee: 40
     armor: STR_SQUAT_FLAK_ZOMBIE_MALE_ARMOR
-    standHeight: 16 
+    standHeight: 16
     kneelHeight: 12
     value: 5
     intelligence: 2
@@ -158,7 +158,7 @@ units:
       psiSkill: 0
       melee: 40
     armor: STR_SQUAT_FLAK_ZOMBIE_MALE_ARMOR
-    standHeight: 16 
+    standHeight: 16
     kneelHeight: 12
     value: 5
     intelligence: 2
@@ -180,7 +180,7 @@ units:
       psiSkill: 0
       melee: 40
     armor: STR_SQUAT_CARAPACE_ZOMBIE_MALE_ARMOR
-    standHeight: 16 
+    standHeight: 16
     kneelHeight: 12
     value: 5
     intelligence: 2

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -67,7 +67,7 @@ items:
     tags:
       ITEM_RECOIL: 40
 
-  - type: STR_SHOTGUN_DRUM 
+  - type: STR_SHOTGUN_DRUM
     categories: [ STR_CAT_SHOTGUN, STR_CAT_SCOUT]
     shotgunBehavior: 1   #*** makes the shotgun a bit more useful at range bit tightening the spread ***
     shotgunSpread: 25
@@ -75,8 +75,8 @@ items:
     costBuy: 2000 #Precisely 4x the cost of standard shotgun shells. Cost of the drum itself is abstracted out
     costSell: 600
     weight: 12 #4x the weight of the shells themselves.
-    bigSprite: 1018 
-    floorSprite: 938 
+    bigSprite: 1018
+    floorSprite: 938
     handSprite: 776
     hitSound: {mod: 40k, index: 22}
     hitAnimation: {mod: 40k, index: 26}
@@ -102,7 +102,7 @@ items:
     meleeAnimation: {mod: 40k, index: 28} # 28 bolt anitmation
     power: 50 # More raw damage than a bayonet, less than felinid claws. Much less than a power fist.
     damageBonus:
-      strength: 0.2 
+      strength: 0.2
       melee: 0.2
     damageAlter:     #DA POWER
       ArmorEffectiveness: 0.7
@@ -486,10 +486,10 @@ items:
     requiresBuy: #Fixed requirement
       - STR_BALLISTIC_WEAPONS_HIGHGRADE
     costBuy: 15000 #-5000 vs as high grade lasgun, consider ammo cost
-    costSell: 1500   
+    costSell: 1500
     bigSprite: 1014
     floorSprite: 936
-    handSprite: 724 
+    handSprite: 724
     bulletSprite: {mod: 40k, index: 2}
     fireSound: {mod: 40k, index: 4}
     hitAnimation: {mod: 40k, index: 36}
@@ -871,6 +871,8 @@ items:
       ToHealth: 0.8
       ToArmorPre: 0.2
       ToArmor: 0.2
+      ToItem: 1.0
+      ToTile: 1.0
       FixRadius: 1
     clipSize: 3
     blastRadius: 2

--- a/Ruleset/commendations.rul
+++ b/Ruleset/commendations.rul
@@ -80,3 +80,11 @@ ufopaedia:
     text: STR_HERO_TO_THE_IMPERIUM_DESCRIPTION
 #    text_width: 158
     listOrder: 100040
+
+  - id: STR_BATTLE_TESTED
+    type_id: 10
+    section: STR_COMMENDATIONS_SECTION
+    image_id: REGIMENT_ATTENTION.SPK
+    text: STR_BATTLE_TESTED_COMMENDATION_DESCRIPTION
+#    text_width: 158
+    listOrder: 100050


### PR DESCRIPTION
1. Added Battle Tested commendations entry.

2. Nerfed battle cannon reaction fire (reduced accuracy and snap range)

3. Standardized Daemon senses to be minimum 40 darkness visibility, 33 heat vision and 5 psi vision.

4. Increased standardization of krak explosives RE: Item and Tile damage.
