### PR TITLE
Fixing Leman Russ Turret and Battle Tested

### DIFF
--- a/Ruleset/ALLFACTIONS/weapons_turrets.rul
+++ b/Ruleset/ALLFACTIONS/weapons_turrets.rul
@@ -309,14 +309,14 @@ items:
       energy: 5
       time: 1
     costSnap:
-      energy: 0
-      time: 0
+      energy: 10
+      time: 1
     dropoff: 4
     autoRange: 27
-    snapRange: 0
+    snapRange: 12
     aimRange: 36
     accuracyAuto: 60
-    accuracySnap: 0
+    accuracySnap: 50
     accuracyAimed: 90
     tuSnap: 0
     autoShots: 1

--- a/Ruleset/IG/soldierTransformation_IG.rul
+++ b/Ruleset/IG/soldierTransformation_IG.rul
@@ -33,7 +33,7 @@ soldierTransformation:
       # STR_KILLPOINT_TOKEN: 60 # not changed because of officer sword
       STR_OFFICER_COMMISSION: 1
     requiredCommendations:
-      STR_BATTLE_TESTED: 1
+      STR_BATTLE_TESTED: 0
     requiredMinStats:
       bravery: 50
       tu: 1
@@ -45,7 +45,7 @@ soldierTransformation:
       # STR_KILLPOINT_TOKEN: 60 # not changed because of officer sword
       STR_OFFICER_COMMISSION: 1
     requiredCommendations:
-      STR_BATTLE_TESTED: 1
+      STR_BATTLE_TESTED: 0
     lowerBoundAtMinStats: true
     requiredMinStats:
       bravery: 50
@@ -60,7 +60,7 @@ soldierTransformation:
       # STR_VETERAN_PROMOTION: 1
     requiredCommendations:
       STR_VETERAN_COMMENDATION: 0
-      STR_BATTLE_TESTED: 1
+      STR_BATTLE_TESTED: 0
     requiredMinStats:
       bravery: 50
       tu: 1
@@ -77,7 +77,7 @@ soldierTransformation:
     requiredItems:
       STR_KILLPOINT_TOKEN: 100
     requiredCommendations:
-      STR_BATTLE_TESTED: 1
+      STR_BATTLE_TESTED: 0
     requiredMinStats:
       bravery: 50
       tu: 1


### PR DESCRIPTION
1. Leman Russ Turret can snap shot once, but with short range, requiring 10 Energy.

2. Initial Battle Tested rank recognized.
