### PR TITLE
Hotshot Las Munitions Have Degrading Accuracy

### DIFF
--- a/Language/en-US.yml
+++ b/Language/en-US.yml
@@ -5208,3 +5208,6 @@ en-US:
   STR_RELOAD_WEAPONS: "Reload Turret"
   STR_TURRET_RELOAD: "Reload Turret"
   STR_QUICK_SHOT: "Quick Shot"
+
+  STR_HOTSHOT_MUNITIONS: "Hotshot Munitions"
+  STR_HOTSHOT_MUNITIONS_CODEX: "{NEWLINE}While undeniably powerful, Hotshot munitions produce heat above acceptable parameters that cumulatively degrades weapon performance and accuracy until the munition has either had time to cool or is replaced. Hellgun weaponry is specifically designed to run hot and thus does not suffer from this problem."

--- a/Ruleset/BALANCE/las_ammo.rul
+++ b/Ruleset/BALANCE/las_ammo.rul
@@ -1,3 +1,8 @@
+extended:
+  tags:
+    RuleItem:
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER: int
+
 items:
   # from rebalance mod
   - &LASGUN_DAMAGE_ALTER
@@ -19,7 +24,7 @@ items:
     tags:
       ITEM_AMMO_COLOR: 2
       ITEM_AMMO_SHADE: -3
-
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER: 5
 
   - type: STR_LASGUN_CLIP
     refNode: *LASGUN_DAMAGE_ALTER
@@ -32,6 +37,8 @@ items:
     damageAlter:
       ArmorEffectiveness: 0.75
     clipSize: 20 #-10 hotshot drains more power.
+    tags:
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER: 5 #
 
   - type: STR_LASCANNON_CLIP_MALTHUS #LASCANON MALTHUS POWER PACK               2018
     power: 140

--- a/Ruleset/scripts/scripts_hotshot_penalty.rul
+++ b/Ruleset/scripts/scripts_hotshot_penalty.rul
@@ -1,0 +1,73 @@
+extended:
+  tags:
+    RuleItem:
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER: int #how much accuracy falloff do we increment per shot?
+    BattleItem:
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_TOTAL: int #how much total accuracy falloff does this weapon have?
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_PRIOR_AMMO_COUNT: int #prior ammo count for a basis of comparison
+      ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_COOLDOWN: int #how much does this weapon cooldown per turn?
+
+  scripts:
+    accuracyMultiplierBonusStats: #handles accuracy falloff incrementation
+      - new: ROSIGMA_aMBS_repeated_accuracy_penalty
+        offset: 10
+        code: |
+          var int temp;
+          var int temp2;
+          var int multiplier;
+
+          ammo.getTag multiplier Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER;
+
+          if le multiplier 0;
+            #debug_log "accuracyMultiplierBonusStats | ROSIGMA_aMBS_repeated_accuracy_penalty | offset: 10 | ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER is 0. Aborting. multiplier:" temp;
+            return bonus; # final accuracy
+          end;
+
+          ammo.getTag temp Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_PRIOR_AMMO_COUNT;
+          ammo.getAmmoQuantity temp2;
+
+          sub temp temp2;
+          if lt temp 1;
+            #debug_log "accuracyMultiplierBonusStats | ROSIGMA_aMBS_repeated_accuracy_penalty | offset: 10 | temp is null or negative. Weapon reloaded?:" temp;
+            return bonus;
+          end;
+
+          mul temp multiplier;
+          #debug_log "accuracyMultiplierBonusStats | ROSIGMA_aMBS_repeated_accuracy_penalty | offset: 10 | Accuracy penalty, temp:" temp;
+          #debug_log "accuracyMultiplierBonusStats | ROSIGMA_aMBS_repeated_accuracy_penalty | offset: 10 | Original accuracy, bonus:" bonus;
+          sub bonus temp;
+          #debug_log "accuracyMultiplierBonusStats | ROSIGMA_aMBS_repeated_accuracy_penalty | offset: 10 | New accuracy set, bonus:" bonus;
+          return bonus; # final accuracy
+
+    newTurnItem:
+      - new: ROSIGMA_nTI_repeated_accuracy_penalty #handles accuracy falloff cooldown/removal
+        offset: 5
+        code: |
+          var int temp;
+          var int temp2;
+          var int ammoCount;
+
+          if neq side FACTION_PLAYER;
+            return;
+          end;
+
+          item.getTag temp Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_MULTIPLIER;
+
+          if le temp 0;
+            return;
+          end;
+
+          item.getAmmoQuantity ammoCount;
+          item.setTag Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_PRIOR_AMMO_COUNT ammoCount;
+
+          item.getTag temp2 Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_COOLDOWN;
+          if le temp2 0; #if we have no assigned value assume the weapon cools down completely
+            item.setTag Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_TOTAL 0;
+            return;
+          end;
+
+          sub temp temp2;
+          limit_lower temp 0;
+          item.setTag Tag.ITEM_AMMO_REPEATED_ACCURACY_FALLOFF_TOTAL temp;
+          return;
+

--- a/Ruleset/ufopedia40k.rul
+++ b/Ruleset/ufopedia40k.rul
@@ -5757,3 +5757,10 @@ ufopaedia:
     image_id: IMPERIAL_ASSASSIN_CODEX.SPK
     text: STR_INFILTRATION_CODEX
     listOrder: 52924
+
+  - id: STR_HOTSHOT_MUNITIONS
+    type_id: 10
+    section: STR_HELP_ROSIGMA
+    image_id: 1CH.SPK
+    text: STR_HOTSHOT_MUNITIONS_CODEX
+    listOrder: 52925


### PR DESCRIPTION
1. Per title. Each shot made with a Hotshot las packs imposes a small cumulative accuracy penalty until the start of the player's next turn as the pack and weapon get hot. This penalty can be reset by reloading the weapon.
