### PR TITLE
Boneheads Get Their Healing Factor and Proper Costing!

### DIFF
--- a/Ruleset/IG/soldiers_command_IG.rul
+++ b/Ruleset/IG/soldiers_command_IG.rul
@@ -6,6 +6,7 @@ extended:
       #bonehead orders
       SOLDIER_BONEHEAD_OGRYN_CAN_BE_ORDERED: int
       SOLDIER_BONEHEAD_OGRYN_CAN_ISSUE_ORDERS: int
+      SOLDIER_WOUND_TIME_MULTIPLIER: int
 
 soldiers:
   - type: STR_PENITENT_GUARD # rank 0
@@ -21,6 +22,7 @@ soldiers:
     tags:
       SOLDIER_COMMAND_POINTS: 5
       SOLDIER_BONEHEAD_OGRYN_CAN_ISSUE_ORDERS: 1
+      SOLDIER_WOUND_TIME_MULTIPLIER: 33
 
   - type: STR_GUARDSM # rank 0 - 3 # max 4
     tags:

--- a/Ruleset/soldierBonuses.rul
+++ b/Ruleset/soldierBonuses.rul
@@ -63,7 +63,10 @@ soldierTransformation:
   - name: STR_BONEHEAD_ENHANCEMENT
     cost: 200000
     requiredItems:
-      STR_KILLPOINT_TOKEN: 200
+      STR_ALIEN_ALLOYS: 50
+      STR_ELERIUM_115: 25
+      STR_UFO_CONSTRUCTION: 5
+      STR_KILLPOINT_TOKEN: 400
       # STR_ALIEN_HABITAT: 1
     keepSoldierArmor: true
     allowsDeadSoldiers: false


### PR DESCRIPTION
1. Boneheads now heal at the same rate Ogryns do.

2. Bonehead upgrade now costs what it should since we're no longer in testing.
