### PR TITLE
Soldier/Armor Tweaks

### DIFF
--- a/Ruleset/ALLFACTIONS/personal_light.rul
+++ b/Ruleset/ALLFACTIONS/personal_light.rul
@@ -557,12 +557,40 @@ armors:
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_CHAOS_SQUATS_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_CHAOS_SQUATS_ARMOR_HEAVY
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_CHAOS_SQUATS_ARMOR_LEADER
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_CHAOS_SQUATS_EXOARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_CHAOS_TERMINATOR_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_CHAP_ARMOR_UC
@@ -599,8 +627,22 @@ armors:
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_CULTIST_SQUATS_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_CULTIST_SQUATS_ARMOR_LEADER
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_DARK_APOSTLE_ALPHA_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_DARK_APOSTLE_ALPHA_RITUALIST_ARMOR
@@ -1228,9 +1270,9 @@ armors:
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_GSC_KELER_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
-  - type: STR_GENE_HYBRID_ACOLYTE_ARMOR 
+  - type: STR_GENE_HYBRID_ACOLYTE_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
-  - type: STR_GENE_HYBRID_ACOLYTE_LEADER_ARMOR 
+  - type: STR_GENE_HYBRID_ACOLYTE_LEADER_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_GSC_KRIEG_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
@@ -1808,12 +1850,26 @@ armors:
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_SQUAT_CARAPACE_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_SQUAT_CARAPACE_ZOMBIE_FEMALE_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_SQUAT_CARAPACE_ZOMBIE_MALE_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_SQUAT_FLAK_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_SQUAT_FLAK_ZOMBIE_FEMALE_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_SQUAT_FLAK_ZOMBIE_MALE_ARMOR
@@ -1882,6 +1938,13 @@ armors:
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_TRAITOR_SQUATS_ARMOR
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
+    recovery:
+      stun:
+        energyCurrent: 0.10
+        healthCurrent: 0.25 #Squats get bonus Stun regen that scales with health and energy
+      energy:
+        stamina: 0.33
+        healthCurrent: 0.5 #Squats get bonus Stamina regen that scales with health
   - type: STR_TSARGENT_UC
     refNode: *STR_PERSONAL_LIGHT_AND_RECOVERY_STAMINA
   - type: STR_TZAANGOR_ARMOR

--- a/Ruleset/IG/armors_IG.rul
+++ b/Ruleset/IG/armors_IG.rul
@@ -18,6 +18,7 @@ extended:
   tags:
     RuleArmor:
       INFECTION_RESIST: int #reduces infection damage by this as a %
+      INFECTION_RESIST_TYPE: int
       INFECTION_REDUCTION: int #reduces infection damage by this as a flat amount
       ARMOR_ENERGY_SHIELD_HP_PER_TURN: int
       ARMOR_ENERGY_SHIELD_DECAY: int
@@ -42,6 +43,10 @@ items:
       - STR_IMPERIAL_GUARD_OPERATIONS
 
   - type: STR_MEDIC_CARAPACE_ARMOR
+    stats:
+      tu: -5 #heavy
+      stamina: -10 #heavy
+      reactions: -10 #heavy
     requiresBuy:
       - STR_CARAPACE_ARMOR_IG
       - STR_IMPERIAL_GUARD_OPERATIONS
@@ -115,7 +120,9 @@ armors:
        stamina: 10
     loftempsSet: [ 3 ]
     specialWeapon: STR_BAYONET
-
+    tags:
+      INFECTION_RESIST: 33 #infection resistant to GSC due to robust physiology
+      INFECTION_RESIST_TYPE: 2
 
   - &BEASTGUARD_FLAK_ARMOR_REF
     type: STR_BEASTGUARD_FLAK_ARMOR
@@ -136,7 +143,7 @@ armors:
     drawingRoutine: 0
     zombiImmune: true
     tags:
-      INFECTION_RESIST: 50 #infection resistant
+      INFECTION_RESIST: 33 #infection/corruption resistant due to warp acclimatization and physiology
     damageModifier: #GUARD ARMOR
       - 1.0 #none
       - 1.0 #AP
@@ -172,6 +179,7 @@ armors:
     stats:
        tu: -5 #heavy
        stamina: -10 #heavy
+       reactions: -10 #heavy
        bravery: 10 #always multiples of 10
     specialWeapon: STR_GUARD_MEDI_KIT
     builtInWeapons:
@@ -346,8 +354,9 @@ armors:
     underArmor: 60
     weight: 20
     stats:
-       tu: 0
-       stamina: -5
+       tu: -5
+       stamina: -10
+       reactions: -10
        strength: 5
        bravery: 10 #always multiples of 10
     drawingRoutine: 0
@@ -502,11 +511,11 @@ armors:
     units:
       - STR_GUARD_FELINID_VETERAN
     stats:
