### PR TITLE
Battle Tested Fixes; Token Cost Tweaks

### DIFF
--- a/Ruleset/40k.rul
+++ b/Ruleset/40k.rul
@@ -9357,12 +9357,12 @@ manufacture:
       - STR_NAVY_COMUNICATIONS
     space: 25
     time: 1200
-    cost: 500000
+    cost: 1000000
     requiresBaseFunc: [COMU]
     requiredItems:
       STR_ALIEN_ALLOYS: 50
       STR_ELERIUM_115: 200
-      STR_KILLPOINT_TOKEN: 200
+      STR_KILLPOINT_TOKEN: 400
 
   - name: STR_TANK_LASER_CANNON
     requires:

--- a/Ruleset/IG/manufacture_IG.rul
+++ b/Ruleset/IG/manufacture_IG.rul
@@ -280,6 +280,7 @@ manufacture:
   - name: STR_PSYKER_REQUISITION
     requires:
       - STR_PSYKER_RECRUITMENT
+    cost: 200000
     producedItems:
       STR_LASER_PISTOLG: 1
       STR_LASPISTOL_CLIP: 2

--- a/Ruleset/IG/soldierTransformation_IG.rul
+++ b/Ruleset/IG/soldierTransformation_IG.rul
@@ -56,10 +56,14 @@ soldierTransformation:
       - STR_GUARD_OFFICER
     cost: 50000
     requiredItems:
-      STR_KILLPOINT_TOKEN: 60
+      STR_KILLPOINT_TOKEN: 100
       # STR_VETERAN_PROMOTION: 1
     requiredCommendations:
       STR_VETERAN_COMMENDATION: 0
+      STR_BATTLE_TESTED: 1
+    requiredMinStats:
+      bravery: 50
+      tu: 1
 
   - name: STR_PROMOTE_SCION_OFFICER
     refNode: *STR_OFFICER_PROMOTION
@@ -70,6 +74,14 @@ soldierTransformation:
     requires:
 #      - STR_REGIMENT_OFFICERS
       - STR_STORMTROOPER_REQUISITION
+    requiredItems:
+      STR_KILLPOINT_TOKEN: 100
+    requiredCommendations:
+      STR_BATTLE_TESTED: 1
+    requiredMinStats:
+      bravery: 50
+      tu: 1
+
 
   - name: STR_VETERAN_PROMOTION
     requiredMinStats:
@@ -79,7 +91,7 @@ soldierTransformation:
     requires:
       - STR_GUARDSMEN_VETERAN
     requiredItems:
-      STR_KILLPOINT_TOKEN: 60
+      STR_KILLPOINT_TOKEN: 100
 
   - name: STR_KRIEG_GRENADIER_PROMOTION
     requiredMinStats:
@@ -96,7 +108,7 @@ soldierTransformation:
     allowedSoldierTypes:
       - STR_GUARDSM_KRIEG
     requiredItems:
-      STR_KILLPOINT_TOKEN: 60
+      STR_KILLPOINT_TOKEN: 100
 
   - name: STR_PARDON_PENITENT
     requires:

--- a/Ruleset/OTHER/manufacture_killpoints.rul
+++ b/Ruleset/OTHER/manufacture_killpoints.rul
@@ -94,13 +94,15 @@ manufacture:
       # STR_ALIEN_HABITAT: 2
 
   - name: STR_UNPACK_PSYKER_REQUISITION
+    requires:
+      - STR_GENERALLOCK
     producedItems:
-      STR_KILLPOINT_TOKEN: 240
+      STR_KILLPOINT_TOKEN: 0
       # STR_ALIEN_HABITAT: 4
 
   - name: STR_PSYKER_REQUISITION
     requiredItems:
-      STR_KILLPOINT_TOKEN: 120
+      STR_KILLPOINT_TOKEN: 500
       # STR_ALIEN_HABITAT: 2
 
   - name: STR_MKX_APO_ARMOR                #1 BADGE 1

--- a/Ruleset/research_ROSIGMA.rul
+++ b/Ruleset/research_ROSIGMA.rul
@@ -7860,7 +7860,7 @@ research:
       - STR_HIGHTIER_PREREQ
       - STR_PSI_LAB
       - STR_IMPERIAL_GUARD_OPERATIONS
-    spawnedItem: STR_PSYKER_REQUISITION
+    spawnedItem: STR_PURITY_SEAL
     unlocks:
       - STR_PSYKER_RECRUITMENT
 
@@ -8954,7 +8954,7 @@ research:
       - STR_GENERALLOCK
     lookup: STR_CHOSEN_IGS
     unlocks:
-      - STR_GUARD_SUPORT #added to enable medic armors    
+      - STR_GUARD_SUPORT #added to enable medic armors
       - STR_MOTION_SCANNER
       - STR_LASER_WEAPONS
       - STR_LIGHT_BOLTERS_LOWTIER


### PR DESCRIPTION
1. Battle Tested commendation is now needed for all officer transforms along with 50 Bravery.

2. Token cost for Orbital Strikes increased from 200 to 400. Monetary cost increased to 1 million.

3. Psyker Token Cost increased from 120 to 500.

4. Veteran promotion Token Cost increased from 60 to 100.

5. No more free Honor Tokens just for researching Psyker Requiisiton.