### PR TITLE
Ogryn/Bonehead Prereq Fixes

### DIFF
--- a/Ruleset/IG/manufacture_IG.rul
+++ b/Ruleset/IG/manufacture_IG.rul
@@ -4,7 +4,7 @@ manufacture:
     category: STR_ARMOR
     requires:
       - STR_FELINIDGUARD_ASSASSIN
-    requiredItems: 
+    requiredItems:
       STR_ALIEN_ALLOYS: 20
       STR_KILLPOINT_TOKEN: 100
     producedItems:
@@ -1716,7 +1716,7 @@ manufacture:
     category: STR_AMMUNITION
     requires:
       - STR_OGRYN_REQUISITION
-      - STR_MIDTIER_GUARDSMEN
+      - STR_MIDTIER_PREREQ
     space: 2
     time: 100
     cost: 500

--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -4332,6 +4332,7 @@ items:
     turretType: 1
 
   - type: STR_RIPPER_GUN
+    oneHandedPenalty: 50
     compatibleAmmo:
       - STR_RIPPER_GUN_CLIP
       - STR_RIPPER_GUN_CLIP_INC
@@ -4351,11 +4352,11 @@ items:
       ToStun: 0.5 #impact shock
 
   - type: STR_RIPPER_GUN_CLIP_AP
-    costBuy: 4000
+    costBuy: 6000
     costSell: 1000
     requiresBuy:
       - STR_OGRYN_REQUISITION
-      - STR_MIDTIER_GUARDSMEN
+      - STR_MIDTIER_PREREQ
     size: 0.3
     weight: 10
     bigSprite: 1009
@@ -4374,9 +4375,9 @@ items:
       ToArmor: 0.02 #AP ammo; small armor damage
       ArmorEffectiveness: 0.5 #has significant armor penetration
       ToHealth: 0.7 #AP weapon features reduced health damage
-      ToTime: 0.1 #shotguns have impact shock; the Ripper especially so; reduced due to AP ammo
-      ToEnergy: 0.1 #impact shock; reduced due to AP ammo
-      ToStun: 0.3 #impact shock; reduced due to AP ammo
+      ToTime: 0.05 #shotguns have impact shock; the Ripper especially so; reduced due to AP ammo
+      ToEnergy: 0.05 #impact shock; reduced due to AP ammo
+      ToStun: 0.25 #impact shock; reduced due to AP ammo
     shotgunBehavior: 1
     shotgunSpread: 20 #these flechettes are more aerodynamic and have improved grouping
     shotgunPellets: 6
@@ -4413,7 +4414,9 @@ items:
       ArmorEffectiveness: 1.00
       ToHealth: 1.5
       ToMorale: 2.0 #being savaged with white phosphorous and promethium is kinda demoralizing
-      ToStun: 0.75 #painful
+      ToTime: 0.2 #has less heft than buckshot
+      ToEnergy: 0.1 #has less heft than buckshot
+      ToStun: 0.7 #painful
       ToTile: 0.3
     shotgunBehavior: 1
     shotgunSpread: 35

--- a/Ruleset/soldierBonuses.rul
+++ b/Ruleset/soldierBonuses.rul
@@ -75,7 +75,7 @@ soldierTransformation:
     transferTime: 168
     requires:
       - STR_IMPERIAL_GUARD_OPERATIONS
-      - STR_MIDTIER_GUARDSMEN
+      - STR_MIDTIER_PREREQ
       - STR_OGRYN_REQUISITION
       - STR_APOC_BAY
       - STR_BONEHEAD_SURGERY_RESEARCH


### PR DESCRIPTION
1. Boneheads, Ripper Gun Flechette Drums Purchase/Manufacture now requires STR_MIDTIER_PREREQ instead of STR_MIDTIER_GUARDSMEN so all paths with Ogryn Requisition can benefit from these.

2. Price of Ripper Gun Flechettes slightly increased to make manufacturing it a bit more competitive.

3. Ripper Gun Flechette TU/Stun/Energy damage slightly increased.

4. Ripper Gun Incendiary TU/Energy damage increased and slightly increased. Stun damage slightly decreased.

5. Ripper Gun one-handed penalty increased to 50% up from 25%.