-       tu: 5
-       firing: 10
-       reactions: 10
-       strength: 5
-       bravery: 20 #always multiples of 10
+      tu: -2
+      firing: 10
+      stamina: -10 #more used to moving in armor, but it's heavier.
+      strength: 5
+      bravery: 20 #always multiples of 10
     loftempsSet: [ 2 ] #Felenid
     specialWeapon: STR_GUARD_MEDI_KIT
     builtInWeapons:
@@ -843,10 +852,14 @@ armors:
       - STR_GUARD_SQUAT
     stats:
        bravery: 10
+       stamina: 5
        strength: 5
     weight: 10 #high quality squat armor fit, also... smaller surface area
     loftempsSet: [ 3 ]
     specialWeapon: STR_BAYONET
+    tags:
+      INFECTION_RESIST: 33 #infection resistant to GSC due to robust physiology
+      INFECTION_RESIST_TYPE: 2
 
   - type: STR_BEASTGUARD_CARAPACE_ARMOR
     visibilityAtDay: 35 #abhuman squat malus
@@ -866,7 +879,7 @@ armors:
     drawingRoutine: 0
     zombiImmune: true
     tags:
-      INFECTION_RESIST: 50 #infection resistant
+      INFECTION_RESIST: 33 #infection/corruption resistant due to warp acclimatization and physiology
     weight: 15
     damageModifier: #GUARD ARMOR
       - 1.0 #none
@@ -908,7 +921,7 @@ armors:
     drawingRoutine: 0
     zombiImmune: true
     tags:
-      INFECTION_RESIST: 50 #infection resistant
+      INFECTION_RESIST: 33 #infection/corruption resistant due to warp acclimatization and physiology
     weight: 20
     damageModifier: #GUARD ARMOR
       - 1.0 #none
@@ -976,6 +989,9 @@ armors:
     builtInWeapons:
       - STR_SLAB_SHIELD
     specialWeapon: STR_BAYONET
+    zombiImmune: true
+    tags:
+      INFECTION_RESIST: 33 #infection/corruption resistant due to warp acclimatization and physiology
     #scripts:
       #hitUnit: *armorForcesHitsToFront
 
@@ -1164,6 +1180,10 @@ armors:
     units:
       - STR_GUARDSM
       - STR_GUARD_OFFICER
+    stats:
+      tu: -10 #heavy
+      stamina: -20 #heavy
+      reactions: -10 #heavy
 
   - &STR_GUARD_ARMOR_TANITH # DAMAGE + STATS
     type: STR_TANITH_CAMO_ARMOR
@@ -1203,7 +1223,10 @@ armors:
   - type: STR_TANITH_MEDIC_ARMOR
     refNode: *STR_GUARD_ARMOR_TANITH
     weight: 5
-
+    stats:
+      tu: -5 #heavy
+      stamina: -10 #heavy
+      reactions: -10 #heavy
 
   - &STR_GUARD_ARMOR_SENTINEL_OPEN # DAMAGE + STATS
     type: STR_SENTINEL_ARMOR_UC
@@ -1594,7 +1617,10 @@ armors:
 
   - type: STR_STORMTROOPER_MEDIC_CARAPACE_ARMOR
     refNode: *STR_GUARD_ARMOR_CARAPACE_VETERAN
-
+    stats:
+      tu: -5 #heavy
+      stamina: -10 #heavy
+      reactions: -10 #heavy
 
     storeItem: STR_NONE
     corpseBattle:
@@ -1735,6 +1761,10 @@ armors:
     units:
       - STR_STORMTROOPER
       - STR_STORMTROOPER_OFFICER
+    stats:
+      tu: -5 #heavy
+      stamina: -10 #heavy
+      reactions: -10 #heavy
 
     corpseBattle:
       - STR_STORMTROOPER_CORPSE
@@ -2031,6 +2061,10 @@ armors:
     recovery:
       morale:
         flatHundred: 1
+    psiDefence:
+      psiStrength: 1.0
+      psiSkill: 0.2
+      moraleCurrent: 1.0 #kriegs resist mental subversion while morale is high; disciplined
     units:
       - STR_GUARDSM_KRIEG
 
@@ -2087,6 +2121,10 @@ armors:
     recovery:
       morale:
         flatHundred: 1
+    psiDefence:
+      psiStrength: 1.0
+      psiSkill: 0.2
+      moraleCurrent: 1.0 #kriegs resist mental subversion while morale is high; disciplined
     units:
       - STR_GUARD_KRIEG_GRENADIER
 
@@ -2170,6 +2208,10 @@ armors:
     builtInWeapons:
       - INV_NULL_MEDI_KIT
       - AUX_MEDICAE_MEDI_KIT
+    stats:
+      tu: -5 #heavy
+      stamina: -10 #heavy
+      reactions: -10 #heavy
 
   - type: STR_GUARD_IMPERIAL_ASSASSIN_UC
     spriteSheet: IGMA_IMPERIAL_ASSASSIN.PCK
@@ -2594,6 +2636,10 @@ armors:
 
   - type: STR_TANITH_MEDIC_ARMOR
     refNode: *STR_TANITH_ARMOR
