### PR TITLE
Bomberman Kamikazi Activates Only On Melee Attack Now

### DIFF
--- a/Ruleset/scripts/scripts_bomberman.rul
+++ b/Ruleset/scripts/scripts_bomberman.rul
@@ -21,6 +21,10 @@ extended:
           var int numInventoryItems;
           var int randomFuse;
 
+          if neq battle_action BA_HIT; #only triggers on melee attacks
+            return power part side;
+          end;
+
           #if our armor doesn't have the kamikazi tag, cancel out
           attacker.getRuleArmor armorRule;
           armorRule.getTag temp Tag.ARMOR_IS_KAMIKAZI; #we check the armor for this tag to avoid having to cycle through items every time we damage something

--- a/Ruleset/soldierBonuses.rul
+++ b/Ruleset/soldierBonuses.rul
@@ -83,7 +83,7 @@ soldierTransformation:
     allowedSoldierTypes:
       - STR_OGRYN
     requiredCommendations:
-      STR_BATTLE_TESTED: 0
+      STR_VETERAN_COMMENDATION: 0
     requiresBaseFunc: [MED] #need Apothecary Bay for the surgery
     requiredMinStats:
       bravery: 50


### PR DESCRIPTION
1. Per title.
2. Also Ogryn Bonehead surgery now requires the Veteran commendation instead of merely Battle Tested.
