### PR TITLE
Thunderclap Nerf

### DIFF
--- a/Ruleset/IG/weapons_IG.rul
+++ b/Ruleset/IG/weapons_IG.rul
@@ -4885,3 +4885,38 @@ items:
     fixedWeaponShow: true
     recover: false
     defaultInventorySlot: STR_LEFT_HAND
+
+  - type: STR_PSYKER_SPELL
+    weight: 0
+    costUse:
+      time: 20
+      energy: 10
+      stun: 5
+      morale: 10
+    flatUse:
+      time: true
+      energy: true
+      stun: true
+      morale: true
+    accuracyUse: 100
+    dropoff: 0
+    LOSRequired: true
+    powerRangeThreshold: 10.0
+    powerRangeReduction: 5.0
+    damageType: 6
+    power: 1
+    damageBonus:
+      psi: 0.01
+    damageAlter:
+      RandomType: 6
+      ArmorEffectiveness: 0.4
+      ToTime: 1.0
+      ToEnergy: 0.6
+      ToStun: 0.2
+      ToMorale: 0.2
+      FixRadius: 5
+      IgnoreDirection: false
+      ToItem: 0.0
+      ToTile: 0.0
+      ToArmor: 0.0
+      ToArmorPre: 0.0


### PR DESCRIPTION
1. Per title. Incredibly overdue. Decreased armor penetration from 75% to 60%, changed damage scaling from PsiStrength to Psi * 0.001. Increase cast cost by +5 Stun and +5 Morale.