+    stats:
+      tu: -5 #heavy
+      stamina: -10 #heavy
+      reactions: -10 #heavy
 
   - &STR_GUARD_POWER_ARMOR_REF # DAMAGE + STATS
     type: STR_GUARD_POWER_ARMOR
@@ -2660,6 +2706,12 @@ armors:
     recovery:
       morale:
         flatHundred: 1
+    psiDefence:
+      psiStrength: 1.0
+      psiSkill: 0.2
+      moraleCurrent: 1.0 #kriegs resist mental subversion while morale is high; disciplined
+    tags:
+
 
     units:
       - STR_GUARD_KRIEG_GRENADIER #vet equivalent

--- a/Ruleset/IG/soldiers_IG.rul
+++ b/Ruleset/IG/soldiers_IG.rul
@@ -880,47 +880,47 @@ soldiers:
     costSalary: 5000
     minStats:
       tu: 25 # was 40
-      stamina: 50 #was 40
-      health: 35 #was 25
+      stamina: 60 #was 40
+      health: 40 #was 25
       bravery: 30 #was 20
       reactions: 20 #was 30
       firing: 45 #was 40
       throwing: 25 #was 35
-      strength: 15 #was 10
+      strength: 30 #was 10
       psiStrength: 0
       psiSkill: 0
       melee: 10 #was 20
     maxStats:
       tu: 45 #was 60
-      stamina: 80 #was 70
-      health: 55 #was 40
+      stamina: 90 #was 70
+      health: 60 #was 40
       bravery: 80 #was 60
       reactions: 50 #was 60
       firing: 80 #was 70
       throwing: 50 #was 65
-      strength: 40 #was 25
+      strength: 50 #was 25
       psiStrength: 100
       psiSkill: 20 #was 6
       melee: 40 #was 60
     statCaps:
-      tu: 60 #was 75
-      stamina: 110 #was 90
-      health: 75 #was 55
+      tu: 65 #was 75
+      stamina: 120 #was 90
+      health: 110 #was 55
       bravery: 110 # was 100
       reactions: 80 # was 60
       firing: 100 # was 100
       throwing: 70
-      strength: 75 # was 65
+      strength: 80 # was 65
       psiStrength: 100
       psiSkill: 50
       melee: 75 #was 90
     trainingStatCaps:
       tu: 55
-      stamina: 70
-      health: 60
+      stamina: 100
+      health: 100
       firing: 90
       throwing: 60
-      strength: 55
+      strength: 70
       psiStrength: 100
       psiSkill: 50
       melee: 50
@@ -1259,7 +1259,7 @@ soldiers:
       tu: 50
       stamina: 60
       health: 35
-      bravery: 50
+      bravery: 60
       reactions: 50
       firing: 60
       throwing: 50
@@ -1271,7 +1271,7 @@ soldiers:
       tu: 60
       stamina: 70
       health: 40
-      bravery: 60
+      bravery: 100
       reactions: 60
       firing: 70
       throwing: 65
@@ -1282,6 +1282,7 @@ soldiers:
     statCaps:
       tu: 75
       stamina: 120
+      bravery: 110
       firing: 130
       strength: 65
       health: 55

--- a/Ruleset/IG/soldiers_command_IG.rul
+++ b/Ruleset/IG/soldiers_command_IG.rul
@@ -6,6 +6,7 @@ extended:
       #bonehead orders
       SOLDIER_BONEHEAD_OGRYN_CAN_BE_ORDERED: int
       SOLDIER_BONEHEAD_OGRYN_CAN_ISSUE_ORDERS: int
+#*** Tag for reducing wound time after battle ***
       SOLDIER_WOUND_TIME_MULTIPLIER: int
 
 soldiers:
@@ -78,10 +79,12 @@ soldiers:
 
   - type: STR_GUARD_SQUAT
     tags:
-      SOLDIER_COMMAND_POINTS: 1
+      SOLDIER_COMMAND_POINTS: 2 #abhuman, but highly disciplined
+      SOLDIER_WOUND_TIME_MULTIPLIER: 50 #recovers in half normal time
 
   - type: STR_GUARD_BEASTMAN
     tags:
       SOLDIER_COMMAND_POINTS: 1
+      SOLDIER_WOUND_TIME_MULTIPLIER: 75 #slightly improved recovery time
 
 #  - type: STR_GUARD_IMPERIAL_ASSASSIN


### PR DESCRIPTION
1. Squats buffed:
* Stun recovery scales with current Energy and current Health.
* Energy recovery  scales with current Health.
* Squats now have mid level resistance to GSC infection.
* Squats now have halved wound recovery time.
* Squat Health and Stamina training maximums improved.
* Squats now yield +1 command point.

2. Kriegers now get higher initial Bravery and all Krieg armor types get Krieger Mind Control resistance as they should.

3. Beastman infection/corruption resistance reduced from 50% to 33%, but now have 33% faster wound recovery time.

4. Added TU, Stamina and Reaction penalties to Medic variants of armor.
